### PR TITLE
fix(compose): remap CH HTTP to 8124 + doctor port-collision check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,13 +168,19 @@ print(' '.join(names))" 2>/dev/null); \
 # safe to re-run.
 # ClickHouse schema migrator. Idempotent; reads SQL files from
 # src/eveys_ocpp/clickhouse/ddl/ and applies any not yet recorded in
-# the schema_migrations table. Uses the HTTP port (8123) so this works
-# whether ClickHouse is local or in compose. See ADR-0020.
+# the schema_migrations table. See ADR-0020.
+#
+# Default HTTP port is 8124 to match docker-compose's host mapping. The
+# canonical CH HTTP port is 8123, but a Homebrew `clickhouse server`
+# already running on the laptop will steal it (loopback bind wins over
+# docker's `*:8123`) and migrations silently target the wrong server.
+# CI overrides this via E2E_CH_HTTP_PORT=8123 because the GitHub
+# Actions runner binds CH directly on 8123 with no collision risk.
 ch-migrate: install
 	@echo ">> applying ClickHouse migrations..."
 	@$(VENV)/bin/python -m eveys_ocpp.clickhouse.migrate \
 	    --host $${E2E_CH_HOST:-localhost} \
-	    --port $${E2E_CH_HTTP_PORT:-8123} \
+	    --port $${E2E_CH_HTTP_PORT:-8124} \
 	    --db $${EVEYS_OCPP_CLICKHOUSE_DB:-eveys_ocpp}
 
 e2e: install

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -97,7 +97,15 @@ services:
     image: clickhouse/clickhouse-server:24
     container_name: eveys-ocpp-clickhouse
     ports:
-      - "8123:8123"   # HTTP
+      # HTTP remapped to 8124: the canonical 8123 is squatted by any
+      # Homebrew `clickhouse server` already running on the laptop
+      # (loopback bind wins over docker's `*:8123`). When the
+      # collision happened our `make ch-migrate` silently targeted
+      # the wrong server and the stack went into a confusing split-
+      # brain state. See issue #24. `make ch-migrate` now passes
+      # `--port 8124` to match this; ad-hoc curl probes also need
+      # 8124 (e.g. `curl http://localhost:8124/?query=...`).
+      - "8124:8123"   # HTTP   (host 8124 → container 8123)
       - "9001:9000"   # native (remapped: host 9001 → container 9000 to free
                       # host port 9000 for the eveys/ocpp WebSocket server)
     environment:

--- a/docs/07-local-dev-setup.md
+++ b/docs/07-local-dev-setup.md
@@ -78,10 +78,12 @@ Slower (~5 minutes cold start). Not the default.
 | Postgres 16 | `postgres:16-alpine` | `5432` | Transactional state (`charge_points`, `transactions`) |
 | Redis 7 | `redis:7-alpine` | `6379` | Online registry, idempotency cache, pub/sub |
 | Kafka (KRaft mode) | `apache/kafka:3.7.0` | `9092` | Event firehose |
-| ClickHouse | `clickhouse/clickhouse-server:24` (Ubuntu base; the `:24-alpine` variant is broken on Apple Silicon) | `8123` (HTTP), `9000` (native) | Time-series store ([ADR-0004](./adr/0004-clickhouse-timeseries-store.md)) |
-| `eveys/ocpp` | built locally | `19000` (WS, container 9000), `50051` (gRPC), `9100` (metrics) | This service |
+| ClickHouse | `clickhouse/clickhouse-server:24` (Ubuntu base; the `:24-alpine` variant is broken on Apple Silicon) | `8124` (HTTP, container 8123), `9001` (native, container 9000) | Time-series store ([ADR-0004](./adr/0004-clickhouse-timeseries-store.md)) |
+| `eveys/ocpp` | built locally | `19000` (WS, container 9000), `50051` (gRPC), `9100` (metrics), `8080` (REST) | This service |
 
-> **Note**: ClickHouse native protocol normally listens on `9000`. Our service also wants `9000` inside its container for the WebSocket port. The compose file remaps both onto host ports to avoid the collision: ClickHouse native to `9001`, gateway WS to **`19000`** (container `9000` for both, host published differently). HTTP (`8123`) is unchanged. So a charger or test client connects to `ws://<host>:19000/<cp_id>`.
+> **Note**: ClickHouse native protocol normally listens on `9000`. Our service also wants `9000` inside its container for the WebSocket port. The compose file remaps both onto host ports to avoid the collision: ClickHouse native to `9001`, gateway WS to **`19000`** (container `9000` for both, host published differently).
+>
+> ClickHouse HTTP (canonical `8123`) is also remapped — to **`8124`** — so that a Homebrew `clickhouse server` already running on the laptop (common on machines that touch other ClickHouse projects) can't quietly intercept queries: the loopback bind on the Homebrew side wins over docker's `*:8123`, and migrations end up in the wrong server with no error. `make doctor` flags the collision; `make ch-migrate` defaults to `8124`. CI environments that don't run a host-side CH override via `E2E_CH_HTTP_PORT=8123`.
 
 ### Bring it up
 
@@ -140,8 +142,8 @@ redis-cli -p 6379 PING
 echo "hello" | kcat -P -b localhost:9092 -t test
 kcat -C -b localhost:9092 -t test -c 1
 
-# ClickHouse — HTTP interface
-curl 'http://localhost:8123/?query=SELECT%201'
+# ClickHouse — HTTP interface (remapped from 8123 to 8124)
+curl 'http://localhost:8124/?query=SELECT%201'
 
 # eveys/ocpp metrics
 curl http://localhost:9100/metrics | head -20

--- a/docs/12-connecting-real-charger.md
+++ b/docs/12-connecting-real-charger.md
@@ -98,7 +98,7 @@ psql postgres://eveys:eveys@localhost:5432/eveys_ocpp -c "\dt"
 #           charging_schedule_periods, local_auth_lists,
 #           local_auth_list_entries, alembic_version
 
-curl 'http://localhost:8123/?query=SHOW+TABLES+FROM+eveys_ocpp'
+curl 'http://localhost:8124/?query=SHOW+TABLES+FROM+eveys_ocpp'
 # Expected: cp.boot  cp.meter  cp.status  schema_migrations  tx.started
 ```
 
@@ -311,7 +311,7 @@ ORDER BY occurred_at DESC;
 Use the HTTP interface for one-offs:
 
 ```bash
-curl 'http://localhost:8123/?query=SELECT+count()+FROM+eveys_ocpp.%60cp.meter%60'
+curl 'http://localhost:8124/?query=SELECT+count()+FROM+eveys_ocpp.%60cp.meter%60'
 ```
 
 DDL is in `src/eveys_ocpp/clickhouse/ddl/`.

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -165,6 +165,53 @@ else
     miss "Docker daemon" "not running — start Docker Desktop"
 fi
 
+# Host-port collisions with the compose stack.
+#
+# `make compose-up` publishes a fixed set of ports. If something on the
+# laptop is already bound to one of them (a Homebrew clickhouse server,
+# a stray Postgres, a previous `python -m http.server`), the docker
+# binding either fails outright or — on macOS for loopback addresses —
+# the existing process wins and our queries silently target the wrong
+# server. The latter is what bit us in issue #24, where a Homebrew CH
+# on `localhost:8123` swallowed our migrations and the docker CH stayed
+# empty.
+#
+# We probe TCP listen state (not just open sockets) so a `curl` that
+# just connected and closed doesn't trigger a false positive.
+declare -a expected_ports=(
+    "5432:postgres"
+    "6379:redis"
+    "9092:kafka"
+    "8124:clickhouse-http"
+    "9001:clickhouse-native"
+    "19000:gateway-ws"
+    "50051:gateway-grpc"
+    "9100:gateway-metrics"
+    "8080:gateway-rest"
+)
+collisions=0
+for entry in "${expected_ports[@]}"; do
+    port="${entry%%:*}"
+    name="${entry##*:}"
+    # `lsof -iTCP:<port> -sTCP:LISTEN -nP -F c` lists every listener on
+    # the port and returns one `c<full-command-name>` line per process,
+    # avoiding the truncation `lsof`'s default tabular output applies to
+    # the COMMAND column. We strip docker's own listeners
+    # (`com.docker.backend`, `vpnkit`, `Docker`) — those are how compose
+    # itself binds.
+    holders=$(lsof -iTCP:"$port" -sTCP:LISTEN -nP -F c 2>/dev/null \
+        | awk '/^c/ {sub(/^c/,""); print}' \
+        | grep -viE 'com\.docker|vpnkit|^Docker$' \
+        | sort -u)
+    if [ -n "$holders" ]; then
+        collisions=$((collisions + 1))
+        miss "port $port" "$name port held by non-docker process(es): $(echo "$holders" | tr '\n' ' ')— stop it before \`make compose-up\`"
+    fi
+done
+if [ "$collisions" -eq 0 ]; then
+    ok  "ports" "no collisions on the 9 ports compose publishes"
+fi
+
 # Free disk space at the repo root.
 disk_avail_kb=$(df -k . 2>/dev/null | awk 'NR==2 {print $4}' || echo 0)
 disk_avail_gb=$(( disk_avail_kb / 1024 / 1024 ))

--- a/tests/compose_smoke/conftest.py
+++ b/tests/compose_smoke/conftest.py
@@ -64,7 +64,9 @@ _EXPECTED_CONTAINERS = (
 # real WS / gRPC / DB / ClickHouse from outside the docker network.
 HOST_WS_PORT = 19000
 HOST_PG_PORT = 5432
-HOST_CH_HTTP_PORT = 8123
+# Compose remaps CH HTTP from the canonical 8123 to 8124 to dodge a
+# Homebrew `clickhouse server` already on the laptop (issue #24).
+HOST_CH_HTTP_PORT = 8124
 
 # Where the published ports actually answer. On a laptop this is
 # `localhost`. Under GitLab Docker-in-Docker the test process and the

--- a/tests/e2e/test_clickhouse_schema.py
+++ b/tests/e2e/test_clickhouse_schema.py
@@ -22,7 +22,7 @@ import pytest
 from eveys_ocpp.clickhouse.migrate import apply_pending
 
 _CH_HOST = os.environ.get("E2E_CH_HOST", "localhost")
-_CH_HTTP_PORT = int(os.environ.get("E2E_CH_HTTP_PORT", "8123"))
+_CH_HTTP_PORT = int(os.environ.get("E2E_CH_HTTP_PORT", "8124"))
 _CH_DB = os.environ.get("EVEYS_OCPP_CLICKHOUSE_DB", "eveys_ocpp")
 _E2E_REQUIRE = os.environ.get("E2E_REQUIRE") == "1"
 

--- a/tests/e2e/test_kafka_to_clickhouse.py
+++ b/tests/e2e/test_kafka_to_clickhouse.py
@@ -32,7 +32,7 @@ from eveys_ocpp.events import KafkaEventProducer
 from eveys_ocpp.settings import Settings
 
 _CH_HOST = os.environ.get("E2E_CH_HOST", "localhost")
-_CH_HTTP_PORT = int(os.environ.get("E2E_CH_HTTP_PORT", "8123"))
+_CH_HTTP_PORT = int(os.environ.get("E2E_CH_HTTP_PORT", "8124"))
 # Native ClickHouse port. The container always listens on 9000 (CI's
 # tests:e2e job reaches it as clickhouse:9000, the in-process compose
 # stack uses container-side 9000 too). Dev laptops that run ClickHouse

--- a/tests/e2e/test_local_smoke.py
+++ b/tests/e2e/test_local_smoke.py
@@ -37,6 +37,10 @@ _PG_HOST = os.environ.get("E2E_PG_HOST", "localhost")
 _REDIS_HOST = os.environ.get("E2E_REDIS_HOST", "localhost")
 _KAFKA_HOST = os.environ.get("E2E_KAFKA_HOST", "localhost")
 _CH_HOST = os.environ.get("E2E_CH_HOST", "localhost")
+# Compose remaps CH HTTP from 8123 to 8124 to dodge a Homebrew
+# `clickhouse server` already on the laptop (see issue #24). CI binds
+# CH directly on 8123, so it overrides via E2E_CH_HTTP_PORT=8123.
+_CH_HTTP_PORT = int(os.environ.get("E2E_CH_HTTP_PORT", "8124"))
 
 
 def _can_connect(host: str, port: int, timeout: float = 0.5) -> bool:
@@ -54,7 +58,7 @@ for _name, _host, _port in (
     ("postgres", _PG_HOST, 5432),
     ("redis", _REDIS_HOST, 6379),
     ("kafka", _KAFKA_HOST, 9092),
-    ("clickhouse-http", _CH_HOST, 8123),
+    ("clickhouse-http", _CH_HOST, _CH_HTTP_PORT),
 ):
     if not _can_connect(_host, _port):
         _unreachable_services.append(f"{_name} ({_host}:{_port})")
@@ -87,7 +91,7 @@ def compose_endpoints() -> Iterator[dict[str, str]]:
         "postgres": f"{_PG_HOST}:5432",
         "redis": f"{_REDIS_HOST}:6379",
         "kafka": f"{_KAFKA_HOST}:9092",
-        "clickhouse": f"{_CH_HOST}:8123",
+        "clickhouse": f"{_CH_HOST}:{_CH_HTTP_PORT}",
     }
 
 
@@ -101,7 +105,7 @@ def test_clickhouse_responds_ok() -> None:
     """ClickHouse `/ping` must return `Ok.\\n`."""
     import urllib.request
 
-    with urllib.request.urlopen(f"http://{_CH_HOST}:8123/ping", timeout=2) as resp:
+    with urllib.request.urlopen(f"http://{_CH_HOST}:{_CH_HTTP_PORT}/ping", timeout=2) as resp:
         body = resp.read().decode()
     assert body.strip() == "Ok."
 


### PR DESCRIPTION
## Summary

Closes the port-hygiene half of #24.

A Homebrew \`clickhouse server\` running on the same laptop as \`make compose-up\` silently steals the canonical 8123 port — the loopback bind wins over docker's \`*:8123\` on macOS — and migrations, curl probes, and ingestor INSERTs all end up at the wrong server with no error. We hit this; it cost an hour of misdiagnosis chasing a fake "TCP/HTTP analyzer split" before the two-process reality became clear.

### Compose
- \`clickhouse\` HTTP host port: \`8123 -> 8124\`. Container side stays 8123; the in-container healthcheck still hits localhost:8123.

### Makefile
- \`ch-migrate\` defaults to \`E2E_CH_HTTP_PORT=8124\`. CI already pins \`E2E_CH_HTTP_PORT=8123\` explicitly in \`.github/workflows/e2e.yml\` (the runner has no host CH), so this is a pure local-dev fix.

### Tests
- \`tests/compose_smoke/conftest.py\` uses 8124 for \`HOST_CH_HTTP_PORT\`.
- \`tests/e2e/test_local_smoke.py\` now reads \`E2E_CH_HTTP_PORT\` (default 8124) in place of three hard-coded 8123 references.
- \`tests/e2e/test_clickhouse_schema.py\` and \`test_kafka_to_clickhouse.py\` default flipped to 8124.

### scripts/doctor.sh
- New port-collision check. \`lsof -F c -iTCP:<port> -sTCP:LISTEN\` enumerates listeners on every port compose publishes (\`5432, 6379, 9092, 8124, 9001, 19000, 50051, 9100, 8080\`). Filters out \`com.docker.backend / vpnkit / Docker\` so docker's own bindings don't trip it. Flags real squatters with the offending command name so the operator can stop them before \`make compose-up\`.

### Docs
- \`docs/07-local-dev-setup.md\` table reflects the remap; the callout explains the collision and why we don't use the canonical port.
- \`docs/12-connecting-real-charger.md\` curl examples bumped to \`localhost:8124\`.

## Test plan
- [x] \`bash scripts/doctor.sh\` shows the existing host-redis collision (\`redis-server\` on 6379) and zero false positives from docker's own listeners.
- [x] \`make compose-up && make compose-wait\` brings the stack up; \`curl localhost:8124/ping\` returns \`Ok\`.
- [x] \`pytest tests/unit/test_clickhouse_migrate.py --no-cov\` → 13/13.
- [x] \`ruff check src/ tests/\` clean.
- [x] CI workflows verified to set \`E2E_CH_HTTP_PORT=8123\` so this default change does not affect them.