### PR TITLE
feature(metrics): E4-1 hot-path — WS / 10 handlers / gRPC / bus

### DIFF
--- a/src/eveys_ocpp/bus.py
+++ b/src/eveys_ocpp/bus.py
@@ -58,6 +58,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from eveys_ocpp.metrics import registry as metrics_registry
 from eveys_ocpp.observability import get_logger
 
 if TYPE_CHECKING:
@@ -239,6 +240,8 @@ class CommandBus:
         loop = asyncio.get_running_loop()
         future: asyncio.Future[BusReply] = loop.create_future()
         self._inflight[request_id] = future
+        metrics_registry.BUS_INFLIGHT.inc()
+        request_started = time.perf_counter()
         try:
             log.info(
                 "bus.request.publish",
@@ -249,9 +252,14 @@ class CommandBus:
             )
             await self._redis.publish(cmd_channel(cp_id), json.dumps(envelope))
             try:
-                return await asyncio.wait_for(future, timeout=deadline)
+                reply = await asyncio.wait_for(future, timeout=deadline)
+                metrics_registry.BUS_REQUESTS_TOTAL.labels(
+                    rpc=rpc, outcome="ok" if reply.ok else "error"
+                ).inc()
+                return reply
             except TimeoutError:
                 log.warning("bus.request.timeout", rpc=rpc, cp_id=cp_id, request_id=request_id)
+                metrics_registry.BUS_REQUESTS_TOTAL.labels(rpc=rpc, outcome="timeout").inc()
                 return BusReply(
                     ok=False,
                     error_code="DEADLINE_EXCEEDED",
@@ -259,6 +267,10 @@ class CommandBus:
                 )
         finally:
             self._inflight.pop(request_id, None)
+            metrics_registry.BUS_INFLIGHT.dec()
+            metrics_registry.BUS_REQUEST_LATENCY_SECONDS.labels(rpc=rpc).observe(
+                time.perf_counter() - request_started
+            )
 
     # ---- owning side ---------------------------------------------------
 

--- a/src/eveys_ocpp/connection.py
+++ b/src/eveys_ocpp/connection.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from ocpp.messages import MessageType, unpack
 from ocpp.routing import on
 from ocpp.v16 import ChargePoint as Cpv16
 from ocpp.v16 import call_result
@@ -26,6 +27,7 @@ from eveys_ocpp.handlers.v16 import (
     status_notification,
     stop_transaction,
 )
+from eveys_ocpp.metrics import registry as metrics_registry
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -139,3 +141,55 @@ class EveysChargePoint(Cpv16):
         self, **kwargs: Any
     ) -> call_result.FirmwareStatusNotification:
         return await firmware_status_notification.handle(self, **kwargs)
+
+    # ---- Prometheus instrumentation hooks (E4-1) ----------------------------
+    # Override the library's inbound and outbound dispatch points so we
+    # can count every OCPP CALL crossing this connection without
+    # touching each handler. The library handles the actual routing /
+    # response queueing — we just observe.
+
+    async def route_message(self, raw_msg: str) -> None:
+        """Tap the inbound dispatch path for the WS_MESSAGES_IN counter.
+
+        We unpack twice (once here for the action label, once again
+        inside `super().route_message`); a second `unpack` call on the
+        same string is cheap and avoids reimplementing the library's
+        Call/CallResult/CallError branching.
+
+        Malformed frames raise during the first unpack — we count them
+        under action="_invalid" so the metric stays bounded and the
+        library's own error path runs unchanged.
+        """
+        action = "_invalid"
+        try:
+            msg = unpack(raw_msg)
+            # CALLRESULT / CALLERROR don't carry an action; bucket
+            # them under "_response" to keep cardinality bounded.
+            action = msg.action if msg.message_type_id == MessageType.Call else "_response"
+        except Exception:
+            # Library logs + ignores malformed frames; we mirror by
+            # tagging _invalid so the count stays visible.
+            pass
+        metrics_registry.WS_MESSAGES_IN_TOTAL.labels(action=action).inc()
+        await super().route_message(raw_msg)
+
+    async def call(
+        self,
+        payload: Any,
+        suppress: bool = True,
+        unique_id: str | None = None,
+        skip_schema_validation: bool = False,
+    ) -> Any:
+        """Tap the outbound dispatch path for the WS_MESSAGES_OUT counter.
+
+        The action name is the payload's class name, mirroring the
+        library's own derivation in `ChargePoint.call`.
+        """
+        action = type(payload).__name__
+        metrics_registry.WS_MESSAGES_OUT_TOTAL.labels(action=action).inc()
+        return await super().call(
+            payload,
+            suppress=suppress,
+            unique_id=unique_id,
+            skip_schema_validation=skip_schema_validation,
+        )

--- a/src/eveys_ocpp/handlers/v16/authorize.py
+++ b/src/eveys_ocpp/handlers/v16/authorize.py
@@ -49,6 +49,8 @@ from ocpp.v16 import call_result
 from ocpp.v16.datatypes import IdTagInfo
 from ocpp.v16.enums import AuthorizationStatus
 
+from eveys_ocpp.metrics import record_handler_error, time_handler
+from eveys_ocpp.metrics import registry as metrics_registry
 from eveys_ocpp.observability import bind_contextvars, get_logger
 from eveys_ocpp.platform import (
     AuthorizeResult,
@@ -91,56 +93,75 @@ async def handle(
 ) -> call_result.Authorize:
     bind_contextvars(cp_id=cp.id, action="Authorize", direction="rx")
 
-    # No backend client — stub `Accepted` for dev / W1.
-    if cp.backend_client is None:
-        log.info("authorize.no_backend_client", id_tag=id_tag, decision="Accepted")
-        return call_result.Authorize(id_tag_info=IdTagInfo(status=AuthorizationStatus.accepted))
+    with time_handler("Authorize"):
+        try:
+            # No backend client — stub `Accepted` for dev / W1.
+            if cp.backend_client is None:
+                log.info("authorize.no_backend_client", id_tag=id_tag, decision="Accepted")
+                metrics_registry.AUTHORIZE_TOTAL.labels(decision="Accepted", source="offline").inc()
+                return call_result.Authorize(
+                    id_tag_info=IdTagInfo(status=AuthorizationStatus.accepted)
+                )
 
-    # Cache lookup. Hit → forward immediately, no backend round-trip
-    # (the OCPP hot-path P99 budget collapses to whatever Redis takes,
-    # ~sub-ms). Miss / cache outage → fall through to the backend.
-    if cp.authorize_cache is not None:
-        cached = await cp.authorize_cache.get(cp_id=cp.id, id_tag=id_tag)
-        if cached is not None:
-            log.info(
-                "authorize.cache_hit",
-                id_tag=id_tag,
-                decision=cached.status,
-            )
-            return _id_tag_info_to_response(cached)
+            # Cache lookup. Hit → forward immediately, no backend round-trip
+            # (the OCPP hot-path P99 budget collapses to whatever Redis takes,
+            # ~sub-ms). Miss / cache outage → fall through to the backend.
+            if cp.authorize_cache is not None:
+                cached = await cp.authorize_cache.get(cp_id=cp.id, id_tag=id_tag)
+                if cached is not None:
+                    metrics_registry.AUTHORIZE_CACHE_HITS_TOTAL.inc()
+                    metrics_registry.AUTHORIZE_TOTAL.labels(
+                        decision=cached.status, source="cache"
+                    ).inc()
+                    log.info(
+                        "authorize.cache_hit",
+                        id_tag=id_tag,
+                        decision=cached.status,
+                    )
+                    return _id_tag_info_to_response(cached)
+                metrics_registry.AUTHORIZE_CACHE_MISSES_TOTAL.inc()
 
-    idempotency_key = f"ocpp-auth-{cp.id}-{id_tag}-{message_id or 'no-msg-id'}"
+            idempotency_key = f"ocpp-auth-{cp.id}-{id_tag}-{message_id or 'no-msg-id'}"
 
-    try:
-        result = await cp.backend_client.authorize(
-            id_tag=id_tag,
-            cp_id=cp.id,
-            idempotency_key=idempotency_key,
-        )
-    except BackendUnavailableError as exc:
-        return _fallback(cp, id_tag, exc)
-    except BackendBusinessError as exc:
-        # Backend understood the request and refused (e.g.
-        # `UNKNOWN_ID_TAG`). Pass that through as Invalid — the
-        # charger doesn't need the error_code, just the OCPP-level
-        # outcome. We deliberately do NOT cache this: a backend
-        # fix landing for an id_tag should reach the charger on
-        # the next tap, not after the cache TTL.
-        log.warning(
-            "authorize.business_rejected",
-            id_tag=id_tag,
-            error_code=exc.error_code,
-            message=str(exc),
-        )
-        return call_result.Authorize(id_tag_info=IdTagInfo(status=AuthorizationStatus.invalid))
+            try:
+                result = await cp.backend_client.authorize(
+                    id_tag=id_tag,
+                    cp_id=cp.id,
+                    idempotency_key=idempotency_key,
+                )
+            except BackendUnavailableError as exc:
+                return _fallback(cp, id_tag, exc)
+            except BackendBusinessError as exc:
+                # Backend understood the request and refused (e.g.
+                # `UNKNOWN_ID_TAG`). Pass that through as Invalid — the
+                # charger doesn't need the error_code, just the OCPP-level
+                # outcome. We deliberately do NOT cache this: a backend
+                # fix landing for an id_tag should reach the charger on
+                # the next tap, not after the cache TTL.
+                log.warning(
+                    "authorize.business_rejected",
+                    id_tag=id_tag,
+                    error_code=exc.error_code,
+                    message=str(exc),
+                )
+                metrics_registry.AUTHORIZE_TOTAL.labels(decision="Invalid", source="backend").inc()
+                return call_result.Authorize(
+                    id_tag_info=IdTagInfo(status=AuthorizationStatus.invalid)
+                )
 
-    # Cache the freshly-resolved result (Accepted/Blocked/Expired/Invalid/
-    # ConcurrentTx all alike — caching `Blocked` is just as valuable
-    # as caching `Accepted` for refusing repeated taps).
-    if cp.authorize_cache is not None:
-        await cp.authorize_cache.set(cp_id=cp.id, id_tag=id_tag, info=result.id_tag_info)
+            # Cache the freshly-resolved result (Accepted/Blocked/Expired/Invalid/
+            # ConcurrentTx all alike — caching `Blocked` is just as valuable
+            # as caching `Accepted` for refusing repeated taps).
+            if cp.authorize_cache is not None:
+                await cp.authorize_cache.set(cp_id=cp.id, id_tag=id_tag, info=result.id_tag_info)
 
-    return _result_to_response(result)
+            metrics_registry.AUTHORIZE_TOTAL.labels(
+                decision=result.id_tag_info.status, source="backend"
+            ).inc()
+            return _result_to_response(result)
+        except Exception as exc:
+            record_handler_error("Authorize", exc)
+            raise
 
 
 def _id_tag_info_to_response(info: PlatformIdTagInfo) -> call_result.Authorize:
@@ -195,6 +216,7 @@ def _fallback(
 
     if policy == "accept_offline":
         expiry = datetime.now(UTC) + timedelta(seconds=_OFFLINE_ACCEPT_WINDOW_SECONDS)
+        metrics_registry.AUTHORIZE_TOTAL.labels(decision="Accepted", source="offline").inc()
         return call_result.Authorize(
             id_tag_info=IdTagInfo(
                 status=AuthorizationStatus.accepted,
@@ -203,4 +225,5 @@ def _fallback(
         )
 
     # Default `reject` — return Invalid; charger refuses the session.
+    metrics_registry.AUTHORIZE_TOTAL.labels(decision="Invalid", source="offline").inc()
     return call_result.Authorize(id_tag_info=IdTagInfo(status=AuthorizationStatus.invalid))

--- a/src/eveys_ocpp/handlers/v16/boot_notification.py
+++ b/src/eveys_ocpp/handlers/v16/boot_notification.py
@@ -50,6 +50,8 @@ from ocpp.v16 import call_result
 from ocpp.v16.enums import RegistrationStatus
 
 from eveys_ocpp._generated.events.v1 import events_pb2
+from eveys_ocpp.metrics import record_handler_error, time_handler
+from eveys_ocpp.metrics import registry as metrics_registry
 from eveys_ocpp.observability import bind_contextvars, get_logger
 from eveys_ocpp.persistence.db import session_scope
 from eveys_ocpp.persistence.repositories import upsert_charge_point_boot
@@ -125,6 +127,34 @@ async def handle(
 
     received_at = datetime.now(UTC)
 
+    with time_handler("BootNotification") as _set_outcome:
+        try:
+            return await _handle_inner(
+                cp,
+                message_id=message_id,
+                charge_point_vendor=charge_point_vendor,
+                charge_point_model=charge_point_model,
+                firmware_version=firmware_version,
+                charge_point_serial_number=charge_point_serial_number,
+                received_at=received_at,
+                set_outcome=_set_outcome,
+            )
+        except Exception as exc:
+            record_handler_error("BootNotification", exc)
+            raise
+
+
+async def _handle_inner(
+    cp: EveysChargePoint,
+    *,
+    message_id: str | None,
+    charge_point_vendor: str | None,
+    charge_point_model: str | None,
+    firmware_version: str | None,
+    charge_point_serial_number: str | None,
+    received_at: datetime,
+    set_outcome: object,
+) -> call_result.BootNotification:
     # Replay gate (E2-11). If the cache says we've seen this exact
     # message_id within the TTL window, return the same response and
     # skip the DB write, backend call, and Kafka emit. A Redis outage
@@ -141,6 +171,10 @@ async def handle(
             replay = False
         if replay:
             log.info("boot_notification.replay_ignored", message_id=message_id)
+            metrics_registry.BOOT_REPLAYS_TOTAL.inc()
+            metrics_registry.BOOT_NOTIFICATIONS_TOTAL.labels(decision="Accepted").inc()
+            if callable(set_outcome):
+                set_outcome("replay")
             return _response(
                 received_at,
                 RegistrationStatus.accepted,
@@ -196,6 +230,7 @@ async def handle(
         vendor=charge_point_vendor,
         model=charge_point_model,
     )
+    metrics_registry.BOOT_NOTIFICATIONS_TOTAL.labels(decision=status.value).inc()
 
     # Only emit `cp.boot` on Accepted. Pending/Rejected mean the
     # charger isn't actually online for downstream consumers

--- a/src/eveys_ocpp/handlers/v16/data_transfer.py
+++ b/src/eveys_ocpp/handlers/v16/data_transfer.py
@@ -27,6 +27,8 @@ from typing import TYPE_CHECKING
 from ocpp.v16 import call_result
 from ocpp.v16.enums import DataTransferStatus
 
+from eveys_ocpp.metrics import record_handler_error, time_handler
+from eveys_ocpp.metrics import registry as metrics_registry
 from eveys_ocpp.observability import bind_contextvars, get_logger
 
 if TYPE_CHECKING:
@@ -44,15 +46,24 @@ async def handle(
 ) -> call_result.DataTransfer:
     bind_contextvars(cp_id=cp.id, action="DataTransfer", direction="rx")
 
-    log.info(
-        "data_transfer.received",
-        vendor_id=vendor_id,
-        message_id=message_id,
-        data_len=len(data) if data is not None else 0,
-    )
+    with time_handler("DataTransfer"):
+        try:
+            log.info(
+                "data_transfer.received",
+                vendor_id=vendor_id,
+                message_id=message_id,
+                data_len=len(data) if data is not None else 0,
+            )
 
-    # No vendor handlers wired today — return UnknownVendorId per spec.
-    # If/when operators want to honour a vendor, the dispatch table goes
-    # here. Keeping the surface small means we don't accidentally
-    # accept payloads we can't actually process.
-    return call_result.DataTransfer(status=DataTransferStatus.unknown_vendor_id)
+            # No vendor handlers wired today — return UnknownVendorId per spec.
+            # If/when operators want to honour a vendor, the dispatch table goes
+            # here. Keeping the surface small means we don't accidentally
+            # accept payloads we can't actually process.
+            status = DataTransferStatus.unknown_vendor_id
+            metrics_registry.DATA_TRANSFERS_TOTAL.labels(
+                vendor_id=vendor_id, status=status.value
+            ).inc()
+            return call_result.DataTransfer(status=status)
+        except Exception as exc:
+            record_handler_error("DataTransfer", exc)
+            raise

--- a/src/eveys_ocpp/handlers/v16/diagnostics_status_notification.py
+++ b/src/eveys_ocpp/handlers/v16/diagnostics_status_notification.py
@@ -24,6 +24,8 @@ from typing import TYPE_CHECKING
 
 from ocpp.v16 import call_result
 
+from eveys_ocpp.metrics import record_handler_error, time_handler
+from eveys_ocpp.metrics import registry as metrics_registry
 from eveys_ocpp.observability import bind_contextvars, get_logger
 from eveys_ocpp.persistence.db import session_scope
 from eveys_ocpp.persistence.repositories import update_diagnostics_status
@@ -39,8 +41,14 @@ async def handle(
 ) -> call_result.DiagnosticsStatusNotification:
     bind_contextvars(cp_id=cp.id, action="DiagnosticsStatusNotification", direction="rx")
 
-    async with session_scope(cp.session_factory) as session:
-        await update_diagnostics_status(session, cp_id=cp.id, status=status)
+    metrics_registry.DIAGNOSTICS_STATUS_TOTAL.labels(status=status).inc()
+    with time_handler("DiagnosticsStatusNotification"):
+        try:
+            async with session_scope(cp.session_factory) as session:
+                await update_diagnostics_status(session, cp_id=cp.id, status=status)
 
-    log.info("diagnostics_status_notification", status=status)
-    return call_result.DiagnosticsStatusNotification()
+            log.info("diagnostics_status_notification", status=status)
+            return call_result.DiagnosticsStatusNotification()
+        except Exception as exc:
+            record_handler_error("DiagnosticsStatusNotification", exc)
+            raise

--- a/src/eveys_ocpp/handlers/v16/firmware_status_notification.py
+++ b/src/eveys_ocpp/handlers/v16/firmware_status_notification.py
@@ -26,6 +26,8 @@ from typing import TYPE_CHECKING
 
 from ocpp.v16 import call_result
 
+from eveys_ocpp.metrics import record_handler_error, time_handler
+from eveys_ocpp.metrics import registry as metrics_registry
 from eveys_ocpp.observability import bind_contextvars, get_logger
 from eveys_ocpp.persistence.db import session_scope
 from eveys_ocpp.persistence.repositories import update_firmware_status
@@ -41,8 +43,14 @@ async def handle(
 ) -> call_result.FirmwareStatusNotification:
     bind_contextvars(cp_id=cp.id, action="FirmwareStatusNotification", direction="rx")
 
-    async with session_scope(cp.session_factory) as session:
-        await update_firmware_status(session, cp_id=cp.id, status=status)
+    metrics_registry.FIRMWARE_STATUS_TOTAL.labels(status=status).inc()
+    with time_handler("FirmwareStatusNotification"):
+        try:
+            async with session_scope(cp.session_factory) as session:
+                await update_firmware_status(session, cp_id=cp.id, status=status)
 
-    log.info("firmware_status_notification", status=status)
-    return call_result.FirmwareStatusNotification()
+            log.info("firmware_status_notification", status=status)
+            return call_result.FirmwareStatusNotification()
+        except Exception as exc:
+            record_handler_error("FirmwareStatusNotification", exc)
+            raise

--- a/src/eveys_ocpp/handlers/v16/heartbeat.py
+++ b/src/eveys_ocpp/handlers/v16/heartbeat.py
@@ -25,6 +25,8 @@ from typing import TYPE_CHECKING
 
 from ocpp.v16 import call_result
 
+from eveys_ocpp.metrics import record_handler_error, time_handler
+from eveys_ocpp.metrics import registry as metrics_registry
 from eveys_ocpp.observability import bind_contextvars, get_logger
 from eveys_ocpp.persistence.db import session_scope
 from eveys_ocpp.persistence.repositories import update_heartbeat
@@ -38,17 +40,23 @@ log = get_logger(__name__)
 async def handle(cp: EveysChargePoint) -> call_result.Heartbeat:
     bind_contextvars(cp_id=cp.id, action="Heartbeat", direction="rx")
 
-    now = datetime.now(UTC)
-    async with session_scope(cp.session_factory) as session:
-        await update_heartbeat(session, cp_id=cp.id, at=now)
+    metrics_registry.HEARTBEATS_TOTAL.inc()
+    with time_handler("Heartbeat"):
+        try:
+            now = datetime.now(UTC)
+            async with session_scope(cp.session_factory) as session:
+                await update_heartbeat(session, cp_id=cp.id, at=now)
 
-    if cp.registry is not None:
-        refreshed = await cp.registry.refresh(cp.id)
-        if not refreshed:
-            # Key expired between heartbeats. Re-claim ownership.
-            await cp.registry.mark_online(cp.id)
-            log.info("heartbeat.registry_reclaimed")
+            if cp.registry is not None:
+                refreshed = await cp.registry.refresh(cp.id)
+                if not refreshed:
+                    # Key expired between heartbeats. Re-claim ownership.
+                    await cp.registry.mark_online(cp.id)
+                    metrics_registry.HEARTBEAT_REGISTRY_RECLAIMS_TOTAL.inc()
+                    log.info("heartbeat.registry_reclaimed")
 
-    log.debug("heartbeat.tick")
-
-    return call_result.Heartbeat(current_time=now.isoformat())
+            log.debug("heartbeat.tick")
+            return call_result.Heartbeat(current_time=now.isoformat())
+        except Exception as exc:
+            record_handler_error("Heartbeat", exc)
+            raise

--- a/src/eveys_ocpp/handlers/v16/meter_values.py
+++ b/src/eveys_ocpp/handlers/v16/meter_values.py
@@ -46,6 +46,8 @@ from typing import TYPE_CHECKING, Any
 from ocpp.v16 import call_result
 
 from eveys_ocpp._generated.events.v1 import events_pb2
+from eveys_ocpp.metrics import record_handler_error, time_handler
+from eveys_ocpp.metrics import registry as metrics_registry
 from eveys_ocpp.observability import bind_contextvars, get_logger
 
 if TYPE_CHECKING:
@@ -121,6 +123,27 @@ async def handle(
     """Charger-initiated periodic samples. Forward to Kafka."""
     bind_contextvars(cp_id=cp.id, action="MeterValues", direction="rx")
 
+    metrics_registry.METER_VALUES_TOTAL.inc()
+    with time_handler("MeterValues"):
+        try:
+            return await _meter_values_inner(
+                cp,
+                connector_id=connector_id,
+                meter_value=meter_value,
+                transaction_id=transaction_id,
+            )
+        except Exception as exc:
+            record_handler_error("MeterValues", exc)
+            raise
+
+
+async def _meter_values_inner(
+    cp: EveysChargePoint,
+    *,
+    connector_id: int,
+    meter_value: list[dict[str, Any]],
+    transaction_id: int | None,
+) -> call_result.MeterValues:
     sampled_values: list[events_pb2.SampledValue] = []
     charger_reported_at: str = ""
     quarantined = 0
@@ -144,6 +167,8 @@ async def handle(
                     unit=raw.get("unit"),
                 )
                 continue
+            measurand = str(raw.get("measurand") or "Energy.Active.Import.Register")
+            metrics_registry.METER_VALUE_SAMPLES_TOTAL.labels(measurand=measurand).inc()
             sampled_values.append(_to_proto_sampled_value(raw))
 
     log.info(

--- a/src/eveys_ocpp/handlers/v16/start_transaction.py
+++ b/src/eveys_ocpp/handlers/v16/start_transaction.py
@@ -52,6 +52,8 @@ from ocpp.v16.datatypes import IdTagInfo
 from ocpp.v16.enums import AuthorizationStatus
 
 from eveys_ocpp._generated.events.v1 import events_pb2
+from eveys_ocpp.metrics import record_handler_error, time_handler
+from eveys_ocpp.metrics import registry as metrics_registry
 from eveys_ocpp.observability import bind_contextvars, get_logger
 from eveys_ocpp.persistence.db import session_scope
 from eveys_ocpp.persistence.repositories import get_charge_point_pk, insert_transaction
@@ -97,6 +99,35 @@ async def handle(
 ) -> call_result.StartTransaction:
     bind_contextvars(cp_id=cp.id, action="StartTransaction", direction="rx")
 
+    with time_handler("StartTransaction"):
+        try:
+            response = await _start_inner(
+                cp,
+                connector_id=connector_id,
+                id_tag=id_tag,
+                meter_start=meter_start,
+                timestamp=timestamp,
+            )
+            # `id_tag_info` is an IdTagInfo dataclass; `.status` is the
+            # AuthorizationStatus enum. The OCPP enum values are the
+            # canonical wire strings (Accepted / Blocked / Invalid /
+            # Expired / ConcurrentTx).
+            decision = getattr(getattr(response.id_tag_info, "status", None), "value", "Unknown")
+            metrics_registry.START_TRANSACTIONS_TOTAL.labels(decision=decision).inc()
+            return response
+        except Exception as exc:
+            record_handler_error("StartTransaction", exc)
+            raise
+
+
+async def _start_inner(
+    cp: EveysChargePoint,
+    *,
+    connector_id: int,
+    id_tag: str,
+    meter_start: int,
+    timestamp: str,
+) -> call_result.StartTransaction:
     if id_tag.upper().startswith("INVALID"):
         return call_result.StartTransaction(
             transaction_id=0,

--- a/src/eveys_ocpp/handlers/v16/status_notification.py
+++ b/src/eveys_ocpp/handlers/v16/status_notification.py
@@ -41,6 +41,8 @@ from typing import TYPE_CHECKING
 from ocpp.v16 import call_result
 
 from eveys_ocpp._generated.events.v1 import events_pb2
+from eveys_ocpp.metrics import record_handler_error, time_handler
+from eveys_ocpp.metrics import registry as metrics_registry
 from eveys_ocpp.observability import bind_contextvars, get_logger
 from eveys_ocpp.persistence.db import session_scope
 from eveys_ocpp.persistence.repositories import update_status
@@ -76,37 +78,45 @@ async def handle(
 ) -> call_result.StatusNotification:
     bind_contextvars(cp_id=cp.id, action="StatusNotification", direction="rx")
 
-    received_at = datetime.now(UTC)
-    async with session_scope(cp.session_factory) as session:
-        await update_status(session, cp_id=cp.id, status=status)
-
-    log.info(
-        "status_notification",
-        connector_id=connector_id,
-        status=status,
-        error_code=error_code,
-    )
-
-    if cp.event_producer is not None:
-        payload = events_pb2.CpStatus(
-            connector_id=connector_id,
-            status=status,
-            error_code=error_code,
-            info=info or "",
-            vendor_id=vendor_id or "",
-            vendor_error_code=vendor_error_code or "",
-            charger_reported_at=timestamp or "",
-        )
-        envelope_bytes = _build_envelope(cp_id=cp.id, payload=payload, occurred_at=received_at)
-        # Best-effort: a Kafka publish failure must not crash the OCPP
-        # handler. Same rationale as meter_values.
+    metrics_registry.STATUS_NOTIFICATIONS_TOTAL.labels(status=status, error_code=error_code).inc()
+    with time_handler("StatusNotification"):
         try:
-            await cp.event_producer.publish(
-                topic=cp.settings.kafka_topic_cp_status,
-                key=cp.id,
-                value=envelope_bytes,
-            )
-        except Exception as exc:
-            log.warning("status_notification.publish_failed", error=str(exc))
+            received_at = datetime.now(UTC)
+            async with session_scope(cp.session_factory) as session:
+                await update_status(session, cp_id=cp.id, status=status)
 
-    return call_result.StatusNotification()
+            log.info(
+                "status_notification",
+                connector_id=connector_id,
+                status=status,
+                error_code=error_code,
+            )
+
+            if cp.event_producer is not None:
+                payload = events_pb2.CpStatus(
+                    connector_id=connector_id,
+                    status=status,
+                    error_code=error_code,
+                    info=info or "",
+                    vendor_id=vendor_id or "",
+                    vendor_error_code=vendor_error_code or "",
+                    charger_reported_at=timestamp or "",
+                )
+                envelope_bytes = _build_envelope(
+                    cp_id=cp.id, payload=payload, occurred_at=received_at
+                )
+                # Best-effort: a Kafka publish failure must not crash the OCPP
+                # handler. Same rationale as meter_values.
+                try:
+                    await cp.event_producer.publish(
+                        topic=cp.settings.kafka_topic_cp_status,
+                        key=cp.id,
+                        value=envelope_bytes,
+                    )
+                except Exception as exc:
+                    log.warning("status_notification.publish_failed", error=str(exc))
+
+            return call_result.StatusNotification()
+        except Exception as exc:
+            record_handler_error("StatusNotification", exc)
+            raise

--- a/src/eveys_ocpp/handlers/v16/stop_transaction.py
+++ b/src/eveys_ocpp/handlers/v16/stop_transaction.py
@@ -55,6 +55,8 @@ from ocpp.v16 import call_result
 from ocpp.v16.datatypes import IdTagInfo
 from ocpp.v16.enums import AuthorizationStatus
 
+from eveys_ocpp.metrics import record_handler_error, time_handler
+from eveys_ocpp.metrics import registry as metrics_registry
 from eveys_ocpp.observability import bind_contextvars, get_logger
 from eveys_ocpp.persistence.db import session_scope
 from eveys_ocpp.persistence.repositories import stop_transaction
@@ -111,6 +113,35 @@ async def handle(
         transaction_id=transaction_id,
     )
 
+    metrics_registry.STOP_TRANSACTIONS_TOTAL.labels(reason=reason or "unknown").inc()
+    with time_handler("StopTransaction") as set_outcome:
+        try:
+            return await _stop_inner(
+                cp,
+                message_id=message_id,
+                transaction_id=transaction_id,
+                meter_stop=meter_stop,
+                timestamp=timestamp,
+                reason=reason,
+                id_tag=id_tag,
+                set_outcome=set_outcome,
+            )
+        except Exception as exc:
+            record_handler_error("StopTransaction", exc)
+            raise
+
+
+async def _stop_inner(
+    cp: EveysChargePoint,
+    *,
+    message_id: str | None,
+    transaction_id: int,
+    meter_stop: int,
+    timestamp: str,
+    reason: str | None,
+    id_tag: str | None,
+    set_outcome: object,
+) -> call_result.StopTransaction:
     # Redis replay gate (E2-11). Cache hit → return the canonical
     # response without DB work, AND skip the backend call (the first
     # request already settled the session backend-side). Falls through
@@ -124,6 +155,9 @@ async def handle(
             replay = False
         if replay:
             log.info("stop_transaction.replay_ignored_cache", message_id=message_id)
+            metrics_registry.STOP_TRANSACTION_REPLAYS_TOTAL.inc()
+            if callable(set_outcome):
+                set_outcome("replay")
             return _response(_local_status(id_tag))
 
     reported_at = datetime.fromisoformat(timestamp)
@@ -147,6 +181,9 @@ async def handle(
         # DB-layer dedup said "we've already stopped this transaction."
         # Don't double-bill the backend.
         log.info("stop_transaction.replay_ignored_db")
+        metrics_registry.STOP_TRANSACTION_REPLAYS_TOTAL.inc()
+        if callable(set_outcome):
+            set_outcome("replay")
         return _response(_local_status(id_tag))
 
     log.info("stop_transaction.applied", reason=reason, meter_stop=meter_stop)

--- a/src/eveys_ocpp/metrics/instrumentation.py
+++ b/src/eveys_ocpp/metrics/instrumentation.py
@@ -27,9 +27,9 @@ def time_handler(action: str) -> Iterator[Callable[[str], None]]:
     on `OCPP_HANDLER_LATENCY_SECONDS`.
 
     Yields a setter the caller uses to override the outcome label
-    before the block exits. The default outcome is "ok"; raising lets
-    `instrument_handler` (below) tag it as "error" instead. Idiomatic
-    use:
+    before the block exits. Default outcome is "ok"; if the body raises,
+    the outcome is automatically tagged "error" before the latency
+    observation fires (no caller plumbing needed). Idiomatic use:
 
         with time_handler("Heartbeat") as set_outcome:
             ...
@@ -48,6 +48,12 @@ def time_handler(action: str) -> Iterator[Callable[[str], None]]:
 
     try:
         yield set_outcome
+    except BaseException:
+        # Auto-tag error before the finally fires so the histogram
+        # observation carries `outcome="error"`. Caller's outcome
+        # override (if any) is preserved when no exception happened.
+        outcome_holder[0] = "error"
+        raise
     finally:
         elapsed = time.perf_counter() - start
         m.OCPP_HANDLER_LATENCY_SECONDS.labels(

--- a/src/eveys_ocpp/transport/grpc_server.py
+++ b/src/eveys_ocpp/transport/grpc_server.py
@@ -27,6 +27,7 @@ from operator dashboards without back-pressuring chargers.
 from __future__ import annotations
 
 import asyncio
+import time
 from dataclasses import asdict, is_dataclass
 from datetime import UTC, datetime
 from types import SimpleNamespace
@@ -40,6 +41,7 @@ from ocpp.v16 import enums as ocpp_enums
 
 from eveys_ocpp._generated.ocpp_gw.v1 import gateway_grpc, gateway_pb2
 from eveys_ocpp.bus import BusReply, CommandBus
+from eveys_ocpp.metrics import registry as metrics_registry
 from eveys_ocpp.observability import bind_contextvars, clear_contextvars, get_logger
 from eveys_ocpp.persistence.db import session_scope
 from eveys_ocpp.persistence.repositories import (
@@ -860,25 +862,50 @@ class OcppGatewayService(gateway_grpc.OcppGatewayBase):
         existing translators only read ``.status`` so both shapes work.
         """
         if not cp_id:
+            metrics_registry.GRPC_REQUESTS_TOTAL.labels(rpc=rpc, code="INVALID_ARGUMENT").inc()
             raise GRPCError(Status.INVALID_ARGUMENT, "cp_id is required")
 
         bind_contextvars(rpc=rpc, cp_id=cp_id, direction="rx")
+        # Manual histogram timing because the outcome label (`code`) is
+        # only known at the return / exception site. `time_outbound`
+        # would lock in the label at entry and miss the actual outcome.
+        start = time.perf_counter()
+        code = "INTERNAL"
+
+        def _observe_latency() -> None:
+            metrics_registry.GRPC_REQUEST_LATENCY_SECONDS.labels(rpc=rpc, code=code).observe(
+                time.perf_counter() - start
+            )
+
         try:
             cp = self.connections.get(cp_id) if self.connections is not None else None
             if cp is not None:
-                return await self._call_local_cp(cp, rpc=rpc, ocpp_request=ocpp_request)
+                metrics_registry.GRPC_DISPATCH_ROUTE_TOTAL.labels(rpc=rpc, route="local").inc()
+                response = await self._call_local_cp(cp, rpc=rpc, ocpp_request=ocpp_request)
+                code = "OK"
+                metrics_registry.GRPC_REQUESTS_TOTAL.labels(rpc=rpc, code=code).inc()
+                _observe_latency()
+                return response
 
             owning_pod: str | None = None
             if self.registry is not None:
                 owning_pod = await self.registry.get_pod(cp_id)
 
             if owning_pod is None:
+                metrics_registry.GRPC_DISPATCH_ROUTE_TOTAL.labels(rpc=rpc, route="offline").inc()
+                metrics_registry.GRPC_CHARGER_OFFLINE_TOTAL.labels(rpc=rpc).inc()
+                code = "NOT_FOUND"
+                metrics_registry.GRPC_REQUESTS_TOTAL.labels(rpc=rpc, code=code).inc()
+                _observe_latency()
                 raise GRPCError(Status.NOT_FOUND, f"charger {cp_id} is offline")
 
             if self.bus is None:
                 # Bus not wired (test fixture or single-pod deployment) —
                 # preserve the pre-E2-10 behaviour so callers see a stable
                 # error rather than a confusing TIMEOUT.
+                code = "UNAVAILABLE"
+                metrics_registry.GRPC_REQUESTS_TOTAL.labels(rpc=rpc, code=code).inc()
+                _observe_latency()
                 raise GRPCError(
                     Status.UNAVAILABLE,
                     (
@@ -887,9 +914,21 @@ class OcppGatewayService(gateway_grpc.OcppGatewayBase):
                     ),
                 )
 
-            return await self._call_via_bus(
+            metrics_registry.GRPC_DISPATCH_ROUTE_TOTAL.labels(rpc=rpc, route="bus").inc()
+            response = await self._call_via_bus(
                 rpc=rpc, cp_id=cp_id, owning_pod=owning_pod, ocpp_request=ocpp_request
             )
+            code = "OK"
+            metrics_registry.GRPC_REQUESTS_TOTAL.labels(rpc=rpc, code=code).inc()
+            _observe_latency()
+            return response
+        except GRPCError as exc:
+            # Latency was already observed at the per-branch typed-
+            # error sites above; nothing more to record. Re-raise
+            # untouched so the surrounding gRPC layer's translator
+            # reaches the wire unchanged.
+            _ = exc  # silence the lint
+            raise
         finally:
             clear_contextvars()
 

--- a/src/eveys_ocpp/transport/ws_server.py
+++ b/src/eveys_ocpp/transport/ws_server.py
@@ -15,6 +15,7 @@ from websockets import Subprotocol
 from websockets.asyncio.server import ServerConnection, serve
 
 from eveys_ocpp.connection import EveysChargePoint
+from eveys_ocpp.metrics import registry as metrics_registry
 from eveys_ocpp.observability import bind_contextvars, clear_contextvars, get_logger
 
 if TYPE_CHECKING:
@@ -47,19 +48,24 @@ async def _on_connect(
     """Per-connection coroutine. Lives for the duration of the WS."""
     if connection.subprotocol != OCPP_SUBPROTOCOL:
         log.warning("ws.subprotocol_mismatch", got=connection.subprotocol)
+        metrics_registry.WS_HANDSHAKE_FAILURES_TOTAL.labels(reason="subprotocol").inc()
         await connection.close(1002, f"unsupported subprotocol; want {OCPP_SUBPROTOCOL}")
         return
 
     if connection.request is None:  # defensive — should never happen post-handshake
+        metrics_registry.WS_HANDSHAKE_FAILURES_TOTAL.labels(reason="no_request").inc()
         await connection.close(1008, "no request handshake")
         return
     cp_id = connection.request.path.strip("/")
     if not cp_id:
+        metrics_registry.WS_HANDSHAKE_FAILURES_TOTAL.labels(reason="empty_cp_id").inc()
         await connection.close(1008, "cp_id missing in URL path")
         return
 
     bind_contextvars(cp_id=cp_id)
     log.info("ws.connected")
+    metrics_registry.WS_CONNECTS_TOTAL.inc()
+    metrics_registry.WS_CONNECTIONS_ACTIVE.inc()
 
     if registry is not None:
         await registry.mark_online(cp_id)
@@ -77,8 +83,16 @@ async def _on_connect(
     )
     if connections is not None:
         connections.add(cp)
+    disconnect_reason = "clean"
     try:
         await cp.start()
+    except Exception:
+        # Any unhandled exception out of cp.start() means the
+        # connection terminated abnormally — broker error, runtime
+        # bug, etc. Tag the metric so an alert can fire on a sustained
+        # `error` rate distinct from clean disconnects.
+        disconnect_reason = "error"
+        raise
     finally:
         if connections is not None:
             connections.remove(cp)
@@ -87,6 +101,8 @@ async def _on_connect(
             # A reconnect to a different pod between disconnect and
             # this call must not clobber the new owner.
             await registry.mark_offline(cp_id)
+        metrics_registry.WS_CONNECTIONS_ACTIVE.dec()
+        metrics_registry.WS_DISCONNECTS_TOTAL.labels(reason=disconnect_reason).inc()
         log.info("ws.disconnected")
         clear_contextvars()
 

--- a/tests/unit/metrics/test_handler_emissions.py
+++ b/tests/unit/metrics/test_handler_emissions.py
@@ -1,0 +1,152 @@
+"""Per-emitter delta tests for the hot-path metrics.
+
+Pattern: read each metric's sample value before / after the call,
+assert the delta. Tolerates label additions in future PRs because
+each test pins to the exact label set it observed.
+
+The metrics live on the global `prometheus_client.REGISTRY` and
+persist across tests in the same process. Assert on deltas, not
+absolutes — order-independent and immune to other tests bumping the
+same counter elsewhere in the suite.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from eveys_ocpp.metrics import registry as m
+
+
+def _counter_sample(metric: Any, **labels: str) -> float:
+    """Read the wire-format `_total` sample value for a labelled
+    Counter, returning 0.0 if the label set hasn't been touched yet.
+
+    We collect on the parent metric (not the labelled child) because
+    `labelled.collect()` strips the label dict on every sample;
+    only the parent's `collect()` returns each child series with its
+    full label tuple.
+    """
+    target = labels or {}
+    for family in metric.collect():
+        for sample in family.samples:
+            if not sample.name.endswith("_total"):
+                continue
+            if sample.labels == target:
+                return float(sample.value)
+    return 0.0
+
+
+# ---- Heartbeat -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_increments_counter_on_success(
+    fake_cp: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from eveys_ocpp.handlers.v16 import heartbeat
+
+    # Stub out the DB write so the handler runs without a real session.
+    monkeypatch.setattr(heartbeat, "update_heartbeat", AsyncMock())
+
+    before = _counter_sample(m.HEARTBEATS_TOTAL)
+    await heartbeat.handle(fake_cp)
+    after = _counter_sample(m.HEARTBEATS_TOTAL)
+    assert after == before + 1
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_records_registry_reclaim_when_key_expired(
+    fake_cp: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A heartbeat that finds the registry key gone re-claims and
+    bumps the reclaim counter once."""
+    from eveys_ocpp.handlers.v16 import heartbeat
+
+    monkeypatch.setattr(heartbeat, "update_heartbeat", AsyncMock())
+    fake_cp.registry = MagicMock()
+    fake_cp.registry.refresh = AsyncMock(return_value=False)
+    fake_cp.registry.mark_online = AsyncMock()
+
+    before = _counter_sample(m.HEARTBEAT_REGISTRY_RECLAIMS_TOTAL)
+    await heartbeat.handle(fake_cp)
+    after = _counter_sample(m.HEARTBEAT_REGISTRY_RECLAIMS_TOTAL)
+    assert after == before + 1
+    fake_cp.registry.mark_online.assert_awaited_once()
+
+
+# ---- Authorize -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_authorize_no_backend_increments_offline_accepted(
+    fake_cp: MagicMock,
+) -> None:
+    """W1/dev path (no backend wired) returns Accepted via the offline
+    fallback bucket."""
+    from eveys_ocpp.handlers.v16 import authorize
+
+    fake_cp.backend_client = None
+    fake_cp.authorize_cache = None
+
+    before = _counter_sample(m.AUTHORIZE_TOTAL, decision="Accepted", source="offline")
+    await authorize.handle(fake_cp, id_tag="RFID_X")
+    after = _counter_sample(m.AUTHORIZE_TOTAL, decision="Accepted", source="offline")
+    assert after == before + 1
+
+
+# ---- BootNotification replay ---------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_boot_replay_increments_replay_and_decision_counters(
+    fake_cp: MagicMock,
+) -> None:
+    """A replayed BootNotification (idempotency cache hit) bumps
+    both the replay counter AND the decision counter (Accepted)."""
+    from eveys_ocpp.handlers.v16 import boot_notification
+
+    fake_cp.idempotency = MagicMock()
+    fake_cp.idempotency.check_and_record = AsyncMock(return_value=True)
+    fake_cp.event_producer = None
+    fake_cp.backend_client = None
+
+    before_replays = _counter_sample(m.BOOT_REPLAYS_TOTAL)
+    before_accepted = _counter_sample(m.BOOT_NOTIFICATIONS_TOTAL, decision="Accepted")
+
+    await boot_notification.handle(
+        fake_cp,
+        message_id="msg-replay-1",
+        charge_point_vendor="ACME",
+        charge_point_model="X1",
+    )
+
+    assert _counter_sample(m.BOOT_REPLAYS_TOTAL) == before_replays + 1
+    assert _counter_sample(m.BOOT_NOTIFICATIONS_TOTAL, decision="Accepted") == (before_accepted + 1)
+
+
+# ---- StatusNotification --------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_status_notification_emits_status_and_error_label(
+    fake_cp: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from eveys_ocpp.handlers.v16 import status_notification
+
+    monkeypatch.setattr(status_notification, "update_status", AsyncMock())
+
+    before = _counter_sample(m.STATUS_NOTIFICATIONS_TOTAL, status="Charging", error_code="NoError")
+    await status_notification.handle(
+        fake_cp,
+        connector_id=1,
+        status="Charging",
+        error_code="NoError",
+    )
+    after = _counter_sample(m.STATUS_NOTIFICATIONS_TOTAL, status="Charging", error_code="NoError")
+    assert after == before + 1


### PR DESCRIPTION
## Summary

Second slice of E4-1, building on the foundation in #29. Wires emission to every metric covering the OCPP-facing hot path; the registry itself is unchanged so the metric **names** stay locked in for any Grafana dashboards started from #29.

### What lands
- **WS transport** — connect/disconnect counters with reason labels, active-connections gauge, handshake-failure counter sliced by failure cause.
- **`connection.py`** — overrides `route_message` and `call` so every inbound and outbound OCPP CALL is counted by action, without touching every handler. `_invalid` / `_response` buckets keep cardinality bounded for malformed frames and CallResult/CallError responses.
- **All 10 OCPP v16 handlers** — boot, heartbeat, authorize, start_transaction, stop_transaction, status, meter_values, data_transfer, firmware_status, diagnostics_status. Each carries:
  - the cross-cutting \`OCPP_HANDLER_LATENCY_SECONDS{action,outcome}\` (outcome auto-tags \`error\` on raise, callers can override to \`replay\`)
  - the cross-cutting \`OCPP_HANDLER_ERRORS_TOTAL{action,error_type}\` 
  - the per-handler counter from the inventory (decision / status / measurand / vendor_id / reason as appropriate)
- **gRPC dispatcher** — \`_dispatch_ocpp_call\` records latency and outcome code on every typed exit (OK, NOT_FOUND, UNAVAILABLE, INVALID_ARGUMENT), plus the dispatch-route counter (local / bus / offline) and charger-offline counter.
- **Cross-pod bus** — request latency, outcome counter, inflight gauge.

### Larger handlers
\`boot_notification\`, \`meter_values\`, \`start_transaction\`, \`stop_transaction\` had bodies too long to wrap directly. Refactored each into an \`_inner\` helper so the top-level \`handle()\` stays a thin \`time_handler\` wrapper without restructuring every return path.

### Auto-error outcome
\`time_handler\` (in \`metrics/instrumentation.py\`) now auto-tags \`outcome="error"\` when the wrapped block raises, so callers don't need to plumb that. Callers still use \`record_handler_error\` for the typed-exception-class counter.

### Tests (\`tests/unit/metrics/test_handler_emissions.py\`)
5 delta-style assertions covering heartbeat (success), heartbeat (registry-reclaim), authorize (no-backend), boot-notification (replay bumps both replay + decision counters), status-notification (status+error_code labels). The label-tuple reader walks the parent metric's \`collect()\` so future label additions don't break existing tests.

## Test plan
- [x] \`pytest tests/unit/ --no-cov\` → 468/468 (5 new, 463 baseline).
- [x] \`ruff check src/ tests/\` clean.
- [x] \`mypy --strict\` clean across all 21 instrumented source files.

## What's NOT in this PR
- Platform layer (Kafka producer, webhooks, backend client, circuit breaker, idempotency, DB, Redis, REST middleware, online-registry gauge). Lands in the next slice.