### PR TITLE
feature(compose): publish REST 8080 + thread backend integration env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,12 @@ SHELL := /usr/bin/env bash
 VENV       ?= .venv
 PYTHON     ?= $(shell command -v python3.13 || command -v python3.12)
 UV         ?= $(shell command -v uv)
-COMPOSE    := docker compose -f deploy/compose/docker-compose.yml
+# `--env-file .env` is conditional: present when the developer has
+# created a repo-root .env, absent otherwise (so CI / fresh checkouts
+# don't fail because the file is missing). Compose's own variable
+# substitution still uses the file when it's there.
+COMPOSE_ENV := $(if $(wildcard .env),--env-file .env,)
+COMPOSE    := docker compose -f deploy/compose/docker-compose.yml $(COMPOSE_ENV)
 
 .PHONY: help doctor install format lint types tests e2e smoke compose-smoke precommit clean distclean \
         compose-up compose-down compose-status compose-down-volumes compose-wait \

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -140,6 +140,13 @@ services:
       - "19000:9000"     # WebSocket (host 19000 → container 9000)
       - "50051:50051"    # gRPC (lands with E2-4)
       - "9100:9100"      # Prometheus metrics (lands with E4-1)
+      - "8080:8080"      # Backend-facing REST surface (ADR-0026)
+    # Make the developer's host backend (e.g. https://toger.test or
+    # http://localhost) reachable from inside the container. On Docker
+    # Desktop macOS / Windows, host-gateway resolves to the host's NIC.
+    extra_hosts:
+      - "toger.test:host-gateway"
+      - "host.docker.internal:host-gateway"
     environment:
       EVEYS_OCPP_DB_URL: postgresql+asyncpg://eveys:eveys@postgres:5432/eveys_ocpp
       EVEYS_OCPP_REDIS_URL: redis://redis:6379/0
@@ -152,6 +159,19 @@ services:
       EVEYS_OCPP_CLICKHOUSE_DB: eveys_ocpp
       EVEYS_OCPP_LOG_JSON: "true"
       EVEYS_OCPP_LOG_LEVEL: "INFO"
+      # Backend integration: each variable is read from the developer's
+      # shell or .env at compose-up time. Empty values disable cleanly
+      # (the gateway falls back to its offline policies).
+      EVEYS_OCPP_REST_INBOUND_TOKENS: ${EVEYS_OCPP_REST_INBOUND_TOKENS:-}
+      EVEYS_OCPP_BACKEND_BASE_URL: ${EVEYS_OCPP_BACKEND_BASE_URL:-}
+      EVEYS_OCPP_BACKEND_TOKEN: ${EVEYS_OCPP_BACKEND_TOKEN:-}
+      EVEYS_OCPP_BACKEND_AUTHORIZE_FALLBACK: ${EVEYS_OCPP_BACKEND_AUTHORIZE_FALLBACK:-reject}
+      EVEYS_OCPP_WEBHOOK_BASE_URL: ${EVEYS_OCPP_WEBHOOK_BASE_URL:-}
+      EVEYS_OCPP_WEBHOOK_SECRET: ${EVEYS_OCPP_WEBHOOK_SECRET:-}
+      EVEYS_OCPP_WEBHOOK_URL_CP_BOOT: ${EVEYS_OCPP_WEBHOOK_URL_CP_BOOT:-}
+      EVEYS_OCPP_WEBHOOK_URL_CP_ONLINE: ${EVEYS_OCPP_WEBHOOK_URL_CP_ONLINE:-}
+      EVEYS_OCPP_WEBHOOK_URL_CP_STATUS: ${EVEYS_OCPP_WEBHOOK_URL_CP_STATUS:-}
+      EVEYS_OCPP_WEBHOOK_URL_TX_STARTED: ${EVEYS_OCPP_WEBHOOK_URL_TX_STARTED:-}
     depends_on:
       postgres: { condition: service_healthy }
       redis: { condition: service_healthy }


### PR DESCRIPTION
## Summary
- Publish container port **8080** to the host so `curl` and the backend's outbound HTTPClient can reach `/api/v1/*` from the laptop.
- Thread `EVEYS_OCPP_REST_INBOUND_TOKENS`, `BACKEND_BASE_URL`, `BACKEND_TOKEN`, `WEBHOOK_*` env through compose's `\${VAR:-}` so a repo-root `.env` populates them.
- Map `toger.test` and `host.docker.internal` to `host-gateway` via `extra_hosts` — otherwise the container resolves `toger.test` to itself.
- `Makefile` conditionally passes `--env-file .env` to `docker compose` when the file exists; CI and fresh checkouts (no .env) keep working.

## Test plan
- [x] `curl http://localhost:8080/api/v1/health` → 200.
- [x] `curl -H "Authorization: Bearer <inbound>" http://localhost:8080/api/v1/charge-points` → 200 with the real charge-point list.
- [x] Wrong / no token → 401.
- [x] From inside the container, `https://toger.test/api/eveys/charge-point-gateway/health` with the gateway's outbound bearer → 200.
- [x] No `.env` present → compose-up still works, env vars empty, gateway falls back to offline policies.