### PR TITLE
fix(api): connectors[] query — asynch placeholders + qualified table

### DIFF
--- a/src/eveys_ocpp/clickhouse/read_client.py
+++ b/src/eveys_ocpp/clickhouse/read_client.py
@@ -146,19 +146,30 @@ class ClickHouseReadClient:
         if not cp_ids:
             return {}
 
-        sql = """
+        # `asynch` substitutes parameters via `str.format(**escape_params(params))`,
+        # so placeholders are `{name}` not the DB-API `%(name)s` paramstyle. The
+        # IN list expands as one named placeholder per id — `escape_params`
+        # quotes each value, so user-controlled cp_ids cannot break out of
+        # the IN expression.
+        placeholders = ", ".join(f"{{cp_id_{i}}}" for i in range(len(cp_ids)))
+        # Fully-qualified table name — ClickHouse 24's analyzer does not
+        # always honour the connection's `currentDatabase()` for unqualified
+        # references in subqueries; spelling the database keeps both old
+        # and new analyzers happy.
+        db = self._settings.clickhouse_db
+        sql = f"""
             SELECT
                 cp_id,
                 connector_id,
                 argMax(status, occurred_at) AS status,
                 argMax(error_code, occurred_at) AS error_code,
                 max(occurred_at) AS last_changed_at
-            FROM cp_status
-            WHERE cp_id IN %(cp_ids)s
+            FROM {db}.cp_status
+            WHERE cp_id IN ({placeholders})
             GROUP BY cp_id, connector_id
             ORDER BY cp_id, connector_id
         """
-        params: dict[str, Any] = {"cp_ids": tuple(cp_ids)}
+        params: dict[str, Any] = {f"cp_id_{i}": cp_id for i, cp_id in enumerate(cp_ids)}
 
         async with self._conn.cursor() as cursor:
             await cursor.execute(sql, params)


### PR DESCRIPTION
## Summary

Follow-up fix to PR #22 (per-connector status array). The query in \`fetch_latest_connector_statuses\` was malformed in two ways that made the new \`connectors[]\` field always empty in real deployments — the broad \`except\` in the route handler swallowed the errors silently, so unit tests passed but the live endpoint returned \`[]\`.

### Bug 1: wrong placeholder syntax

\`asynch\` substitutes parameters via \`str.format(**escape_params(params))\`, so placeholders use \`{name}\` braces — not the DB-API \`%(name)s\` paramstyle the original PR used. The literal \`%\` reached ClickHouse and was rejected with a syntax error.

### Bug 2: unqualified table reference

ClickHouse 24's analyzer doesn't always honour \`currentDatabase()\` for unqualified table refs, so \`FROM cp_status\` raised \`UNKNOWN_TABLE\` even when the connection was opened with \`database='eveys_ocpp'\`. Qualifying as \`{db}.cp_status\` keeps both the old and new analyzers happy.

### Fix

- Switched the IN list to one named \`{name}\` placeholder per cp_id; \`escape_params\` quotes each value so user-supplied cp_ids cannot break out.
- Qualified the table as \`{db}.cp_status\`.

## Test plan
- [x] \`pytest tests/unit/api/test_charge_points.py --no-cov\` → 11/11 (existing tests still pass; the fix is purely in the query string composition).
- [x] \`ruff check\` clean.
- [x] \`mypy\` clean.
- [x] Manual verification against a live ClickHouse with seeded \`cp_status\` rows: query now returns the expected rows where it previously raised silently.