### PR TITLE
feature(metrics): E4-1 platform — Kafka / webhooks / backend client / circuit breaker / REST middleware

### DIFF
--- a/src/eveys_ocpp/api/_app.py
+++ b/src/eveys_ocpp/api/_app.py
@@ -20,6 +20,7 @@ the time-series endpoints.
 
 from __future__ import annotations
 
+import time
 import uuid
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING
@@ -46,6 +47,7 @@ from eveys_ocpp.api._errors import (
     internal_error_handler,
     validation_exception_handler,
 )
+from eveys_ocpp.metrics import registry as metrics_registry
 from eveys_ocpp.observability import bind_contextvars
 
 if TYPE_CHECKING:
@@ -99,8 +101,11 @@ def make_app(
     # Order matters: request-id MUST run before auth so the auth-reject
     # response carries the correlation id. Middlewares run in reverse
     # registration order (FastAPI/Starlette quirk), so register auth
-    # first, then request-id last → request-id wraps everything.
+    # first, then metrics, then request-id last → request-id wraps
+    # everything; metrics wraps the auth + handlers so a 401 still
+    # observes latency.
     app.middleware("http")(make_bearer_auth_middleware(settings))
+    app.middleware("http")(_metrics_middleware)
     app.middleware("http")(_request_id_middleware)
 
     # Exception handlers. ApiError is the typed shape routes raise;
@@ -138,4 +143,31 @@ async def _request_id_middleware(
     bind_contextvars(request_id=rid, http_path=request.url.path, http_method=request.method)
     response = await call_next(request)
     response.headers["X-Request-ID"] = rid
+    return response
+
+
+async def _metrics_middleware(
+    request: Request,
+    call_next: Callable[[Request], Awaitable[JSONResponse]],
+) -> JSONResponse:
+    """Increment `REST_REQUESTS_TOTAL{method,route,code}` and observe
+    `REST_REQUEST_LATENCY_SECONDS{method,route}` on every request.
+
+    `route` uses the FastAPI **route template** (e.g.
+    `/api/v1/charge-points/{cp_id}`) — never the literal path — so a
+    cp_id-keyed traffic pattern doesn't blow up label cardinality.
+    Requests that don't match a route (404s, OPTIONS preflights) get
+    `route="_unmatched"`.
+    """
+    started = time.perf_counter()
+    response = await call_next(request)
+    route_obj = request.scope.get("route")
+    route_label = getattr(route_obj, "path", None) or "_unmatched"
+    method = request.method
+    metrics_registry.REST_REQUESTS_TOTAL.labels(
+        method=method, route=route_label, code=str(response.status_code)
+    ).inc()
+    metrics_registry.REST_REQUEST_LATENCY_SECONDS.labels(method=method, route=route_label).observe(
+        time.perf_counter() - started
+    )
     return response

--- a/src/eveys_ocpp/events.py
+++ b/src/eveys_ocpp/events.py
@@ -22,10 +22,12 @@ Two implementations:
 
 from __future__ import annotations
 
+import time
 from typing import TYPE_CHECKING, Protocol
 
 from aiokafka import AIOKafkaProducer
 
+from eveys_ocpp.metrics import registry as metrics_registry
 from eveys_ocpp.observability import get_logger
 
 if TYPE_CHECKING:
@@ -122,7 +124,19 @@ class KafkaEventProducer:
     async def publish(self, *, topic: str, key: str, value: bytes) -> None:
         if self._producer is None:
             raise RuntimeError("KafkaEventProducer.publish called before start()")
-        await self._producer.send_and_wait(topic, value=value, key=key.encode("utf-8"))
+        start = time.perf_counter()
+        try:
+            await self._producer.send_and_wait(topic, value=value, key=key.encode("utf-8"))
+        except Exception:
+            metrics_registry.KAFKA_PUBLISH_TOTAL.labels(topic=topic, outcome="error").inc()
+            raise
+        else:
+            metrics_registry.KAFKA_PUBLISH_TOTAL.labels(topic=topic, outcome="ok").inc()
+            metrics_registry.KAFKA_PUBLISH_BYTES_TOTAL.labels(topic=topic).inc(len(value))
+        finally:
+            metrics_registry.KAFKA_PUBLISH_LATENCY_SECONDS.labels(topic=topic).observe(
+                time.perf_counter() - start
+            )
 
 
 class NullEventProducer:

--- a/src/eveys_ocpp/platform/circuit_breaker.py
+++ b/src/eveys_ocpp/platform/circuit_breaker.py
@@ -31,6 +31,7 @@ import time
 from dataclasses import dataclass
 from enum import Enum
 
+from eveys_ocpp.metrics import registry as metrics_registry
 from eveys_ocpp.observability import get_logger
 from eveys_ocpp.platform.errors import BackendCircuitOpenError
 
@@ -71,6 +72,10 @@ class CircuitBreaker:
                 if time.monotonic() - self._opened_at >= self.cooldown_seconds:
                     log.info("circuit_breaker.half_open", name=self.name)
                     self._state = _State.HALF_OPEN
+                    self._record_state_metric()
+                    metrics_registry.BACKEND_CIRCUIT_TRANSITIONS_TOTAL.labels(
+                        name=self.name, to_state="half_open"
+                    ).inc()
                 else:
                     raise BackendCircuitOpenError(f"circuit breaker open for {self.name}")
 
@@ -78,8 +83,12 @@ class CircuitBreaker:
         async with self._lock:
             if self._state is not _State.CLOSED:
                 log.info("circuit_breaker.closed", name=self.name)
+                metrics_registry.BACKEND_CIRCUIT_TRANSITIONS_TOTAL.labels(
+                    name=self.name, to_state="closed"
+                ).inc()
             self._state = _State.CLOSED
             self._consecutive_failures = 0
+            self._record_state_metric()
 
     async def record_failure(self) -> None:
         async with self._lock:
@@ -99,6 +108,15 @@ class CircuitBreaker:
                 )
                 self._state = _State.OPEN
                 self._opened_at = time.monotonic()
+                self._record_state_metric()
+                metrics_registry.BACKEND_CIRCUIT_TRANSITIONS_TOTAL.labels(
+                    name=self.name, to_state="open"
+                ).inc()
+
+    def _record_state_metric(self) -> None:
+        """Reflect the live state into the gauge. closed=0, half_open=1, open=2."""
+        value = {_State.CLOSED: 0.0, _State.HALF_OPEN: 1.0, _State.OPEN: 2.0}[self._state]
+        metrics_registry.BACKEND_CIRCUIT_STATE.labels(name=self.name).set(value)
 
     @property
     def state(self) -> str:

--- a/src/eveys_ocpp/platform/client.py
+++ b/src/eveys_ocpp/platform/client.py
@@ -29,12 +29,14 @@ concern. The client just raises typed exceptions.
 
 from __future__ import annotations
 
+import time
 import uuid
 from dataclasses import dataclass
 from typing import Any
 
 import httpx
 
+from eveys_ocpp.metrics import registry as metrics_registry
 from eveys_ocpp.observability import get_logger
 from eveys_ocpp.platform.circuit_breaker import CircuitBreaker
 from eveys_ocpp.platform.errors import (
@@ -190,6 +192,18 @@ class BackendHTTPClient:
 
     # ---- HTTP plumbing -----------------------------------------------------
 
+    @staticmethod
+    def _endpoint_label(path: str) -> str:
+        """Bound the cardinality of the `endpoint` metric label.
+
+        `path` looks like `/api/eveys/authorize` or
+        `/api/eveys/sessions/open`. The label space is small and
+        well-known (5 endpoints) — strip the prefix and use the
+        remainder. Strip leading slash + replace internal slashes
+        with underscores so Prometheus accepts the label literally.
+        """
+        return path.removeprefix("/api/eveys/").lstrip("/").replace("/", "_") or "root"
+
     async def _request(
         self,
         *,
@@ -214,6 +228,15 @@ class BackendHTTPClient:
         """
         await self._breaker.before_call()
 
+        endpoint = self._endpoint_label(path)
+        request_started = time.perf_counter()
+        outcome = "internal_error"
+
+        def _observe_latency() -> None:
+            metrics_registry.BACKEND_REQUEST_LATENCY_SECONDS.labels(
+                endpoint=endpoint, outcome=outcome
+            ).observe(time.perf_counter() - request_started)
+
         request_id = _new_request_id()
         headers: dict[str, str] = {"X-Request-ID": request_id}
         if idempotency_key is not None:
@@ -221,6 +244,8 @@ class BackendHTTPClient:
 
         last_exc: Exception | None = None
         for attempt in range(max_retries + 1):
+            if attempt > 0:
+                metrics_registry.BACKEND_RETRIES_TOTAL.labels(endpoint=endpoint).inc()
             try:
                 response = await self._http.request(
                     method,
@@ -241,6 +266,11 @@ class BackendHTTPClient:
                 if attempt < max_retries:
                     continue
                 await self._breaker.record_failure()
+                outcome = "timeout"
+                metrics_registry.BACKEND_REQUESTS_TOTAL.labels(
+                    endpoint=endpoint, outcome=outcome
+                ).inc()
+                _observe_latency()
                 raise BackendTimeoutError(
                     f"backend timeout after {max_retries + 1} attempts on {path}"
                 ) from exc
@@ -256,6 +286,11 @@ class BackendHTTPClient:
                 if attempt < max_retries:
                     continue
                 await self._breaker.record_failure()
+                outcome = "network_error"
+                metrics_registry.BACKEND_REQUESTS_TOTAL.labels(
+                    endpoint=endpoint, outcome=outcome
+                ).inc()
+                _observe_latency()
                 raise BackendNetworkError(
                     f"backend network error after {max_retries + 1} attempts on {path}"
                 ) from exc
@@ -272,7 +307,17 @@ class BackendHTTPClient:
                 # is wrong).
                 await self._breaker.record_success()
                 if status in (401, 403):
+                    outcome = "auth_error"
+                    metrics_registry.BACKEND_REQUESTS_TOTAL.labels(
+                        endpoint=endpoint, outcome=outcome
+                    ).inc()
+                    _observe_latency()
                     raise BackendAuthError(message, error_code=error_code, http_status=status)
+                outcome = "business_error"
+                metrics_registry.BACKEND_REQUESTS_TOTAL.labels(
+                    endpoint=endpoint, outcome=outcome
+                ).inc()
+                _observe_latency()
                 raise BackendBusinessError(message, error_code=error_code, http_status=status)
 
             # 5xx — retryable transport failure.
@@ -291,6 +336,11 @@ class BackendHTTPClient:
                 if attempt < max_retries:
                     continue
                 await self._breaker.record_failure()
+                outcome = "server_error"
+                metrics_registry.BACKEND_REQUESTS_TOTAL.labels(
+                    endpoint=endpoint, outcome=outcome
+                ).inc()
+                _observe_latency()
                 raise last_exc
 
             # 2xx — happy path.
@@ -304,14 +354,27 @@ class BackendHTTPClient:
                 # transport, and shouldn't trip the breaker.
                 error_code = str(envelope.get("error_code") or "BUSINESS_REJECTION")
                 message = str(envelope.get("message") or "rejected")
+                outcome = "business_error"
+                metrics_registry.BACKEND_REQUESTS_TOTAL.labels(
+                    endpoint=endpoint, outcome=outcome
+                ).inc()
+                _observe_latency()
                 raise BackendBusinessError(message, error_code=error_code, http_status=status)
             data = envelope.get("data")
             if not isinstance(data, dict):
+                outcome = "malformed"
+                metrics_registry.BACKEND_REQUESTS_TOTAL.labels(
+                    endpoint=endpoint, outcome=outcome
+                ).inc()
+                _observe_latency()
                 raise BackendBusinessError(
                     "backend returned success but `data` was missing or non-object",
                     error_code="MALFORMED_RESPONSE",
                     http_status=status,
                 )
+            outcome = "ok"
+            metrics_registry.BACKEND_REQUESTS_TOTAL.labels(endpoint=endpoint, outcome=outcome).inc()
+            _observe_latency()
             return data
 
         # Unreachable — the loop either returns or raises.

--- a/src/eveys_ocpp/webhooks/dispatcher.py
+++ b/src/eveys_ocpp/webhooks/dispatcher.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import time
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -26,6 +27,7 @@ import httpx
 from aiokafka import AIOKafkaConsumer
 
 from eveys_ocpp._generated.events.v1 import events_pb2
+from eveys_ocpp.metrics import registry as metrics_registry
 from eveys_ocpp.observability import get_logger
 from eveys_ocpp.webhooks.signer import compute_signature
 
@@ -210,6 +212,7 @@ class WebhookDispatcher:
 
         max_attempts = self._settings.webhook_max_attempts
         for attempt in range(1, max_attempts + 1):
+            metrics_registry.WEBHOOK_ATTEMPTS_TOTAL.labels(event_type=event_type).inc()
             headers = {
                 "Content-Type": "application/json",
                 "X-Eveys-Signature": signature,
@@ -218,9 +221,13 @@ class WebhookDispatcher:
                 "X-Eveys-Delivered-At": datetime.now(UTC).isoformat(),
                 "X-Eveys-Attempt": str(attempt),
             }
+            attempt_started = time.perf_counter()
             try:
                 response = await self._http.post(url, content=body_bytes, headers=headers)
             except (httpx.TimeoutException, httpx.NetworkError) as exc:
+                metrics_registry.WEBHOOK_DELIVERY_LATENCY_SECONDS.labels(
+                    event_type=event_type
+                ).observe(time.perf_counter() - attempt_started)
                 log.warning(
                     "webhook.delivery_attempt_failed",
                     url=url,
@@ -234,6 +241,10 @@ class WebhookDispatcher:
                 await asyncio.sleep(_BACKOFF_SECONDS[attempt - 1])
                 continue
 
+            metrics_registry.WEBHOOK_DELIVERY_LATENCY_SECONDS.labels(event_type=event_type).observe(
+                time.perf_counter() - attempt_started
+            )
+
             if 200 <= response.status_code < 300:
                 log.info(
                     "webhook.delivered",
@@ -243,6 +254,9 @@ class WebhookDispatcher:
                     attempt=attempt,
                     status=response.status_code,
                 )
+                metrics_registry.WEBHOOK_DELIVERIES_TOTAL.labels(
+                    event_type=event_type, outcome="delivered"
+                ).inc()
                 return
 
             if response.status_code == 429 or response.status_code >= 500:
@@ -269,6 +283,9 @@ class WebhookDispatcher:
                 status=response.status_code,
                 body=response.text[:200],
             )
+            metrics_registry.WEBHOOK_DELIVERIES_TOTAL.labels(
+                event_type=event_type, outcome="rejected"
+            ).inc()
             return
 
         log.error(
@@ -278,6 +295,9 @@ class WebhookDispatcher:
             event_type=event_type,
             max_attempts=max_attempts,
         )
+        metrics_registry.WEBHOOK_DELIVERIES_TOTAL.labels(
+            event_type=event_type, outcome="failed"
+        ).inc()
 
     # ---- envelope → wire body ---------------------------------------------
 

--- a/tests/unit/metrics/test_handler_emissions.py
+++ b/tests/unit/metrics/test_handler_emissions.py
@@ -150,3 +150,49 @@ async def test_status_notification_emits_status_and_error_label(
     )
     after = _counter_sample(m.STATUS_NOTIFICATIONS_TOTAL, status="Charging", error_code="NoError")
     assert after == before + 1
+
+
+# ---- Circuit breaker -----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_records_open_transition() -> None:
+    """Two consecutive failures past the threshold trip the breaker
+    and bump the transitions counter."""
+    from eveys_ocpp.platform.circuit_breaker import CircuitBreaker
+
+    breaker = CircuitBreaker(name="test_breaker_open", threshold=2, cooldown_seconds=60)
+
+    before = _counter_sample(
+        m.BACKEND_CIRCUIT_TRANSITIONS_TOTAL, name="test_breaker_open", to_state="open"
+    )
+    await breaker.record_failure()
+    await breaker.record_failure()
+    after = _counter_sample(
+        m.BACKEND_CIRCUIT_TRANSITIONS_TOTAL, name="test_breaker_open", to_state="open"
+    )
+    assert after == before + 1
+
+
+# ---- Kafka producer ------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kafka_publish_records_ok_count_and_bytes() -> None:
+    """KafkaEventProducer.publish bumps the ok counter and adds the
+    byte count."""
+    from eveys_ocpp.events import KafkaEventProducer
+
+    producer = KafkaEventProducer(bootstrap_servers="ignored:0")
+    fake = AsyncMock()
+    producer._producer = fake  # type: ignore[assignment]
+
+    before_count = _counter_sample(m.KAFKA_PUBLISH_TOTAL, topic="cp.boot", outcome="ok")
+    before_bytes = _counter_sample(m.KAFKA_PUBLISH_BYTES_TOTAL, topic="cp.boot")
+
+    await producer.publish(topic="cp.boot", key="CP_X", value=b"\x00\x01\x02")
+
+    assert _counter_sample(m.KAFKA_PUBLISH_TOTAL, topic="cp.boot", outcome="ok") == (
+        before_count + 1
+    )
+    assert _counter_sample(m.KAFKA_PUBLISH_BYTES_TOTAL, topic="cp.boot") == before_bytes + 3


### PR DESCRIPTION
## Summary

Third slice of E4-1, building on the foundation in #29 and the hot-path instrumentation in #30. Wires emission to the rest of the platform layer — outbound HTTP and async I/O — without touching the registry definitions.

### What lands

- **Kafka producer** — \`KAFKA_PUBLISH_TOTAL{topic,outcome}\`, \`_LATENCY_SECONDS\`, \`_BYTES_TOTAL\`. One observation per \`send_and_wait\`; bytes added on success only.
- **Webhook dispatcher** — \`WEBHOOK_ATTEMPTS_TOTAL{event_type}\` per HTTP attempt (counts retries), \`WEBHOOK_DELIVERIES_TOTAL{event_type,outcome}\` once per envelope's final outcome (\`delivered\` / \`rejected\` / \`failed\`), \`WEBHOOK_DELIVERY_LATENCY_SECONDS{event_type}\` per attempt.
- **Backend HTTP client** — \`BACKEND_REQUESTS_TOTAL{endpoint,outcome}\` on every typed exit (ok / business_error / auth_error / server_error / timeout / network_error / malformed), \`_LATENCY_SECONDS\` with the same outcome label, \`BACKEND_RETRIES_TOTAL{endpoint}\` per retry. Endpoint label is derived by a small static helper from the path.
- **Circuit breaker** — \`BACKEND_CIRCUIT_STATE{name}\` reflects every transition (0=closed, 1=half_open, 2=open) and \`BACKEND_CIRCUIT_TRANSITIONS_TOTAL{name,to_state}\` distinguishes a flapping breaker from a stuck-open one.
- **REST middleware** — \`REST_REQUESTS_TOTAL{method,route,code}\` and \`_LATENCY_SECONDS{method,route}\`. \`route\` is the FastAPI **route template** (never the literal path) so cp_id-keyed traffic doesn't blow up cardinality. Middleware order: request-id (outer) → metrics → auth → handlers, so a 401 still observes latency.

### What's NOT in this PR

5 metrics from the inventory remain:
- \`idempotency.py\` — \`IDEMPOTENCY_LOOKUPS_TOTAL\`.
- \`persistence/db.py\` — \`DB_QUERY_LATENCY_SECONDS\` via SQLAlchemy event listener (needs care to avoid double-counting nested transactions).
- \`registry.py\` — \`REDIS_COMMAND_LATENCY_SECONDS\` + \`REGISTRY_ONLINE_CHARGERS\`.
- \`WEBHOOK_CONSUMER_LAG_MESSAGES\` — needs a poll loop reading Kafka group offsets, a different pattern from the per-attempt instrumentation here.

A focused follow-up PR will land those — they touch code that wants a careful approach beyond the "thin instrumentation, no behaviour change" bar this PR holds.

## Test plan
- [x] \`pytest tests/unit/ --no-cov\` → 470/470 (2 new emission tests + 468 baseline).
- [x] \`ruff check src/ tests/\` clean.
- [x] \`mypy --strict\` clean across all 59 source files.