### PR TITLE
feature(observability): E4-2 — 5 Grafana dashboards + provisioning

### DIFF
--- a/deploy/grafana/README.md
+++ b/deploy/grafana/README.md
@@ -1,0 +1,88 @@
+# Grafana provisioning
+
+Five dashboards covering the gateway's `eveys_ocpp_*` metrics, plus a
+Prometheus datasource provisioning file. These ship as deploy artifacts
+— the gateway's compose stack does not run Grafana itself; you mount
+these files into your own Grafana instance.
+
+## What's here
+
+| File | Purpose |
+| --- | --- |
+| `provisioning/datasources/prometheus.yml` | Default Prometheus datasource (URL via `${PROMETHEUS_URL}`, defaults to `http://prometheus:9090`) |
+| `provisioning/dashboards/eveys.yml` | Auto-loads dashboards from `/var/lib/grafana/dashboards/eveys` into the `eveys/ocpp` folder |
+| `dashboards/01-fleet-overview.json` | Fleet-wide rollup — first stop when triaging |
+| `dashboards/02-per-pod.json` | One pod under the lens (templated `pod_id` picker) |
+| `dashboards/03-per-charger.json` | Per-charger context — note: handler metrics are intentionally **not** labelled by `cp_id` (cardinality), so this dashboard pairs Prometheus with logs/Postgres/ClickHouse for true per-charger drill-down |
+| `dashboards/04-reconnect-storms.json` | Reconnect / handshake / heartbeat health — the page-at-3am view |
+| `dashboards/05-transactions.json` | Charging-session lifecycle: starts, stops, Kafka publish, webhook delivery, consumer lag |
+
+All dashboards reference the `prometheus` datasource UID. If your
+Grafana already has a Prometheus datasource with a different UID,
+either override it via this provisioning file or rename your existing
+datasource UID to `prometheus`.
+
+## Mounting into Grafana (Docker)
+
+```yaml
+# add to your own docker-compose.yml that already runs grafana
+services:
+  grafana:
+    image: grafana/grafana:11.0.0
+    volumes:
+      - ./deploy/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./deploy/grafana/dashboards:/var/lib/grafana/dashboards/eveys:ro
+    environment:
+      - PROMETHEUS_URL=http://prometheus:9090
+```
+
+## Mounting into Grafana (Kubernetes)
+
+If you're running grafana-operator or the official Helm chart with
+`sidecar.dashboards.enabled=true`, the dashboards can be loaded as
+ConfigMaps:
+
+```bash
+kubectl create configmap eveys-ocpp-dashboards \
+  --from-file=deploy/grafana/dashboards/ \
+  -n monitoring
+kubectl label configmap eveys-ocpp-dashboards \
+  grafana_dashboard=1 -n monitoring
+```
+
+The Helm-chart sidecar picks them up automatically.
+
+## Prometheus scrape config
+
+The gateway exposes metrics on the metrics port from `Settings.metrics_port`
+(default `9100`). Sample scrape config:
+
+```yaml
+scrape_configs:
+  - job_name: eveys-ocpp
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['eveys-ocpp:9100']
+```
+
+Every metric series carries `pod_id` as a label (set from
+`EVEYS_OCPP_POD_ID` at gateway boot), which is what the per-pod
+dashboard's templated picker reads.
+
+## Conventions used in the JSON
+
+- All metric names are the literal `eveys_ocpp_*` prefix from the registry.
+- Histograms use `histogram_quantile(p, sum by (label, le) (rate(_bucket[5m])))` — per-pod aggregation happens implicitly because we sum across all `pod_id` labels.
+- Counters use `rate(...)[1m]` for stat panels and `[5m]` for timeseries — stat panels want responsiveness, timeseries want smoothing.
+- `ops` unit on rate panels, `s` on latency, `short` on gauges, `percent` where formula already multiplies by 100.
+
+## Updating dashboards
+
+Edit in the Grafana UI, then **export** (Share → Export → Save to file)
+and copy the JSON back into this directory. The provider yaml has
+`allowUiUpdates: true` so live edits work; `disableDeletion: false`
+means you can iterate freely.
+
+When checking dashboard JSON in, **strip the `id` field** (Grafana
+re-numbers per instance) and **keep `uid` stable** (links between
+dashboards rely on it).

--- a/deploy/grafana/dashboards/01-fleet-overview.json
+++ b/deploy/grafana/dashboards/01-fleet-overview.json
@@ -1,0 +1,248 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {"type": "grafana", "uid": "-- Grafana --"},
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Fleet-wide rollup across all gateway pods. The first stop when triaging — answers 'how many chargers are online, how busy are they, are we delivering events to the backend'.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "red", "value": null},
+              {"color": "green", "value": 1}
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 0},
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "title": "Online chargers (fleet)",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "sum(eveys_ocpp_registry_online_chargers)",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "unit": "ops"}
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 0},
+      "id": 2,
+      "title": "Inbound OCPP CALL rate (per action)",
+      "type": "stat",
+      "options": {
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "expr": "sum by (action) (rate(eveys_ocpp_ws_messages_in_total[5m]))",
+          "legendFormat": "{{action}}",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "thresholds"}, "unit": "percent",
+          "thresholds": {"mode": "absolute", "steps": [
+            {"color": "green", "value": null},
+            {"color": "yellow", "value": 1},
+            {"color": "red", "value": 5}
+          ]}}
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 12, "y": 0},
+      "id": 3,
+      "title": "Authorize backend-error rate",
+      "type": "stat",
+      "options": {
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "100 * sum(rate(eveys_ocpp_backend_requests_total{endpoint=\"authorize\",outcome!=\"ok\"}[5m])) / clamp_min(sum(rate(eveys_ocpp_backend_requests_total{endpoint=\"authorize\"}[5m])), 1)",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "thresholds"}, "unit": "short",
+          "thresholds": {"mode": "absolute", "steps": [
+            {"color": "green", "value": null},
+            {"color": "yellow", "value": 1}
+          ]}}
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 18, "y": 0},
+      "id": 4,
+      "title": "Backend circuits open",
+      "type": "stat",
+      "options": {
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(eveys_ocpp_backend_circuit_state == 2)",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "unit": "short"}
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 4},
+      "id": 5,
+      "title": "Active WS connections (per pod)",
+      "type": "timeseries",
+      "options": {"legend": {"displayMode": "table", "placement": "right", "calcs": ["mean", "max"]}},
+      "targets": [
+        {
+          "expr": "eveys_ocpp_ws_connections_active",
+          "legendFormat": "{{pod_id}}",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "unit": "ops"}
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 4},
+      "id": 6,
+      "title": "WS connect / disconnect rate",
+      "type": "timeseries",
+      "options": {"legend": {"displayMode": "table", "placement": "right"}},
+      "targets": [
+        {
+          "expr": "sum(rate(eveys_ocpp_ws_connects_total[1m]))",
+          "legendFormat": "connects",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        },
+        {
+          "expr": "sum by (reason) (rate(eveys_ocpp_ws_disconnects_total[1m]))",
+          "legendFormat": "disconnects ({{reason}})",
+          "refId": "B",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "unit": "s"}
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 13},
+      "id": 7,
+      "title": "OCPP handler P50 / P99 latency (per action)",
+      "type": "timeseries",
+      "options": {"legend": {"displayMode": "table", "placement": "right"}},
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (action, le) (rate(eveys_ocpp_handler_latency_seconds_bucket[5m])))",
+          "legendFormat": "p50 {{action}}",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (action, le) (rate(eveys_ocpp_handler_latency_seconds_bucket[5m])))",
+          "legendFormat": "p99 {{action}}",
+          "refId": "B",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "unit": "ops"}
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 13},
+      "id": 8,
+      "title": "Webhook deliveries (per outcome)",
+      "type": "timeseries",
+      "options": {"legend": {"displayMode": "table", "placement": "right"}},
+      "targets": [
+        {
+          "expr": "sum by (outcome) (rate(eveys_ocpp_webhook_deliveries_total[5m]))",
+          "legendFormat": "{{outcome}}",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "unit": "ops"}
+      },
+      "gridPos": {"h": 9, "w": 24, "x": 0, "y": 22},
+      "id": 9,
+      "title": "Kafka publish rate by topic",
+      "type": "timeseries",
+      "options": {"legend": {"displayMode": "table", "placement": "right"}},
+      "targets": [
+        {
+          "expr": "sum by (topic, outcome) (rate(eveys_ocpp_kafka_publish_total[5m]))",
+          "legendFormat": "{{topic}} {{outcome}}",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["eveys", "ocpp", "fleet"],
+  "templating": {"list": []},
+  "time": {"from": "now-1h", "to": "now"},
+  "timepicker": {},
+  "timezone": "",
+  "title": "eveys/ocpp — Fleet overview",
+  "uid": "eveys-ocpp-fleet",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/grafana/dashboards/02-per-pod.json
+++ b/deploy/grafana/dashboards/02-per-pod.json
@@ -1,0 +1,248 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {"type": "grafana", "uid": "-- Grafana --"},
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "One pod under the lens. Use the pod_id picker to drill into a specific gateway replica when fleet-overview shows it misbehaving — answers 'is this one pod sick or is the whole fleet?'",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [
+    {"title": "Fleet overview", "type": "link", "url": "/d/eveys-ocpp-fleet", "targetBlank": false}
+  ],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "thresholds"}, "unit": "short",
+          "thresholds": {"mode": "absolute", "steps": [
+            {"color": "green", "value": null}
+          ]}}
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 0},
+      "id": 1,
+      "title": "Active WS connections",
+      "type": "stat",
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+      "targets": [
+        {
+          "expr": "eveys_ocpp_ws_connections_active{pod_id=~\"$pod_id\"}",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "unit": "short"}},
+      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 0},
+      "id": 2,
+      "title": "Online chargers (this pod)",
+      "type": "stat",
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+      "targets": [
+        {
+          "expr": "eveys_ocpp_registry_online_chargers{pod_id=~\"$pod_id\"}",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "unit": "short",
+        "thresholds": {"mode": "absolute", "steps": [
+          {"color": "green", "value": null},
+          {"color": "yellow", "value": 5},
+          {"color": "red", "value": 20}
+        ]}}},
+      "gridPos": {"h": 4, "w": 6, "x": 12, "y": 0},
+      "id": 3,
+      "title": "Cross-pod bus inflight",
+      "type": "stat",
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+      "targets": [
+        {
+          "expr": "eveys_ocpp_bus_inflight{pod_id=~\"$pod_id\"}",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "unit": "short",
+        "thresholds": {"mode": "absolute", "steps": [
+          {"color": "green", "value": null},
+          {"color": "red", "value": 1}
+        ]}}},
+      "gridPos": {"h": 4, "w": 6, "x": 18, "y": 0},
+      "id": 4,
+      "title": "Backend circuit (open=2)",
+      "type": "stat",
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+      "targets": [
+        {
+          "expr": "max(eveys_ocpp_backend_circuit_state{pod_id=~\"$pod_id\"})",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "unit": "ops"}},
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 4},
+      "id": 5,
+      "title": "Inbound CALL rate (per action)",
+      "type": "timeseries",
+      "options": {"legend": {"displayMode": "table", "placement": "right"}},
+      "targets": [
+        {
+          "expr": "sum by (action) (rate(eveys_ocpp_ws_messages_in_total{pod_id=~\"$pod_id\"}[1m]))",
+          "legendFormat": "{{action}}",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "unit": "s"}},
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 4},
+      "id": 6,
+      "title": "Handler P50 / P99 (per action)",
+      "type": "timeseries",
+      "options": {"legend": {"displayMode": "table", "placement": "right"}},
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (action, le) (rate(eveys_ocpp_handler_latency_seconds_bucket{pod_id=~\"$pod_id\"}[5m])))",
+          "legendFormat": "p50 {{action}}",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (action, le) (rate(eveys_ocpp_handler_latency_seconds_bucket{pod_id=~\"$pod_id\"}[5m])))",
+          "legendFormat": "p99 {{action}}",
+          "refId": "B",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "unit": "ops"}},
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 13},
+      "id": 7,
+      "title": "Backend HTTP rate (per endpoint, by outcome)",
+      "type": "timeseries",
+      "options": {"legend": {"displayMode": "table", "placement": "right"}},
+      "targets": [
+        {
+          "expr": "sum by (endpoint, outcome) (rate(eveys_ocpp_backend_requests_total{pod_id=~\"$pod_id\"}[1m]))",
+          "legendFormat": "{{endpoint}} {{outcome}}",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "unit": "s"}},
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 13},
+      "id": 8,
+      "title": "DB query latency P50/P99 (per op)",
+      "type": "timeseries",
+      "options": {"legend": {"displayMode": "table", "placement": "right"}},
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (op, le) (rate(eveys_ocpp_db_query_latency_seconds_bucket{pod_id=~\"$pod_id\"}[5m])))",
+          "legendFormat": "p50 {{op}}",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (op, le) (rate(eveys_ocpp_db_query_latency_seconds_bucket{pod_id=~\"$pod_id\"}[5m])))",
+          "legendFormat": "p99 {{op}}",
+          "refId": "B",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "unit": "short"}},
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 22},
+      "id": 9,
+      "title": "DB pool — in use & overflow",
+      "type": "timeseries",
+      "options": {"legend": {"displayMode": "table", "placement": "right"}},
+      "targets": [
+        {
+          "expr": "eveys_ocpp_db_pool_in_use{pod_id=~\"$pod_id\"}",
+          "legendFormat": "in_use",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        },
+        {
+          "expr": "eveys_ocpp_db_pool_overflow{pod_id=~\"$pod_id\"}",
+          "legendFormat": "overflow",
+          "refId": "B",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "unit": "s"}},
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 22},
+      "id": 10,
+      "title": "Redis command latency P99 (per op)",
+      "type": "timeseries",
+      "options": {"legend": {"displayMode": "table", "placement": "right"}},
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum by (op, le) (rate(eveys_ocpp_redis_command_latency_seconds_bucket{pod_id=~\"$pod_id\"}[5m])))",
+          "legendFormat": "p99 {{op}}",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["eveys", "ocpp", "pod"],
+  "templating": {
+    "list": [
+      {
+        "name": "pod_id",
+        "type": "query",
+        "datasource": {"type": "prometheus", "uid": "prometheus"},
+        "query": {"query": "label_values(eveys_ocpp_build_info, pod_id)", "refId": "PrometheusVariableQueryEditor-VariableQuery"},
+        "refresh": 1,
+        "includeAll": false,
+        "multi": false,
+        "current": {"text": "", "value": ""},
+        "label": "pod"
+      }
+    ]
+  },
+  "time": {"from": "now-1h", "to": "now"},
+  "timepicker": {},
+  "timezone": "",
+  "title": "eveys/ocpp — Per-pod",
+  "uid": "eveys-ocpp-pod",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/grafana/dashboards/03-per-charger.json
+++ b/deploy/grafana/dashboards/03-per-charger.json
@@ -1,0 +1,166 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {"type": "grafana", "uid": "-- Grafana --"},
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "One charge point under the lens. Drill into a specific cp_id when an operator says 'this charger is misbehaving' — answers 'what's this charger sending, how is it being routed, are its writes succeeding?' NOTE: handler/registry metrics are NOT labelled by cp_id (that would blow up cardinality), so this dashboard mostly shows aggregated views filtered by labels we DO carry: action, endpoint, topic.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [
+    {"title": "Fleet overview", "type": "link", "url": "/d/eveys-ocpp-fleet", "targetBlank": false}
+  ],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "type": "text",
+      "gridPos": {"h": 3, "w": 24, "x": 0, "y": 0},
+      "id": 100,
+      "options": {
+        "mode": "markdown",
+        "content": "**Per-charger view caveat.** OCPP metrics in this stack are deliberately **not** labelled by `cp_id` — a single warehouse can run thousands of chargers, and a per-`cp_id` Prometheus series for every action/outcome combo would explode cardinality. To trace one charger end-to-end, **also** check:\n\n- **Logs** — `kubectl logs -l app=eveys-ocpp -f | jq 'select(.cp_id==\"<cp_id>\")'`\n- **Postgres** — `SELECT * FROM charge_points WHERE cp_id = '<cp_id>'; SELECT * FROM transactions WHERE charge_point_id = '<cp_id>' ORDER BY id DESC LIMIT 10;`\n- **ClickHouse** — `SELECT * FROM cp.meter WHERE cp_id = '<cp_id>' ORDER BY ts DESC LIMIT 50;`\n\nThe panels below show fleet-wide aggregates that contextualise the single-charger picture you'll build from logs + DB."
+      }
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "unit": "ops"}},
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 3},
+      "id": 1,
+      "title": "Inbound CALL rate by action (fleet)",
+      "type": "timeseries",
+      "options": {"legend": {"displayMode": "table", "placement": "right"}},
+      "targets": [
+        {
+          "expr": "sum by (action) (rate(eveys_ocpp_ws_messages_in_total[1m]))",
+          "legendFormat": "{{action}}",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "unit": "ops"}},
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 3},
+      "id": 2,
+      "title": "StatusNotification by status (fleet)",
+      "type": "timeseries",
+      "options": {"legend": {"displayMode": "table", "placement": "right"}},
+      "targets": [
+        {
+          "expr": "sum by (status, error_code) (rate(eveys_ocpp_status_notifications_total[5m]))",
+          "legendFormat": "{{status}} ({{error_code}})",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "unit": "ops"}},
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 12},
+      "id": 3,
+      "title": "Authorize results (accepted / invalid / expired / blocked / concurrent)",
+      "type": "timeseries",
+      "options": {"legend": {"displayMode": "table", "placement": "right"}},
+      "targets": [
+        {
+          "expr": "sum by (status) (rate(eveys_ocpp_authorize_total[5m]))",
+          "legendFormat": "{{status}}",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "unit": "ops"}},
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 12},
+      "id": 4,
+      "title": "Authorize cache hits vs misses",
+      "type": "timeseries",
+      "options": {"legend": {"displayMode": "table", "placement": "right"}},
+      "targets": [
+        {
+          "expr": "sum(rate(eveys_ocpp_authorize_cache_hits_total[5m]))",
+          "legendFormat": "hits",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        },
+        {
+          "expr": "sum(rate(eveys_ocpp_authorize_cache_misses_total[5m]))",
+          "legendFormat": "misses",
+          "refId": "B",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "unit": "ops"}},
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 21},
+      "id": 5,
+      "title": "Start / Stop transactions",
+      "type": "timeseries",
+      "options": {"legend": {"displayMode": "table", "placement": "right"}},
+      "targets": [
+        {
+          "expr": "sum(rate(eveys_ocpp_start_transactions_total[5m]))",
+          "legendFormat": "starts",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        },
+        {
+          "expr": "sum by (reason) (rate(eveys_ocpp_stop_transactions_total[5m]))",
+          "legendFormat": "stops ({{reason}})",
+          "refId": "B",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "unit": "ops"}},
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 21},
+      "id": 6,
+      "title": "MeterValues — messages & individual samples",
+      "type": "timeseries",
+      "options": {"legend": {"displayMode": "table", "placement": "right"}},
+      "targets": [
+        {
+          "expr": "sum(rate(eveys_ocpp_meter_values_total[5m]))",
+          "legendFormat": "messages",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        },
+        {
+          "expr": "sum(rate(eveys_ocpp_meter_value_samples_total[5m]))",
+          "legendFormat": "samples",
+          "refId": "B",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["eveys", "ocpp", "charger"],
+  "templating": {"list": []},
+  "time": {"from": "now-1h", "to": "now"},
+  "timepicker": {},
+  "timezone": "",
+  "title": "eveys/ocpp — Per-charger context",
+  "uid": "eveys-ocpp-charger",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/grafana/dashboards/04-reconnect-storms.json
+++ b/deploy/grafana/dashboards/04-reconnect-storms.json
@@ -1,0 +1,195 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {"type": "grafana", "uid": "-- Grafana --"},
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Reconnect/handshake/heartbeat health. The page-at-3am dashboard — answers 'are chargers flapping, why are they getting kicked, and is the handshake itself failing?'",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [
+    {"title": "Fleet overview", "type": "link", "url": "/d/eveys-ocpp-fleet", "targetBlank": false}
+  ],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "unit": "ops",
+        "thresholds": {"mode": "absolute", "steps": [
+          {"color": "green", "value": null},
+          {"color": "yellow", "value": 1},
+          {"color": "red", "value": 5}
+        ]}}},
+      "gridPos": {"h": 4, "w": 8, "x": 0, "y": 0},
+      "id": 1,
+      "title": "Handshake failures /sec (fleet)",
+      "type": "stat",
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+      "targets": [
+        {
+          "expr": "sum(rate(eveys_ocpp_ws_handshake_failures_total[1m]))",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "unit": "ops",
+        "thresholds": {"mode": "absolute", "steps": [
+          {"color": "green", "value": null},
+          {"color": "yellow", "value": 5},
+          {"color": "red", "value": 50}
+        ]}}},
+      "gridPos": {"h": 4, "w": 8, "x": 8, "y": 0},
+      "id": 2,
+      "title": "Disconnect rate /sec (fleet)",
+      "type": "stat",
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+      "targets": [
+        {
+          "expr": "sum(rate(eveys_ocpp_ws_disconnects_total[1m]))",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "unit": "ops",
+        "thresholds": {"mode": "absolute", "steps": [
+          {"color": "green", "value": null},
+          {"color": "yellow", "value": 0.5}
+        ]}}},
+      "gridPos": {"h": 4, "w": 8, "x": 16, "y": 0},
+      "id": 3,
+      "title": "Heartbeat registry reclaims /sec",
+      "type": "stat",
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+      "targets": [
+        {
+          "expr": "sum(rate(eveys_ocpp_heartbeat_registry_reclaims_total[5m]))",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "unit": "ops"}},
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 4},
+      "id": 4,
+      "title": "Handshake failures by reason",
+      "type": "timeseries",
+      "options": {"legend": {"displayMode": "table", "placement": "right"}},
+      "targets": [
+        {
+          "expr": "sum by (reason) (rate(eveys_ocpp_ws_handshake_failures_total[1m]))",
+          "legendFormat": "{{reason}}",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "unit": "ops"}},
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 4},
+      "id": 5,
+      "title": "Disconnects by reason",
+      "type": "timeseries",
+      "options": {"legend": {"displayMode": "table", "placement": "right"}},
+      "targets": [
+        {
+          "expr": "sum by (reason) (rate(eveys_ocpp_ws_disconnects_total[1m]))",
+          "legendFormat": "{{reason}}",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "unit": "ops"}},
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 13},
+      "id": 6,
+      "title": "Connect vs disconnect (churn detector)",
+      "type": "timeseries",
+      "options": {"legend": {"displayMode": "table", "placement": "right"}},
+      "targets": [
+        {
+          "expr": "sum(rate(eveys_ocpp_ws_connects_total[1m]))",
+          "legendFormat": "connects",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        },
+        {
+          "expr": "sum(rate(eveys_ocpp_ws_disconnects_total[1m]))",
+          "legendFormat": "disconnects",
+          "refId": "B",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "unit": "ops"}},
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 13},
+      "id": 7,
+      "title": "BootNotification first-time vs replays",
+      "type": "timeseries",
+      "options": {"legend": {"displayMode": "table", "placement": "right"}},
+      "targets": [
+        {
+          "expr": "sum(rate(eveys_ocpp_boot_notifications_total[5m]))",
+          "legendFormat": "all boot",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        },
+        {
+          "expr": "sum(rate(eveys_ocpp_boot_replays_total[5m]))",
+          "legendFormat": "replays only",
+          "refId": "B",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "unit": "ops"}},
+      "gridPos": {"h": 9, "w": 24, "x": 0, "y": 22},
+      "id": 8,
+      "title": "Heartbeat rate (fleet) — gaps signal silent chargers",
+      "type": "timeseries",
+      "options": {"legend": {"displayMode": "table", "placement": "right"}},
+      "targets": [
+        {
+          "expr": "sum(rate(eveys_ocpp_heartbeats_total[1m]))",
+          "legendFormat": "heartbeats /sec",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["eveys", "ocpp", "reconnect"],
+  "templating": {"list": []},
+  "time": {"from": "now-1h", "to": "now"},
+  "timepicker": {},
+  "timezone": "",
+  "title": "eveys/ocpp — Reconnect storms & handshake health",
+  "uid": "eveys-ocpp-reconnect",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/grafana/dashboards/05-transactions.json
+++ b/deploy/grafana/dashboards/05-transactions.json
@@ -1,0 +1,218 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {"type": "grafana", "uid": "-- Grafana --"},
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Charging-session lifecycle. Answers 'are sessions starting, are MeterValues flowing, are sessions ending cleanly, and is downstream (Kafka, webhooks, ClickHouse) keeping up?'",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [
+    {"title": "Fleet overview", "type": "link", "url": "/d/eveys-ocpp-fleet", "targetBlank": false}
+  ],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "unit": "ops"}},
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 0},
+      "id": 1,
+      "title": "Starts /min",
+      "type": "stat",
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+      "targets": [
+        {
+          "expr": "60 * sum(rate(eveys_ocpp_start_transactions_total[5m]))",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "unit": "ops"}},
+      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 0},
+      "id": 2,
+      "title": "Stops /min",
+      "type": "stat",
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+      "targets": [
+        {
+          "expr": "60 * sum(rate(eveys_ocpp_stop_transactions_total[5m]))",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "unit": "ops",
+        "thresholds": {"mode": "absolute", "steps": [
+          {"color": "green", "value": null},
+          {"color": "yellow", "value": 0.1}
+        ]}}},
+      "gridPos": {"h": 4, "w": 6, "x": 12, "y": 0},
+      "id": 3,
+      "title": "Stop replays /min (idempotency hits)",
+      "type": "stat",
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+      "targets": [
+        {
+          "expr": "60 * sum(rate(eveys_ocpp_stop_transaction_replays_total[5m]))",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "unit": "short"}},
+      "gridPos": {"h": 4, "w": 6, "x": 18, "y": 0},
+      "id": 4,
+      "title": "Webhook consumer lag (max across partitions)",
+      "type": "stat",
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+      "targets": [
+        {
+          "expr": "max(eveys_ocpp_webhook_consumer_lag_messages)",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "unit": "ops"}},
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 4},
+      "id": 5,
+      "title": "Start vs stop rate (open-session indicator)",
+      "type": "timeseries",
+      "options": {"legend": {"displayMode": "table", "placement": "right"}},
+      "targets": [
+        {
+          "expr": "sum(rate(eveys_ocpp_start_transactions_total[5m]))",
+          "legendFormat": "starts",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        },
+        {
+          "expr": "sum(rate(eveys_ocpp_stop_transactions_total[5m]))",
+          "legendFormat": "stops",
+          "refId": "B",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "unit": "ops"}},
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 4},
+      "id": 6,
+      "title": "Stop reasons",
+      "type": "timeseries",
+      "options": {"legend": {"displayMode": "table", "placement": "right"}},
+      "targets": [
+        {
+          "expr": "sum by (reason) (rate(eveys_ocpp_stop_transactions_total[5m]))",
+          "legendFormat": "{{reason}}",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "unit": "ops"}},
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 13},
+      "id": 7,
+      "title": "Kafka publish — by topic & outcome",
+      "type": "timeseries",
+      "options": {"legend": {"displayMode": "table", "placement": "right"}},
+      "targets": [
+        {
+          "expr": "sum by (topic, outcome) (rate(eveys_ocpp_kafka_publish_total[1m]))",
+          "legendFormat": "{{topic}} {{outcome}}",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "unit": "s"}},
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 13},
+      "id": 8,
+      "title": "Kafka publish latency P50/P99",
+      "type": "timeseries",
+      "options": {"legend": {"displayMode": "table", "placement": "right"}},
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (topic, le) (rate(eveys_ocpp_kafka_publish_latency_seconds_bucket[5m])))",
+          "legendFormat": "p50 {{topic}}",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (topic, le) (rate(eveys_ocpp_kafka_publish_latency_seconds_bucket[5m])))",
+          "legendFormat": "p99 {{topic}}",
+          "refId": "B",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "unit": "ops"}},
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 22},
+      "id": 9,
+      "title": "Webhook deliveries by outcome",
+      "type": "timeseries",
+      "options": {"legend": {"displayMode": "table", "placement": "right"}},
+      "targets": [
+        {
+          "expr": "sum by (outcome) (rate(eveys_ocpp_webhook_deliveries_total[5m]))",
+          "legendFormat": "{{outcome}}",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "unit": "short"}},
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 22},
+      "id": 10,
+      "title": "Webhook attempts (retry pressure)",
+      "type": "timeseries",
+      "options": {"legend": {"displayMode": "table", "placement": "right"}},
+      "targets": [
+        {
+          "expr": "sum by (attempt) (rate(eveys_ocpp_webhook_attempts_total[5m]))",
+          "legendFormat": "attempt {{attempt}}",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["eveys", "ocpp", "transactions"],
+  "templating": {"list": []},
+  "time": {"from": "now-1h", "to": "now"},
+  "timepicker": {},
+  "timezone": "",
+  "title": "eveys/ocpp — Transactions & downstream",
+  "uid": "eveys-ocpp-tx",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/grafana/provisioning/dashboards/eveys.yml
+++ b/deploy/grafana/provisioning/dashboards/eveys.yml
@@ -1,0 +1,22 @@
+apiVersion: 1
+
+# Auto-load every dashboard JSON from `deploy/grafana/dashboards/`
+# into the "eveys/ocpp" folder. Editable by default so an operator
+# can iterate against a live system; commit-back is up to the
+# operator's workflow (export from Grafana, replace the JSON).
+providers:
+  - name: eveys-ocpp
+    orgId: 1
+    folder: "eveys/ocpp"
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      # Where the dashboard JSON files are mounted inside the Grafana
+      # container. The provider yaml itself lives under
+      # /etc/grafana/provisioning/dashboards/; the *dashboards* are
+      # mounted to a separate path so Grafana doesn't try to parse the
+      # provider yaml as a dashboard.
+      path: /var/lib/grafana/dashboards/eveys
+      foldersFromFilesStructure: false

--- a/deploy/grafana/provisioning/datasources/prometheus.yml
+++ b/deploy/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,16 @@
+apiVersion: 1
+
+# Default Prometheus datasource for the dashboards in
+# `deploy/grafana/dashboards/`. The URL points at whatever Prometheus
+# the operator has scraping the gateway's `/metrics:9100` — change to
+# match your stack. In compose-based dev a sidecar Prometheus is
+# expected at `http://prometheus:9090`; in k8s the ServiceMonitor
+# pattern handles scraping and the URL would be the cluster-internal
+# Prometheus service.
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: ${PROMETHEUS_URL:-http://prometheus:9090}
+    isDefault: true
+    editable: false


### PR DESCRIPTION
## Summary

Five JSON dashboards covering the `eveys_ocpp_*` metric surface from E4-1, plus a Prometheus datasource provisioning yaml and a dashboards provider that loads them into the **eveys/ocpp** folder.

| # | Dashboard | When to open it |
| - | --------- | --------------- |
| 01 | Fleet overview | First stop when triaging — online chargers, message rate, authorize errors, circuits |
| 02 | Per-pod | Templated `pod_id` picker — isolates one replica when fleet view shows it misbehaving |
| 03 | Per-charger context | Fleet aggregates with a callout that handler metrics are **not** labelled by `cp_id` (cardinality), so true per-charger drill-down requires logs/Postgres/CH alongside |
| 04 | Reconnect storms | Handshake failures, disconnect reasons, heartbeat reclaims, boot replays — the page-at-3am view |
| 05 | Transactions & downstream | start/stop, kafka publish, webhook delivery, consumer lag |

Pure deploy artifacts — the gateway compose stack does not run Grafana itself, so the README documents how to mount these into an external Grafana (compose volume mounts, Helm sidecar via labelled ConfigMaps).

## Why no Grafana in the compose stack

The compose stack is the **gateway**'s data plane (postgres, redis, kafka, clickhouse). Observability is intentionally external — operators bring their own Prometheus + Grafana (or Grafana Cloud, Datadog, etc.). These files are deploy artifacts they layer on.

## Test plan

- [x] All 5 JSON files parse (`python -c "import json; json.loads(...)"`)
- [x] Every metric expression references a metric that exists in the E4-1 registry (52 metrics, prefix `eveys_ocpp_`)
- [x] Per-pod templated variable uses `label_values(eveys_ocpp_build_info, pod_id)` — works even when no chargers are connected (since `build_info` is always set at boot)
- [ ] Smoke-test against a live stack: `docker compose up grafana` with the volumes mounted, dashboards appear under "eveys/ocpp" folder, panels render without "no data" once the gateway emits a sample