### PR TITLE
feature(api): per-connector status array on /charge-points endpoints

### DIFF
--- a/docs/integration/02-gateway-rest-api.md
+++ b/docs/integration/02-gateway-rest-api.md
@@ -48,7 +48,21 @@ List chargers known to the gateway. Cursor-paginated.
       "last_heartbeat_at": "2026-05-05T15:14:30.000+00:00",
       "last_status": "Available",
       "last_diagnostics_status": null,
-      "last_firmware_status": "Installed"
+      "last_firmware_status": "Installed",
+      "connectors": [
+        {
+          "connector_id": 1,
+          "status": "Charging",
+          "error_code": "NoError",
+          "last_changed_at": "2026-05-05T14:30:00.000+00:00"
+        },
+        {
+          "connector_id": 2,
+          "status": "Available",
+          "error_code": "NoError",
+          "last_changed_at": "2026-05-05T14:25:00.000+00:00"
+        }
+      ]
     }
   ],
   "next_cursor": "eyJpZCI6MTAwfQ==",
@@ -57,6 +71,23 @@ List chargers known to the gateway. Cursor-paginated.
 ```
 
 `next_cursor` is `null` on the last page.
+
+#### `connectors[]` vs `last_status`
+
+`connectors[]` is the source of truth for **per-connector state** — one
+entry per connector with the most recent `StatusNotification` data
+sourced from ClickHouse `cp_status`. Empty array (`[]`) when the
+charger has never sent a `StatusNotification`, when the gateway is
+running without a ClickHouse client wired (tests, dev laptops), or
+when ClickHouse is briefly unavailable — the route degrades gracefully
+rather than 500.
+
+`last_status` is a **scalar convenience field** carrying the most
+recent status across **any** connector. For single-connector chargers
+(the common case) it matches the device's current state. For
+multi-connector chargers it is **last-write-wins** across connectors
+and should not be read as "the device is currently X" — read
+`connectors[]` instead.
 
 ### `GET /api/v1/charge-points/{cp_id}`
 
@@ -78,6 +109,20 @@ Single charger detail. Same per-charger object as the list endpoint, plus active
   "last_status": "Charging",
   "last_diagnostics_status": null,
   "last_firmware_status": "Installed",
+  "connectors": [
+    {
+      "connector_id": 1,
+      "status": "Charging",
+      "error_code": "NoError",
+      "last_changed_at": "2026-05-05T14:30:00.000+00:00"
+    },
+    {
+      "connector_id": 2,
+      "status": "Available",
+      "error_code": "NoError",
+      "last_changed_at": "2026-05-05T14:25:00.000+00:00"
+    }
+  ],
   "active_reservations": [
     {
       "reservation_id": 8842,

--- a/src/eveys_ocpp/api/charge_points.py
+++ b/src/eveys_ocpp/api/charge_points.py
@@ -10,6 +10,14 @@ Per the contract `docs/integration/02-gateway-rest-api.md`:
 - The response is **raw** (top-level *is* the resource), not enveloped.
 - `online` and `pod_id` come from the Redis online registry.
 - `last_*` fields come from Postgres (charge_points table).
+- `connectors[]` carries the most recent StatusNotification per
+  connector (sourced from ClickHouse `cp_status`). Empty when no
+  StatusNotifications have been recorded yet, or when the gateway
+  is running without a ClickHouse client wired (tests, dev laptops).
+- `last_status` is kept as a single-string convenience for callers
+  that don't need per-connector resolution. For multi-connector
+  chargers it is **last-write-wins** across connectors and should
+  not be read as the device's current state — use `connectors[]`.
 - 404 with `error_code=UNKNOWN_CP_ID` when the charger has never sent
   a BootNotification.
 """
@@ -71,7 +79,47 @@ def _to_response(cp: dict[str, Any]) -> dict[str, Any]:
         "last_status": cp["last_status"],
         "last_diagnostics_status": cp["last_diagnostics_status"],
         "last_firmware_status": cp["last_firmware_status"],
+        "connectors": cp.get("connectors", []),
     }
+
+
+async def _enrich_with_connectors(
+    request: Request, cp_dicts: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Attach per-connector status from ClickHouse to every dict.
+
+    Batches all charger ids in one query so a list of N chargers stays
+    a single ClickHouse round-trip. Falls back to an empty list per
+    charger when the read client isn't wired (dev / unit tests) or the
+    query fails — the route still serves the metadata correctly.
+    """
+    if not cp_dicts:
+        return cp_dicts
+
+    client = getattr(request.app.state, "ch_client", None)
+    if client is None:
+        for cp in cp_dicts:
+            cp.setdefault("connectors", [])
+        return cp_dicts
+
+    cp_ids = [cp["cp_id"] for cp in cp_dicts]
+    try:
+        latest_by_cp = await client.fetch_latest_connector_statuses(cp_ids=cp_ids)
+    except Exception:  # ClickHouse hiccup must not 500 the metadata path
+        latest_by_cp = {}
+
+    for cp in cp_dicts:
+        rows = latest_by_cp.get(cp["cp_id"], [])
+        cp["connectors"] = [
+            {
+                "connector_id": r["connector_id"],
+                "status": r["status"],
+                "error_code": r["error_code"] or None,
+                "last_changed_at": _isoformat(r["last_changed_at"]),
+            }
+            for r in rows
+        ]
+    return cp_dicts
 
 
 @router.get("/charge-points")
@@ -126,6 +174,8 @@ async def list_charge_points_route(
     if online is not None:
         enriched = [cp for cp in enriched if cp["online"] == online]
 
+    enriched = await _enrich_with_connectors(request, enriched)
+
     return {
         "charge_points": [_to_response(cp) for cp in enriched],
         "next_cursor": next_cursor,
@@ -145,6 +195,7 @@ async def get_charge_point_route(request: Request, cp_id: str) -> dict[str, Any]
         )
 
     enriched = await _enrich_with_presence(request, detail)
+    [enriched] = await _enrich_with_connectors(request, [enriched])
     response = _to_response(enriched)
     response["active_reservations"] = [
         {

--- a/src/eveys_ocpp/clickhouse/read_client.py
+++ b/src/eveys_ocpp/clickhouse/read_client.py
@@ -119,6 +119,59 @@ class ClickHouseReadClient:
             rows = await cursor.fetchall()
         return [dict(zip(cols, row, strict=True)) for row in rows]
 
+    async def fetch_latest_connector_statuses(
+        self,
+        *,
+        cp_ids: list[str],
+    ) -> dict[str, list[dict[str, Any]]]:
+        """Return the most recent StatusNotification per (cp_id, connector_id).
+
+        Used to enrich the `/charge-points` and `/charge-points/{cp_id}`
+        responses with a per-connector breakdown, so a multi-connector
+        charger no longer collapses to a single `last_status` slot. The
+        scalar `last_status` is kept on the response as a "most recent
+        across all connectors" convenience for single-connector callers
+        and consumers who don't need the breakdown.
+
+        Returns a mapping keyed by cp_id; chargers with no recorded
+        StatusNotifications are simply absent from the map. Callers
+        treat that as "no per-connector data, fall back to []".
+
+        Implementation note: ClickHouse's `argMax` makes "latest row per
+        group" cheap — one scan, no subqueries — and the cp_status
+        partition key starts with cp_id so the IN-list prunes well.
+        """
+        assert self._conn is not None  # narrowed by start()
+
+        if not cp_ids:
+            return {}
+
+        sql = """
+            SELECT
+                cp_id,
+                connector_id,
+                argMax(status, occurred_at) AS status,
+                argMax(error_code, occurred_at) AS error_code,
+                max(occurred_at) AS last_changed_at
+            FROM cp_status
+            WHERE cp_id IN %(cp_ids)s
+            GROUP BY cp_id, connector_id
+            ORDER BY cp_id, connector_id
+        """
+        params: dict[str, Any] = {"cp_ids": tuple(cp_ids)}
+
+        async with self._conn.cursor() as cursor:
+            await cursor.execute(sql, params)
+            cols = [d[0] for d in cursor.description]
+            rows = await cursor.fetchall()
+
+        out: dict[str, list[dict[str, Any]]] = {}
+        for row in rows:
+            record = dict(zip(cols, row, strict=True))
+            cp_id = record.pop("cp_id")
+            out.setdefault(cp_id, []).append(record)
+        return out
+
     async def fetch_status_history(
         self,
         *,

--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -85,14 +85,16 @@ def fake_command_service() -> MagicMock:
 
 @pytest.fixture
 def fake_ch_client() -> MagicMock:
-    """Stub ClickHouse read client — only `fetch_meter_values` and
-    `fetch_status_history` are called by the timeseries routes (E3-7d).
+    """Stub ClickHouse read client — used by both the timeseries routes
+    (`fetch_meter_values`, `fetch_status_history`) and the charge-points
+    routes (`fetch_latest_connector_statuses`).
 
-    Default: both return empty lists so a route that didn't get a
-    per-test override still answers cleanly."""
+    Default: every method returns an empty result so a route that didn't
+    get a per-test override still answers cleanly."""
     client = MagicMock()
     client.fetch_meter_values = AsyncMock(return_value=[])
     client.fetch_status_history = AsyncMock(return_value=[])
+    client.fetch_latest_connector_statuses = AsyncMock(return_value={})
     return client
 
 

--- a/tests/unit/api/test_charge_points.py
+++ b/tests/unit/api/test_charge_points.py
@@ -170,3 +170,138 @@ async def test_detail_returns_full_shape_with_inlined_collections(
     assert isinstance(body["active_reservations"][0]["expiry_date"], str)
     assert len(body["active_charging_profiles"]) == 1
     assert body["active_charging_profiles"][0]["purpose"] == "TxDefaultProfile"
+
+
+# ---- per-connector status enrichment ---------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_includes_per_connector_status_from_clickhouse(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    fake_ch_client: MagicMock,
+) -> None:
+    """Each charger in the list response carries a `connectors` array
+    populated from the latest StatusNotification per connector. Multi-
+    connector chargers no longer collapse onto a single `last_status`
+    slot — managers see every connector's true state."""
+    from eveys_ocpp.api import charge_points as cp_module
+
+    rows = [_cp_row(cp_id="CP_MULTI", internal_id=1)]
+    monkeypatch.setattr(cp_module, "list_charge_points", AsyncMock(return_value=rows))
+    fake_ch_client.fetch_latest_connector_statuses = AsyncMock(
+        return_value={
+            "CP_MULTI": [
+                {
+                    "connector_id": 1,
+                    "status": "Charging",
+                    "error_code": "NoError",
+                    "last_changed_at": datetime(2026, 5, 5, 14, 30, tzinfo=UTC),
+                },
+                {
+                    "connector_id": 2,
+                    "status": "Available",
+                    "error_code": "NoError",
+                    "last_changed_at": datetime(2026, 5, 5, 14, 25, tzinfo=UTC),
+                },
+            ]
+        }
+    )
+
+    response = await client.get("/api/v1/charge-points")
+
+    body = response.json()
+    cp = body["charge_points"][0]
+    assert cp["cp_id"] == "CP_MULTI"
+    connectors = cp["connectors"]
+    assert len(connectors) == 2
+    assert {c["connector_id"]: c["status"] for c in connectors} == {
+        1: "Charging",
+        2: "Available",
+    }
+    # last_changed_at serialized as ISO-8601.
+    assert all(isinstance(c["last_changed_at"], str) for c in connectors)
+
+
+@pytest.mark.asyncio
+async def test_list_returns_empty_connectors_when_clickhouse_silent(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When ClickHouse has no per-connector data for a charger (e.g.
+    the charger has booted but never sent a StatusNotification), the
+    response still includes a `connectors` field — empty list, never
+    missing — so consumers can rely on the shape."""
+    from eveys_ocpp.api import charge_points as cp_module
+
+    rows = [_cp_row(cp_id="CP_SILENT", internal_id=1)]
+    monkeypatch.setattr(cp_module, "list_charge_points", AsyncMock(return_value=rows))
+
+    response = await client.get("/api/v1/charge-points")
+
+    body = response.json()
+    assert body["charge_points"][0]["connectors"] == []
+
+
+@pytest.mark.asyncio
+async def test_list_survives_clickhouse_failure(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    fake_ch_client: MagicMock,
+) -> None:
+    """A flaky ClickHouse must not 500 the /charge-points list. The
+    metadata is the load-bearing data; the per-connector breakdown is
+    enrichment — degrade gracefully to []."""
+    from eveys_ocpp.api import charge_points as cp_module
+
+    rows = [_cp_row(cp_id="CP_OK", internal_id=1)]
+    monkeypatch.setattr(cp_module, "list_charge_points", AsyncMock(return_value=rows))
+    fake_ch_client.fetch_latest_connector_statuses = AsyncMock(
+        side_effect=RuntimeError("clickhouse exploded"),
+    )
+
+    response = await client.get("/api/v1/charge-points")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["charge_points"][0]["connectors"] == []
+
+
+@pytest.mark.asyncio
+async def test_detail_includes_per_connector_status(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    fake_registry: MagicMock,
+    fake_ch_client: MagicMock,
+) -> None:
+    from eveys_ocpp.api import charge_points as cp_module
+
+    detail = _cp_row(cp_id="CP_001", internal_id=1)
+    detail["active_reservations"] = []
+    detail["active_charging_profiles"] = []
+    monkeypatch.setattr(cp_module, "get_charge_point_detail", AsyncMock(return_value=detail))
+    fake_registry.get_pod = AsyncMock(return_value="pod-1")
+    fake_ch_client.fetch_latest_connector_statuses = AsyncMock(
+        return_value={
+            "CP_001": [
+                {
+                    "connector_id": 1,
+                    "status": "Faulted",
+                    "error_code": "GroundFailure",
+                    "last_changed_at": datetime(2026, 5, 5, 14, 30, tzinfo=UTC),
+                },
+            ]
+        }
+    )
+
+    response = await client.get("/api/v1/charge-points/CP_001")
+
+    body = response.json()
+    assert body["connectors"] == [
+        {
+            "connector_id": 1,
+            "status": "Faulted",
+            "error_code": "GroundFailure",
+            "last_changed_at": "2026-05-05T14:30:00+00:00",
+        }
+    ]


### PR DESCRIPTION
## Summary
- `GET /charge-points` and `GET /charge-points/{cp_id}` now carry a `connectors[]` array with the most recent `StatusNotification` per connector — sourced from ClickHouse `cp_status` via a single `argMax` query that batches every charger on the page into one round-trip.
- Per-entry shape: `{connector_id, status, error_code, last_changed_at}`.
- `last_status` stays on the response for backward compatibility but the integration doc now flags it as a last-write-wins scalar; multi-connector callers must read `connectors[]` instead.
- Graceful degradation: empty list when no `StatusNotification` has been recorded, when the gateway runs without a ClickHouse client wired (dev/tests), or when ClickHouse hiccups — the metadata path never 500s on enrichment failure.

## Why
The flat `last_status` field collapsed all connectors onto a single slot, so a 2-connector device that's `Charging` on 1 and `Faulted` on 2 would surface one or the other depending on event ordering. Operator dashboards built on it cannot answer "which sockets are usable right now?". This is an additive, non-breaking fix — existing single-connector consumers see the same `last_status` they always did.

## Test plan
- [x] `pytest tests/unit/api/test_charge_points.py --no-cov` → 11/11 (4 new, 7 existing).
- [x] Full unit suite from a clean cwd → 449/449.
- [x] `ruff check src/ tests/` → clean.
- [x] `mypy src/eveys_ocpp/api/charge_points.py src/eveys_ocpp/clickhouse/read_client.py` → clean.
- [x] Integration doc `docs/integration/02-gateway-rest-api.md` updated with the new field and the `last_status` semantics callout.