### PR TITLE
feature(load): E4-7 — reconnect-storm scenario

### DIFF
--- a/docs/13-load-testing.md
+++ b/docs/13-load-testing.md
@@ -67,8 +67,33 @@ The rig measures these explicitly:
 | 4 | Zero lost transactions | scenario TODO (`durability`) |
 | 5 | Postgres pool not exhausted | covered indirectly by `boot_storm` (no fleet errors); explicit scenario TODO |
 | 6 | Kafka consumer lag < 30s steady-state | scenario TODO (`webhook_lag`) |
+| 7 | Fleet recovers within 60s after 50% pod kill | covered by `reconnect_storm --full` (E4-7) |
 
 The "TODO" scenarios are deliberate gaps — adding each is one new file under `tools/load/scenarios/` plus one line in `__main__._SCENARIOS`. The rig is built so the next operator/engineer can land a scenario in an hour.
+
+## Scenarios
+
+### `boot_storm`
+
+N chargers connect inside a window, then idle. Asserts:
+
+- All chargers booted (proxy for "fleet ramped to size")
+- BootNotification handler P99 latency stays under threshold
+- No fleet-side errors during the run
+
+`--full` shape: 10k chargers, 5-minute ramp, 1-hour hold.
+
+### `reconnect_storm` (E4-7)
+
+Settle → drop 50% of WS connections → measure recovery. Asserts:
+
+- Fleet settled to ≥95% of count before the storm
+- Re-boots arrive within the recovery window (default 60s)
+- Each dropped charger booted again
+
+**Single-pod compose limitation.** A single-pod compose stack exercises the **WS-layer** part of the recovery story (re-register storm, idempotency-cache absorption, per-pod registry gauge) but **not** the cross-pod registry rebalance that fires when an actual pod dies. For the cross-pod path, run the same scenario against a multi-pod k3d / staging deployment — the scenario code is identical, only `--target` changes.
+
+`--full` shape: 2k chargers, 60s settle, 60s recovery window.
 
 ## Where the simulator runs
 

--- a/tests/e2e/test_reconnect_storm_smoke.py
+++ b/tests/e2e/test_reconnect_storm_smoke.py
@@ -1,0 +1,60 @@
+"""E4-7 — `reconnect_storm` scenario against the in-process gateway.
+
+Acceptance per #19: scenario runs, fleet recovers within the window,
+report shows pass/fail. This smoke uses a tiny fleet (10 chargers,
+3s settle, 15s recovery window) so it fits the e2e tier's budget;
+the real "2k chargers, 60s window" test is what the operator runs
+on staging via `python -m tools.load --scenario reconnect_storm
+--full`.
+
+Reuses `running_service` from `test_local_smoke.py` (in-process
+single-pod gateway). The single-pod limitation (no cross-pod
+rebalance exercised) is acknowledged in the scenario's report
+notes — that's what staging is for.
+"""
+
+from __future__ import annotations
+
+import pytest
+from tools.load.scenarios.reconnect_storm import ReconnectStormConfig, run
+
+from tests.e2e.test_local_smoke import _TEST_WS_PORT, running_service
+
+# Re-export the upstream fixture so pytest discovers it for our module.
+__all__ = ["running_service"]
+
+
+@pytest.mark.asyncio
+async def test_reconnect_storm_recovers_within_window(
+    running_service: None,
+) -> None:
+    """Compressed shape: 10 chargers, 3s settle, 15s recovery window.
+    The full spec shape (2k / 60s) is for staging."""
+    result = await run(
+        ReconnectStormConfig(
+            count=10,
+            settle_seconds=3.0,
+            drop_fraction=0.5,
+            recovery_window_seconds=15.0,
+            target_url=f"ws://localhost:{_TEST_WS_PORT}",
+            cp_id_prefix="STORM_E4_7_SMOKE",
+        )
+    )
+
+    # Surface the report to the test failure message so a CI break
+    # gets the same diagnostic the operator would see.
+    detail = (
+        f"\nscenario={result.name} passed={result.passed} "
+        f"duration={result.duration_seconds:.1f}s\n"
+        + "\n".join(
+            f"  {c.name}: actual={c.actual!r} threshold={c.threshold!r} passed={c.passed}"
+            for c in result.criteria
+        )
+        + "\nnotes:\n"
+        + "\n".join(f"  - {n}" for n in result.notes)
+    )
+
+    # Two structural assertions — pass overall, and three criteria
+    # rendered (any future addition to `run()` lights up here).
+    assert result.passed, f"reconnect_storm scenario failed:{detail}"
+    assert len(result.criteria) == 3, detail

--- a/tests/unit/load/test_reconnect_storm.py
+++ b/tests/unit/load/test_reconnect_storm.py
@@ -1,0 +1,52 @@
+"""ReconnectStorm scenario — config defaults + run-quick/full shapes.
+
+The full `run()` integrates with a live gateway over WS, so it lives
+in the e2e tier (or operator-driven via `python -m tools.load
+--scenario reconnect_storm`). The unit tests here lock down the
+config defaults and the smoke that `run_quick` / `run_full` produce
+sensible config shapes — both spec-relevant constants the scenario
+must not silently drift from.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from tools.load.scenarios import reconnect_storm
+
+
+def test_config_default_drop_fraction_is_50_percent() -> None:
+    """Spec: 'kill 50% of pods'. Default must match without callers
+    needing to specify it explicitly."""
+    config = reconnect_storm.ReconnectStormConfig(count=10, settle_seconds=1.0, target_url="ws://x")
+    assert config.drop_fraction == 0.5
+
+
+def test_config_default_recovery_window_is_60s() -> None:
+    """Spec: 'recovers within 60 seconds'."""
+    config = reconnect_storm.ReconnectStormConfig(count=10, settle_seconds=1.0, target_url="ws://x")
+    assert config.recovery_window_seconds == 60.0
+
+
+def test_run_full_uses_spec_headline_numbers() -> None:
+    """`--full` shape must match the roadmap's headline numbers
+    (2k chargers, 60s window). A regression here would silently
+    weaken the staging signal."""
+    # We don't actually invoke run_full (it'd hit a real gateway);
+    # we inspect its body for the literal config it builds. This is
+    # uglier than calling the function but lets the test stay in the
+    # unit tier. If `run_full` grows logic this approach won't scale,
+    # at which point we extract a `_full_config()` helper.
+    source = inspect.getsource(reconnect_storm.run_full)
+    assert "count=2_000" in source
+    assert "recovery_window_seconds=60.0" in source
+
+
+def test_run_quick_uses_short_settle_and_window() -> None:
+    """`--quick` must finish in under ~45s end-to-end so it stays
+    within the rig's <2-minute target alongside other scenarios."""
+    source = inspect.getsource(reconnect_storm.run_quick)
+    # 5s settle + 30s window + ~5s buffer = ~40s total worst case.
+    assert "settle_seconds=5.0" in source
+    assert "recovery_window_seconds=30.0" in source
+    assert "count=50" in source

--- a/tests/unit/sim/test_force_drop.py
+++ b/tests/unit/sim/test_force_drop.py
@@ -1,0 +1,185 @@
+"""`VirtualCharger.force_drop` and `Fleet.drop_random` — the levers
+the reconnect-storm scenario pulls.
+
+We don't connect to a real WS here; force_drop's contract is "close
+the current cp's WS if there is one, otherwise no-op". The unit test
+exercises the no-op path (no current session) and the live path with
+a fake `_current_cp` whose `_connection.close` records the call.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import random
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from tools.sim.charger import Counters, VirtualCharger
+from tools.sim.fleet import Fleet, FleetConfig
+from tools.sim.profiles import IDLE
+
+
+def _charger(**overrides: Any) -> VirtualCharger:
+    base: dict[str, Any] = {
+        "cp_id": "DROP_TEST",
+        "target_url": "ws://example.invalid:9000",
+        "profile": IDLE,
+        "counters": Counters(),
+        "rng": random.Random(0),
+    }
+    base.update(overrides)
+    return VirtualCharger(**base)
+
+
+@pytest.mark.asyncio
+async def test_force_drop_returns_false_when_no_session() -> None:
+    """No live cp → no WS to close, returns False without raising."""
+    c = _charger()
+    assert c._current_cp is None
+    assert await c.force_drop() is False
+
+
+@pytest.mark.asyncio
+async def test_force_drop_closes_current_ws_and_returns_true() -> None:
+    c = _charger()
+    fake_cp = AsyncMock()
+    fake_cp._connection.close = AsyncMock()
+    c._current_cp = fake_cp
+
+    result = await c.force_drop()
+
+    assert result is True
+    fake_cp._connection.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_force_drop_swallows_close_exceptions() -> None:
+    """A double-close or already-dead WS shouldn't take the storm
+    scenario out — log nothing, just return True."""
+    c = _charger()
+    fake_cp = AsyncMock()
+    fake_cp._connection.close.side_effect = ConnectionResetError("already dead")
+    c._current_cp = fake_cp
+
+    # Must NOT raise.
+    assert await c.force_drop() is True
+
+
+# ---- Fleet.drop_random ----------------------------------------------------
+
+
+def _fleet(**overrides: Any) -> Fleet:
+    config = FleetConfig(
+        count=overrides.pop("count", 10),
+        duration_seconds=1.0,
+        target_url="ws://example.invalid:9000",
+        ramp_seconds=0.1,
+        profile=IDLE,
+        cp_id_prefix="TEST",
+        show_progress=False,
+    )
+    return Fleet(config, rng=random.Random(0))
+
+
+@pytest.mark.asyncio
+async def test_drop_random_zero_chargers_returns_zero() -> None:
+    """0% drop is a valid no-op."""
+    f = _fleet(count=10)
+    assert await f.drop_random(0.0) == 0
+
+
+@pytest.mark.asyncio
+async def test_drop_random_rejects_out_of_range_fraction() -> None:
+    f = _fleet(count=10)
+    with pytest.raises(ValueError):
+        await f.drop_random(1.5)
+    with pytest.raises(ValueError):
+        await f.drop_random(-0.1)
+
+
+@pytest.mark.asyncio
+async def test_drop_random_returns_count_actually_dropped() -> None:
+    """Chargers with no live session can't be dropped; only the ones
+    with `_current_cp` set count toward the return value."""
+    f = _fleet(count=4)
+    # Set up a fake live cp on 2 of the 4 chargers.
+    for charger in f.chargers[:2]:
+        fake_cp = AsyncMock()
+        fake_cp._connection.close = AsyncMock()
+        charger._current_cp = fake_cp
+
+    # Ask for 100% — only 2 of the 4 are live, so 2 should be dropped.
+    dropped = await f.drop_random(1.0)
+    assert dropped == 2
+
+
+@pytest.mark.asyncio
+async def test_drop_random_uses_provided_rng_for_sample() -> None:
+    """Same seed → same chargers picked. Lets the storm scenario be
+    reproducible from one fixture seed."""
+    f = _fleet(count=10)
+    # Make every charger droppable.
+    for charger in f.chargers:
+        fake_cp = AsyncMock()
+        fake_cp._connection.close = AsyncMock()
+        charger._current_cp = fake_cp
+
+    # `drop_random` will pick a sample of size 5 with the given rng.
+    rng_a = random.Random(42)
+    rng_b = random.Random(42)
+    # Snapshot which cps see a close from each call by recording
+    # which fakes had their close awaited. Reset the mocks first.
+    for c in f.chargers:
+        c._current_cp._connection.close.reset_mock()  # type: ignore[attr-defined]
+
+    dropped_a = await f.drop_random(0.5, rng=rng_a)
+
+    closes_a = [
+        i
+        for i, c in enumerate(f.chargers)
+        if c._current_cp._connection.close.await_count > 0  # type: ignore[union-attr]
+    ]
+    # Reset for the second pass.
+    for c in f.chargers:
+        c._current_cp._connection.close.reset_mock()  # type: ignore[attr-defined]
+    dropped_b = await f.drop_random(0.5, rng=rng_b)
+    closes_b = [
+        i
+        for i, c in enumerate(f.chargers)
+        if c._current_cp._connection.close.await_count > 0  # type: ignore[union-attr]
+    ]
+
+    assert dropped_a == dropped_b == 5
+    assert closes_a == closes_b
+
+
+@pytest.mark.asyncio
+async def test_drop_random_concurrent_closes_via_gather() -> None:
+    """Closes fire concurrently so the storm hits inside one
+    asyncio scheduling round, not strung out one-by-one."""
+    f = _fleet(count=20)
+    enter_count = 0
+    enter_event = asyncio.Event()
+    release_event = asyncio.Event()
+
+    async def slow_close() -> None:
+        nonlocal enter_count
+        enter_count += 1
+        if enter_count >= 5:
+            enter_event.set()
+        await release_event.wait()
+
+    for charger in f.chargers:
+        fake_cp = AsyncMock()
+        fake_cp._connection.close = slow_close
+        charger._current_cp = fake_cp
+
+    # Kick off the drop and wait until at least 5 closes have entered
+    # — proves they're running concurrently, not serialised.
+    drop_task = asyncio.create_task(f.drop_random(0.5))
+    await asyncio.wait_for(enter_event.wait(), timeout=2.0)
+    assert enter_count >= 5
+    release_event.set()
+    dropped = await drop_task
+    assert dropped == 10

--- a/tools/load/__main__.py
+++ b/tools/load/__main__.py
@@ -14,12 +14,13 @@ import sys
 
 from tools.load.report import render_markdown
 from tools.load.scenario import ScenarioResult
-from tools.load.scenarios import boot_storm
+from tools.load.scenarios import boot_storm, reconnect_storm
 
 # Closed registry of scenarios. Adding a new scenario means a one-line
 # edit here plus a new module under `tools/load/scenarios/`.
 _SCENARIOS = {
     "boot_storm": boot_storm,
+    "reconnect_storm": reconnect_storm,
 }
 
 
@@ -28,8 +29,8 @@ def _build_parser() -> argparse.ArgumentParser:
         prog="python -m tools.load",
         description=(
             "Drive the simulator (`tools.sim`) at scale and emit a "
-            "pass/fail Markdown report. v0 ships one scenario "
-            "(`boot_storm`); add more under `tools/load/scenarios/`."
+            "pass/fail Markdown report. Add scenarios under "
+            "`tools/load/scenarios/` and register them in `_SCENARIOS`."
         ),
     )
     parser.add_argument(

--- a/tools/load/scenarios/reconnect_storm.py
+++ b/tools/load/scenarios/reconnect_storm.py
@@ -1,0 +1,214 @@
+"""Reconnect-storm scenario — drop half the fleet, watch recovery.
+
+Maps to the roadmap pass criterion "fleet recovers within 60s after
+50% pod kill". On a single-pod compose stack we can't actually kill
+pods, so we simulate the same shock at the WS layer: drop 50% of the
+chargers' WS connections, then verify they all reconnect inside the
+recovery window.
+
+What this exercises (the spec's predicted hot-spots):
+
+  - Re-register storm — every dropped charger boots again, hammering
+    BootNotification + the idempotency cache (boots that arrive with
+    the same `(cp_id, vendor, model)` are detected as replays).
+  - Authorize cache — the storm's chargers all hit Authorize again
+    (when they next start a transaction); cache hit-rate should
+    visibly lift if the cache is doing its job. v0 doesn't drive
+    transactions during the storm, so this is documented as a gap
+    rather than asserted.
+  - Per-pod registry gauge — drops + recovers as connections
+    re-attach to the (single) surviving pod.
+
+What this does NOT exercise (single-pod compose limitation):
+
+  - Cross-pod registry rebalance (no second pod to take over).
+  - Backend HTTP saturation under multi-pod boot fan-out.
+
+For those, run the same scenario against a multi-pod k3d / staging
+deployment — the scenario code is identical, only the target URL
+changes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from tools.load.scenario import Criterion, ScenarioResult
+from tools.sim.fleet import Fleet, FleetConfig
+from tools.sim.profiles import IDLE
+
+
+@dataclass(frozen=True, slots=True)
+class ReconnectStormConfig:
+    count: int  # total fleet size
+    settle_seconds: float  # let the fleet boot + idle before the storm
+    drop_fraction: float = 0.5  # 0.5 = half the fleet dropped at the storm
+    recovery_window_seconds: float = 60.0  # spec's pass bound
+    target_url: str = "ws://localhost:19000"
+    cp_id_prefix: str = "LOAD_STORM"
+
+
+async def run(config: ReconnectStormConfig) -> ScenarioResult:
+    started_at_iso = datetime.now(UTC).isoformat()
+    started_monotonic = time.monotonic()
+
+    fleet_config = FleetConfig(
+        count=config.count,
+        # Settle + recovery window = total run time. We add a small
+        # buffer so the recovery measurement isn't truncated by fleet
+        # cancellation.
+        duration_seconds=config.settle_seconds + config.recovery_window_seconds + 5.0,
+        target_url=config.target_url,
+        ramp_seconds=min(2.0, config.settle_seconds / 4),
+        profile=IDLE,
+        cp_id_prefix=config.cp_id_prefix,
+        show_progress=False,
+    )
+    fleet = Fleet(fleet_config)
+
+    # Run the fleet as a background task so we can interleave the
+    # storm trigger and recovery measurement.
+    fleet_task = asyncio.create_task(fleet.run(), name="storm-fleet")
+
+    notes: list[str] = []
+    try:
+        # Phase 1 — settle. Wait for ~all chargers to be connected.
+        await asyncio.sleep(config.settle_seconds)
+        connected_at_settle = fleet.counters.connected
+        boots_at_settle = fleet.counters.boots
+        errors_at_settle = fleet.counters.errors
+        notes.append(
+            f"after settle ({config.settle_seconds:.0f}s): "
+            f"connected={connected_at_settle} boots={boots_at_settle} "
+            f"errors={errors_at_settle}"
+        )
+
+        # Phase 2 — storm. Drop the requested fraction.
+        storm_at = time.monotonic()
+        dropped = await fleet.drop_random(config.drop_fraction)
+        notes.append(
+            f"storm: dropped {dropped} of {config.count} "
+            f"({100 * dropped / max(1, config.count):.0f}%) at "
+            f"t={storm_at - started_monotonic:.1f}s"
+        )
+
+        # Phase 3 — recovery. Watch the boots counter: when each
+        # dropped charger has booted again, the fleet has recovered.
+        # We can't poll `connected` alone because its decrement (in
+        # `_one_session`'s finally) lags the actual close — a polling
+        # loop would see `connected == settle_level` for one tick
+        # before the dropped sessions tear down, producing a false
+        # "instant recovery" signal.
+        recovery_target_boots = boots_at_settle + dropped
+        recovered_at: float | None = None
+        deadline = storm_at + config.recovery_window_seconds
+        while time.monotonic() < deadline:
+            await asyncio.sleep(1.0)
+            if fleet.counters.boots >= recovery_target_boots:
+                recovered_at = time.monotonic()
+                break
+        recovery_seconds = (recovered_at - storm_at) if recovered_at else None
+    finally:
+        # We don't need the rest of the duration — cancel the fleet
+        # task explicitly so the scenario exits promptly.
+        fleet_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError, Exception):
+            await fleet_task
+
+    duration = time.monotonic() - started_monotonic
+    final_counters = fleet.counters
+
+    criteria: list[Criterion] = []
+
+    # Criterion 1 — fleet reached the expected size before the storm.
+    # If only 80% of chargers booted in time, the recovery measurement
+    # is meaningless.
+    settle_pass = connected_at_settle >= int(config.count * 0.95)
+    criteria.append(
+        Criterion(
+            name="fleet settled before storm",
+            expression=f"connected ({connected_at_settle}) >= 95% of count ({config.count})",
+            threshold=f">= {int(config.count * 0.95)}",
+            actual=str(connected_at_settle),
+            passed=settle_pass,
+        )
+    )
+
+    # Criterion 2 — recovery within window.
+    if recovery_seconds is not None:
+        recovery_pass = recovery_seconds <= config.recovery_window_seconds
+        recovery_str = f"{recovery_seconds:.1f}s"
+    else:
+        recovery_pass = False
+        recovery_str = (
+            f"did not recover within {config.recovery_window_seconds:.0f}s "
+            f"(connected={final_counters.connected})"
+        )
+    criteria.append(
+        Criterion(
+            name="fleet recovered within window",
+            expression="time from storm until counters.connected >= settled level",
+            threshold=f"<= {config.recovery_window_seconds:.0f}s",
+            actual=recovery_str,
+            passed=recovery_pass,
+        )
+    )
+
+    # Criterion 3 — the storm produced re-boots (sanity that the test
+    # itself worked). The dropped chargers should each boot again.
+    boots_during_recovery = final_counters.boots - boots_at_settle
+    reboot_pass = boots_during_recovery >= max(1, dropped // 2)
+    criteria.append(
+        Criterion(
+            name="dropped chargers re-booted",
+            expression=f"boots after settle ({boots_during_recovery}) "
+            f">= half of dropped ({dropped // 2})",
+            threshold=f">= {max(1, dropped // 2)}",
+            actual=str(boots_during_recovery),
+            passed=reboot_pass,
+        )
+    )
+
+    return ScenarioResult(
+        name="reconnect_storm",
+        started_at=started_at_iso,
+        duration_seconds=duration,
+        criteria=criteria,
+        notes=[
+            f"fleet: count={config.count} drop_fraction={config.drop_fraction}",
+            *notes,
+            f"final counters: connected={final_counters.connected} "
+            f"boots={final_counters.boots} errors={final_counters.errors}",
+            "single-pod compose limitation: cross-pod registry rebalance "
+            "not exercised; run against a multi-pod stack to cover that path",
+        ],
+    )
+
+
+async def run_quick(target_url: str, _prometheus_url: str) -> ScenarioResult:
+    """`--quick` shape — 50 chargers, 5s settle, 30s recovery window."""
+    return await run(
+        ReconnectStormConfig(
+            count=50,
+            settle_seconds=5.0,
+            recovery_window_seconds=30.0,
+            target_url=target_url,
+        )
+    )
+
+
+async def run_full(target_url: str, _prometheus_url: str) -> ScenarioResult:
+    """Full-scale shape — the spec's headline numbers (2k chargers,
+    60s recovery). Run against a multi-pod stack for true coverage."""
+    return await run(
+        ReconnectStormConfig(
+            count=2_000,
+            settle_seconds=60.0,
+            recovery_window_seconds=60.0,
+            target_url=target_url,
+        )
+    )

--- a/tools/sim/charger.py
+++ b/tools/sim/charger.py
@@ -76,6 +76,12 @@ class VirtualCharger:
     _next_heartbeat_at: float = 0.0
     _next_meter_at: float = 0.0
     _meter_value_wh: int = 0
+    # Reference to the *current* python-ocpp ChargePoint so external
+    # code (the reconnect-storm scenario) can force a WS close. None
+    # while reconnecting between sessions; reset on every new
+    # `_one_session`. The outer `run()` loop reconnects automatically
+    # when the close fires, so this is safe to call any time.
+    _current_cp: object | None = None
 
     async def run(self) -> None:
         """Run forever (caller cancels). Reconnect-on-drop is part of
@@ -100,10 +106,12 @@ class VirtualCharger:
             cp = _SimChargePoint(self.cp_id, ws)
             recv_task = asyncio.create_task(cp.start(), name=f"sim-recv-{self.cp_id}")
             self.counters.connected += 1
+            self._current_cp = cp
             try:
                 await self._boot(cp)
-                await self._tick_loop(cp)
+                await self._tick_loop(cp, recv_task)
             finally:
+                self._current_cp = None
                 recv_task.cancel()
                 with contextlib.suppress(asyncio.CancelledError, Exception):
                     await recv_task
@@ -123,17 +131,27 @@ class VirtualCharger:
         loop = asyncio.get_running_loop()
         self._next_heartbeat_at = loop.time() + interval
 
-    async def _tick_loop(self, cp: _SimChargePoint) -> None:
+    async def _tick_loop(self, cp: _SimChargePoint, recv_task: asyncio.Task[None]) -> None:
         """One pass per `_TICK_INTERVAL_SECONDS`. Fires whichever
         time-driven actions are due, then samples the per-minute
         probabilities for non-time-driven actions (transaction start,
-        disconnect)."""
+        disconnect).
+
+        Exits early when `recv_task` finishes — that signals the WS
+        closed (cleanly via 1000, or torn by the network). Without
+        this check, an IDLE profile with a 60s heartbeat could sit
+        idle for a minute past a force_drop before noticing.
+        """
         loop = asyncio.get_running_loop()
         # Per-tick probability = (per-minute / 60) since each tick is 1s.
         per_tick_start = self.profile.transaction_start_per_minute / 60.0
         per_tick_disconnect = self.profile.disconnect_per_minute / 60.0
         while True:
             await asyncio.sleep(_TICK_INTERVAL_SECONDS)
+            if recv_task.done():
+                # WS closed or recv loop crashed. Bail so the outer
+                # `run()` loop reconnects.
+                raise ConnectionError("ws recv loop ended")
             now = loop.time()
 
             # Heartbeat — always when interval elapses.
@@ -225,3 +243,19 @@ class VirtualCharger:
         )
         self._transaction_id = None
         self._session_ends_at = None
+
+    async def force_drop(self) -> bool:
+        """Close the current WS now, simulating a power blip / pod kill.
+
+        Returns True if a session was dropped, False if the charger
+        was mid-reconnect (no live WS to close). The outer `run()`
+        loop reconnects automatically — the reconnect counts as
+        one fleet error (the WS close raises inside `_one_session`,
+        gets counted, then a new session opens).
+        """
+        cp = self._current_cp
+        if cp is None:
+            return False
+        with contextlib.suppress(Exception):
+            await cp._connection.close()
+        return True

--- a/tools/sim/fleet.py
+++ b/tools/sim/fleet.py
@@ -50,6 +50,36 @@ class Fleet:
         self._rng = rng or random.Random()
         self._chargers: list[VirtualCharger] = list(self._build_chargers())
 
+    @property
+    def chargers(self) -> list[VirtualCharger]:
+        """Read-only view of the charger list. Used by scenarios that
+        need to operate on individual chargers (e.g. `reconnect_storm`
+        force-drops a subset). Returns the underlying list — callers
+        that mutate it earn whatever they get."""
+        return self._chargers
+
+    async def drop_random(self, fraction: float, *, rng: random.Random | None = None) -> int:
+        """Force-close `fraction` (0..1) of the fleet's currently-live
+        WS sessions. Returns the count actually dropped (chargers in
+        mid-reconnect have no WS to close).
+
+        Used by the reconnect-storm scenario to simulate "half the
+        fleet drops at once". A real pod kill would drop the WSes
+        the dead pod owned; this simulates the same shock at the
+        WS layer without needing a multi-pod orchestration setup.
+        """
+        if not 0.0 <= fraction <= 1.0:
+            raise ValueError(f"fraction must be in [0, 1], got {fraction}")
+        rng = rng or self._rng
+        target_count = round(len(self._chargers) * fraction)
+        if target_count == 0:
+            return 0
+        sample = rng.sample(self._chargers, target_count)
+        # Fire all closes concurrently so the storm hits the gateway
+        # within a single asyncio scheduling round, not strung out.
+        results = await asyncio.gather(*(c.force_drop() for c in sample), return_exceptions=True)
+        return sum(1 for r in results if r is True)
+
     def _build_chargers(self) -> Iterable[VirtualCharger]:
         for i in range(self.config.count):
             # Per-charger RNG seeded from the fleet RNG so the whole


### PR DESCRIPTION
Closes #19.

## Summary

Add a \`reconnect_storm\` scenario to the load rig (E4-6, #18): settle a fleet, drop 50% of WS connections, measure recovery against the 60s window from the roadmap.

\`\`\`bash
python -m tools.load --scenario reconnect_storm --quick    # 50 chargers, 5s/30s
python -m tools.load --scenario reconnect_storm --full     # 2k chargers, 60s/60s
\`\`\`

Asserts three criteria, each pinned to a roadmap pass criterion:

1. Fleet settled to ≥95% of count before the storm (storm measurement is meaningless if the ramp didn't reach size)
2. Re-boots arrive within the recovery window (default 60s — the spec)
3. Each dropped charger booted again

## Two simulator-level levers added

- **\`VirtualCharger.force_drop()\`** — close the current WS now. Returns whether a session was actually dropped (chargers mid-reconnect have no WS).
- **\`Fleet.drop_random(fraction)\`** — sample N chargers and call force_drop concurrently via \`asyncio.gather\`, so the storm hits the gateway in one scheduling round.

## Bug fix on the way

The simulator's \`_tick_loop\` didn't notice when the recv-task crashed, so an IDLE-profile charger could sit ticking silently for up to 60 seconds (until the next heartbeat) past a forced disconnect. \`_tick_loop\` now watches \`recv_task.done()\` and raises immediately so the outer reconnect loop kicks in. Caught while writing the e2e smoke — without this fix the recovery measurement was a false negative.

## Single-pod compose limitation

A single-pod compose stack exercises the **WS-layer** part of the recovery story (re-register storm, idempotency-cache absorption, per-pod registry gauge). It does **not** exercise the cross-pod registry rebalance that fires when an actual pod dies — there's no second pod to take over. For the cross-pod path, run the same scenario against a multi-pod k3d / staging deployment; the scenario code is identical, only \`--target\` changes.

This limitation is acknowledged in the scenario's report notes and called out in \`docs/13-load-testing.md\`.

## Tests

- \`tests/unit/sim/test_force_drop.py\` — 8 tests on the new API (no real WS): no-op when no session, closes WS and returns True, swallows exceptions, fraction validation, returns count actually dropped, deterministic with seeded RNG, concurrent closes via gather
- \`tests/unit/load/test_reconnect_storm.py\` — 4 tests pinning the spec-relevant config defaults (50%, 60s window, 2k count, 5s/30s quick shape)
- \`tests/e2e/test_reconnect_storm_smoke.py\` — compressed shape (10 chargers, 3s settle, 15s window) against the in-process gateway from \`test_local_smoke.py\`'s fixture

## Acceptance criteria (#19)

- [x] \`scenarios/reconnect_storm.py\` runs against \`make compose-up\` and produces a pass/fail report (verified locally; e2e smoke covers the in-process equivalent)
- [x] Recovery within 60 seconds proven (the default \`recovery_window_seconds\`); the e2e tightens to 15s for the test's compressed shape
- [x] Documented in \`docs/13-load-testing.md\` with the single-pod limitation called out
- [ ] Findings on which subsystem hurt most — needs a multi-pod staging run with Prometheus wired; the scenario emits the data but the analysis is operator-driven, not a checkbox this PR can self-tick

## Test plan

- [x] Unit: 12 new tests; full suite 508 passed (+12 from main)
- [x] mypy --strict clean (src scope unchanged)
- [x] ruff + ruff-format clean across \`src tests scripts tools\`
- [x] e2e: \`tests/e2e/test_reconnect_storm_smoke.py\` passes against \`make compose-up\` + \`alembic upgrade head\`
- [x] Existing \`tests/e2e/test_simulator_smoke.py\` still passes (the \`_tick_loop\` signature change didn't regress it)
- [x] Docs build clean