### PR TITLE
docs: ADR-0028 + ingestor crashloop troubleshooting

### DIFF
--- a/docs/07-local-dev-setup.md
+++ b/docs/07-local-dev-setup.md
@@ -324,6 +324,33 @@ clickhouse:
         memory: 4G
 ```
 
+### `eveys-ocpp-clickhouse-ingestor` keeps restarting (`CrashLoopBackOff` in k8s)
+
+Per [ADR-0028](./adr/0028-ingestor-fail-fast-policy.md), the ingestor exits non-zero after `EVEYS_OCPP_CLICKHOUSE_INGESTOR_MAX_FLUSH_FAILURES` consecutive INSERT failures (default 10). The supervisor — docker compose or kubernetes — restarts it, and the next round of failures crashes it again. That's the **fail-fast** signal that something is wedged: the alternative was the silent-loop that bit us in [issue #24](https://github.com/eveys-mobility/OCPP/issues/24).
+
+To diagnose, look at the **last `flush_failed` log line** before the `exit_fatal`:
+
+```bash
+docker logs eveys-ocpp-clickhouse-ingestor --tail 50 | grep -E "flush_failed|exit_fatal" | tail -5
+```
+
+The `error` field in that log carries the ClickHouse error code. The common causes:
+
+| ClickHouse error | What's wrong | Fix |
+|---|---|---|
+| `Code: 60. DB::Exception: Table eveys_ocpp.cp_status does not exist` | Schema not applied to the CH instance the ingestor reaches | `make ch-migrate`. If that says "up to date" but tables are missing, check for a [Homebrew-CH port collision](#manual-checks) — `lsof -iTCP:8123 -sTCP:LISTEN` on the host. |
+| `Code: 53. DB::Exception: ... Type mismatch in column ...` | Ingestor and CH disagree on column types (proto evolution mid-deploy) | Check that `src/eveys_ocpp/clickhouse/ddl/` matches the row extractors in `src/eveys_ocpp/clickhouse/ingestor.py`. Roll the ingestor image and the CH schema together. |
+| `Code: 192. DB::Exception: Unknown user 'eveys_writer'` | CH user/role mis-provisioned | Verify `CLICKHOUSE_USER` env var matches a real user in CH. |
+| Network errors (`Connection refused`, `getaddrinfo failed`) | Ingestor pointed at the wrong host or CH not yet healthy | Check `make compose-status` shows `clickhouse` `healthy`; ingestor depends on it but a startup race can still bite. |
+
+If you genuinely want the old log-and-loop behaviour during a long debugging session (e.g. you're tailing for a specific error pattern across many failures), bump the threshold for that one process:
+
+```bash
+EVEYS_OCPP_CLICKHOUSE_INGESTOR_MAX_FLUSH_FAILURES=1000000 make compose-up
+```
+
+Don't ship that to production — silent loops are the failure mode this policy exists to prevent.
+
 ### k3d: `unable to import image — image not found`
 
 Build the image locally first:

--- a/docs/adr/0028-ingestor-fail-fast-policy.md
+++ b/docs/adr/0028-ingestor-fail-fast-policy.md
@@ -1,0 +1,132 @@
+# ADR-0028: ClickHouse ingestor fail-fast on sustained INSERT failure
+
+| Status | Date | Authors |
+|---|---|---|
+| Accepted | 2026-05-07 | Mostafa |
+
+## Context
+
+The ClickHouse ingestor sidecar (ADR-0020) reads protobuf envelopes
+from Kafka and INSERTs them into the matching `cp_*` / `tx_*` tables.
+The hot loop is poll → process → flush → commit; offsets are committed
+manually only after a successful flush so a crash mid-batch
+re-delivers (at-least-once).
+
+The original `_flush_batch` failure path simply logged the exception
+and slept 1 s before re-polling. That works for transient blips
+(garbage collection pause, brief network jitter, a single timeout)
+because the next poll re-delivers and the next INSERT lands.
+
+It does not work for **wedged** failures — schema missing, ingestor
+pointed at the wrong CH instance, type mismatch on a recently-evolved
+column. In every one of those cases:
+
+- Every flush raises forever; the consumer-group offset never moves.
+- Fresh events keep landing in the Kafka topic but never reach
+  ClickHouse, so reads return stale or empty data.
+- The container is marked `Up` and `healthy` (we don't probe CH
+  readiness from the ingestor's container healthcheck).
+- The only signal is a log line per failure, growing without bound,
+  with no human actively tailing it.
+
+We hit this exact failure during the issue #24 investigation: a
+Homebrew CH on `localhost:8123` collided with the docker CH on the
+same port, the migrations went to the wrong server, and the docker CH
+stayed empty. The ingestor logged `clickhouse.ingestor.flush_failed`
+roughly twice a second for hours before anyone noticed — the gateway
+was returning empty `connectors[]` arrays the whole time.
+
+A misconfiguration that doesn't heal on its own should not present as
+a green container.
+
+## Decision
+
+The ingestor tracks consecutive `_flush_batch` failures and **raises
+`IngestorFatalError`** once the count reaches a configurable
+threshold. The exception propagates to `main()`, which logs a single
+exit line and returns exit code 1. Docker compose / kubernetes treat
+that as a crash and restart the container, surfacing the wedge as a
+`CrashLoopBackOff` (or compose's equivalent) instead of a silent loop.
+
+The counter resets on every successful flush, so the policy only
+catches *sustained* failure — not the occasional transient one.
+
+The threshold is `EVEYS_OCPP_CLICKHOUSE_INGESTOR_MAX_FLUSH_FAILURES`,
+defaulting to **10**.
+
+## Alternatives considered
+
+- **Liveness probe that fails when the failure counter is non-zero.**
+  Rejected: any single transient failure would mark the pod unhealthy
+  and Kubernetes would restart it, defeating the "ride out a CH GC
+  pause" property. The probe approach also doesn't help docker compose
+  on a laptop, which has no built-in liveness concept beyond the
+  process exit code.
+
+- **Bail on the first failure.** Rejected: a one-shot CH timeout or a
+  brief broker disconnect should not crash the process. The cost of a
+  pod restart isn't zero — Kafka rebalance, partition reassignment,
+  cold caches — and the loop already retries cleanly on the next poll.
+
+- **Bail by elapsed time, not count.** Rejected as more complex with
+  no practical advantage. Counting failures while keeping the existing
+  fixed 1 s backoff means "10 consecutive failures" maps to roughly
+  10–60 seconds of dead air (depending on `BATCH_MAX_SECONDS`) — a
+  range an operator would already consider unacceptable.
+
+- **Surface the wedge via Prometheus / alertmanager only.** Rejected
+  as the *only* mechanism. We do want the metric (E4-1's
+  `eveys_ocpp_ingestor_flush_failures_total`), but a metric with no
+  alert is invisible, an alert depends on alertmanager being healthy,
+  and neither helps the laptop developer who hasn't wired up
+  monitoring. Process-exit is the universally-observable signal.
+
+## Consequences
+
+### Positive
+
+- Wedged misconfigurations show up as restart loops within ~1 minute
+  (10 failures × ~5 s batch window). Operators see `CrashLoopBackOff`
+  with the cause in the last log lines.
+- Single transient failures still ride through silently — counter
+  resets on the next successful flush.
+- No new dependencies. The whole change is one counter, one raise,
+  and one `sys.exit(1)` in `main()`.
+
+### Negative / costs
+
+- A network-partition that lasts longer than ~1 minute now restarts
+  the ingestor instead of waiting it out. Restart is cheap (a few
+  seconds) but it does mean we'll briefly stop ingesting on the
+  margin of "should this even count as down?" That tradeoff is fine
+  for our scale; revisit if Kafka-rebalance cost ever dominates.
+- The default of 10 is a guess. Easy to tune via env var if the
+  in-the-field rate of false-positive bails turns out to be too
+  spicy.
+
+### Risks
+
+- A failure that flips between flushed and failed (e.g. one CH
+  replica out of three returning errors) would never trip the limit
+  even if half the writes fail. The counter is "consecutive", not
+  "rolling N". Acceptable: that scenario is already abnormal and the
+  per-attempt log carries the error code, but it's worth knowing the
+  policy isn't a substitute for a metric-based alert.
+
+### Reversibility
+
+- Reversible. Setting
+  `EVEYS_OCPP_CLICKHOUSE_INGESTOR_MAX_FLUSH_FAILURES` to a very large
+  number (e.g. `1000000`) effectively restores the old log-and-loop
+  behaviour without code changes. Removing the policy entirely is a
+  ~10-line revert.
+
+## References
+
+- ADR-0020 — ClickHouse ingestion sidecar (the loop the policy lives in).
+- Issue #24 — the wedge that motivated the policy.
+- PR #26 — implementation + tests.
+- `src/eveys_ocpp/clickhouse/ingestor.py` — `IngestorFatalError`,
+  the counter, and the bail in `ingest_loop`.
+- `docs/07-local-dev-setup.md` § Troubleshooting — operator-facing
+  "what to do when the ingestor crashlooops" guidance.


### PR DESCRIPTION
## Summary

Records the policy that landed in #26 (and closed #24's second half) and gives operators a place to look when the ingestor sits in CrashLoopBackOff.

### ADR-0028 — \`docs/adr/0028-ingestor-fail-fast-policy.md\`

Decision, alternatives, and consequences for "exit non-zero after N consecutive flush failures." Captures the four alternatives we considered (liveness probe, first-strike bail, time-based, metrics-only) with the specific reason each was rejected. Frames the policy as reversible — bumping the env knob to \`1000000\` restores the old log-and-loop without code changes.

### Troubleshooting entry — \`docs/07-local-dev-setup.md\`

New section "\`eveys-ocpp-clickhouse-ingestor\` keeps restarting" with:

- The exact \`docker logs ... | grep\` one-liner to find the last \`flush_failed\` before \`exit_fatal\`.
- A table mapping common ClickHouse errors to root causes:
  - \`Code: 60. Table eveys_ocpp.cp_status does not exist\` → schema not applied / port collision (links #24).
  - \`Code: 53. Type mismatch\` → proto-vs-DDL drift mid-deploy.
  - \`Code: 192. Unknown user\` → CH user/role mis-provisioned.
  - Network errors → host misconfig / startup race.
- The env-var escape hatch (\`EVEYS_OCPP_CLICKHOUSE_INGESTOR_MAX_FLUSH_FAILURES=1000000\`) with a "do not ship to production" warning.

## Test plan
- [x] \`make docs\` builds clean (sphinx \`-W\` strict).
- [x] \`ruff check .\` clean.
- [x] No source changes — pure documentation.