### PR TITLE
feature(slo): E4-8 — five SLO definitions, recording rules, dashboard

### DIFF
--- a/deploy/grafana/dashboards/06-slos.json
+++ b/deploy/grafana/dashboards/06-slos.json
@@ -1,0 +1,353 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {"type": "grafana", "uid": "-- Grafana --"},
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "SLO compliance per `docs/14-slos.md`. Each panel pairs the long-window SLI (the headline number — what we promise) with a fast 5-minute series so operators can spot a regression before the 7d / 30d window catches up.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [
+    {"title": "Fleet overview", "type": "link", "url": "/d/eveys-ocpp-fleet", "targetBlank": false},
+    {"title": "SLO catalog", "type": "link", "url": "../docs/14-slos.md", "targetBlank": true}
+  ],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "type": "text",
+      "gridPos": {"h": 3, "w": 24, "x": 0, "y": 0},
+      "id": 100,
+      "options": {
+        "mode": "markdown",
+        "content": "**SLO compliance** — see [`docs/14-slos.md`](../docs/14-slos.md) for SLI definitions, targets, windows, and consequences. Each row pairs the headline (long-window) value with a `5m` short-window proxy so operators see regressions early. The error-budget column is `100% - target` minus current consumption."
+      }
+    },
+
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "unit": "percentunit",
+          "min": 0.95,
+          "max": 1.0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "red", "value": null},
+              {"color": "yellow", "value": 0.99},
+              {"color": "green", "value": 0.995}
+            ]
+          }
+        }
+      },
+      "gridPos": {"h": 5, "w": 12, "x": 0, "y": 3},
+      "id": 1,
+      "options": {
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "value_and_name"
+      },
+      "title": "SLO 1 — Charger connection availability (30d, target ≥ 99.5%)",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "slo:boot_acceptance:ratio_30d",
+          "legendFormat": "30d",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        },
+        {
+          "expr": "slo:boot_acceptance:ratio_5m",
+          "legendFormat": "5m",
+          "refId": "B",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "unit": "percentunit", "min": 0.95, "max": 1.0}
+      },
+      "gridPos": {"h": 5, "w": 12, "x": 12, "y": 3},
+      "id": 2,
+      "title": "SLO 1 trend (5m series)",
+      "type": "timeseries",
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}},
+      "targets": [
+        {
+          "expr": "slo:boot_acceptance:ratio_5m",
+          "legendFormat": "boot acceptance",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        },
+        {
+          "expr": "0.995",
+          "legendFormat": "target",
+          "refId": "B",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 0.4},
+              {"color": "red", "value": 0.5}
+            ]
+          }
+        }
+      },
+      "gridPos": {"h": 5, "w": 12, "x": 0, "y": 8},
+      "id": 3,
+      "options": {
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "value_and_name"
+      },
+      "title": "SLO 2 — Authorize P95 latency (7d, target ≤ 500ms)",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "slo:authorize_latency:p95_7d",
+          "legendFormat": "7d",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        },
+        {
+          "expr": "slo:authorize_latency:p95_5m",
+          "legendFormat": "5m",
+          "refId": "B",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "unit": "s"}},
+      "gridPos": {"h": 5, "w": 12, "x": 12, "y": 8},
+      "id": 4,
+      "title": "SLO 2 trend (5m P95)",
+      "type": "timeseries",
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}},
+      "targets": [
+        {
+          "expr": "slo:authorize_latency:p95_5m",
+          "legendFormat": "authorize P95",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        },
+        {
+          "expr": "0.5",
+          "legendFormat": "target",
+          "refId": "B",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 2.5},
+              {"color": "red", "value": 3.0}
+            ]
+          }
+        }
+      },
+      "gridPos": {"h": 5, "w": 12, "x": 0, "y": 13},
+      "id": 5,
+      "options": {
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "value_and_name"
+      },
+      "title": "SLO 3 — RemoteStart end-to-end P95 (7d, target ≤ 3s)",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "slo:remote_start_latency:p95_7d",
+          "legendFormat": "7d",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        },
+        {
+          "expr": "slo:remote_start_latency:p95_5m",
+          "legendFormat": "5m",
+          "refId": "B",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "unit": "s"}},
+      "gridPos": {"h": 5, "w": 12, "x": 12, "y": 13},
+      "id": 6,
+      "title": "SLO 3 trend (5m P95)",
+      "type": "timeseries",
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}},
+      "targets": [
+        {
+          "expr": "slo:remote_start_latency:p95_5m",
+          "legendFormat": "RemoteStart P95",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        },
+        {
+          "expr": "3.0",
+          "legendFormat": "target",
+          "refId": "B",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "unit": "percentunit",
+          "min": 0.99,
+          "max": 1.0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "red", "value": null},
+              {"color": "yellow", "value": 0.999},
+              {"color": "green", "value": 1.0}
+            ]
+          }
+        }
+      },
+      "gridPos": {"h": 5, "w": 24, "x": 0, "y": 18},
+      "id": 7,
+      "options": {
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "value_and_name"
+      },
+      "title": "SLO 4 — Transaction durability (30d, target = 100%)",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "slo:transaction_durability:ratio_30d",
+          "legendFormat": "30d",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "unit": "percentunit",
+          "min": 0.95,
+          "max": 1.0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "red", "value": null},
+              {"color": "yellow", "value": 0.98},
+              {"color": "green", "value": 0.99}
+            ]
+          }
+        }
+      },
+      "gridPos": {"h": 5, "w": 12, "x": 0, "y": 23},
+      "id": 8,
+      "options": {
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "value_and_name"
+      },
+      "title": "SLO 5 — Webhook delivery success (7d, target ≥ 99%)",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "slo:webhook_delivery:ratio_7d",
+          "legendFormat": "7d",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        },
+        {
+          "expr": "slo:webhook_delivery:ratio_5m",
+          "legendFormat": "5m",
+          "refId": "B",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "unit": "percentunit", "min": 0.95, "max": 1.0}},
+      "gridPos": {"h": 5, "w": 12, "x": 12, "y": 23},
+      "id": 9,
+      "title": "SLO 5 trend (5m series)",
+      "type": "timeseries",
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}},
+      "targets": [
+        {
+          "expr": "slo:webhook_delivery:ratio_5m",
+          "legendFormat": "delivery success",
+          "refId": "A",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        },
+        {
+          "expr": "0.99",
+          "legendFormat": "target",
+          "refId": "B",
+          "datasource": {"type": "prometheus", "uid": "prometheus"}
+        }
+      ]
+    },
+
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "type": "text",
+      "gridPos": {"h": 6, "w": 24, "x": 0, "y": 28},
+      "id": 200,
+      "title": "Error-budget reference",
+      "options": {
+        "mode": "markdown",
+        "content": "Per [docs/14-slos.md](../docs/14-slos.md), error budgets are derived as `1 - target`:\n\n| SLO | Target | Error budget (window) |\n| --- | --- | --- |\n| 1 — Boot acceptance | ≥ 99.5% | 0.5% — ~3.6 hours of refused boots per 30d |\n| 2 — Authorize latency | ≤ 500ms (P95) | 5% of authorizes may exceed 500ms |\n| 3 — RemoteStart e2e | ≤ 3s (P95) | 5% of RemoteStarts may exceed 3s |\n| 4 — Transaction durability | = 100% | 0% — zero-tolerance; any miss is a billing incident |\n| 5 — Webhook delivery | ≥ 99% | 1% — the dispatcher's retries should absorb most transient hiccups |\n\nAlerting on SLO breach is intentionally **not** wired here — that's an operations task that depends on Alertmanager + paging integration, deferred until on-call is staffed (Phase 7)."
+      }
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["eveys", "ocpp", "slo"],
+  "templating": {"list": []},
+  "time": {"from": "now-7d", "to": "now"},
+  "timepicker": {},
+  "timezone": "",
+  "title": "eveys/ocpp — SLOs",
+  "uid": "eveys-ocpp-slos",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/prometheus/rules.yml
+++ b/deploy/prometheus/rules.yml
@@ -1,0 +1,107 @@
+groups:
+  - name: eveys_ocpp_slos
+    interval: 30s
+    rules:
+      # SLO 1 — Charger connection availability.
+      # SLI: fraction of BootNotifications the gateway accepted.
+      # Window: 30 days. Target: >= 99.5%.
+      - record: slo:boot_acceptance:ratio_30d
+        expr: |
+          sum(rate(eveys_ocpp_boot_notifications_total{decision="Accepted"}[30d]))
+          /
+          clamp_min(sum(rate(eveys_ocpp_boot_notifications_total[30d])), 1)
+      - record: slo:boot_acceptance:ratio_5m
+        # Faster-moving short-window proxy for the dashboard's "current"
+        # column. Doesn't drive the SLO directly — the 30d series does —
+        # but lets operators see if a regression is brewing without
+        # waiting a month for the headline number to dip.
+        expr: |
+          sum(rate(eveys_ocpp_boot_notifications_total{decision="Accepted"}[5m]))
+          /
+          clamp_min(sum(rate(eveys_ocpp_boot_notifications_total[5m])), 1)
+
+      # SLO 2 — Authorize latency.
+      # SLI: P95 of backend `authorize` HTTP latency over 7 days.
+      # Target: <= 500ms.
+      - record: slo:authorize_latency:p95_7d
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum by (le) (
+              rate(eveys_ocpp_backend_request_latency_seconds_bucket{endpoint="authorize"}[7d])
+            )
+          )
+      - record: slo:authorize_latency:p95_5m
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum by (le) (
+              rate(eveys_ocpp_backend_request_latency_seconds_bucket{endpoint="authorize"}[5m])
+            )
+          )
+
+      # SLO 3 — RemoteStart end-to-end latency.
+      # SLI: P95 of gRPC RemoteStart latency over 7 days. Target: <= 3s.
+      # The histogram already includes the OCPP CALL round-trip to the
+      # charger (per registry.py:258), so this measures the user-visible
+      # "tap RemoteStart, see charger respond" timeline.
+      - record: slo:remote_start_latency:p95_7d
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum by (le) (
+              rate(eveys_ocpp_grpc_request_latency_seconds_bucket{rpc="RemoteStart"}[7d])
+            )
+          )
+      - record: slo:remote_start_latency:p95_5m
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum by (le) (
+              rate(eveys_ocpp_grpc_request_latency_seconds_bucket{rpc="RemoteStart"}[5m])
+            )
+          )
+
+      # SLO 4 — Transaction durability.
+      # SLI: fraction of StopTransactions that landed in Postgres.
+      # Target: 100% (any miss is a billing incident).
+      #
+      # Caveat: we don't currently emit a separate "received but not
+      # persisted" counter — `eveys_ocpp_stop_transactions_total` is
+      # incremented after the handler's DB commit, so a stop that
+      # fails to persist gets counted in `eveys_ocpp_handler_errors_total
+      # {action="StopTransaction"}` instead. The SLI sums both as the
+      # denominator and only the persisted total as the numerator. If a
+      # future task adds a dedicated `received` counter, switch the
+      # denominator to that — see docs/14-slos.md.
+      - record: slo:transaction_durability:ratio_30d
+        expr: |
+          sum(rate(eveys_ocpp_stop_transactions_total[30d]))
+          /
+          clamp_min(
+            sum(rate(eveys_ocpp_stop_transactions_total[30d]))
+            +
+            sum(rate(eveys_ocpp_handler_errors_total{action="StopTransaction"}[30d])),
+            1
+          )
+
+      # SLO 5 — Webhook delivery success.
+      # SLI: fraction of webhook envelopes successfully delivered,
+      # *excluding* `rejected` (4xx — the backend's bug, not ours).
+      # Target: >= 99% over 7 days.
+      - record: slo:webhook_delivery:ratio_7d
+        expr: |
+          sum(rate(eveys_ocpp_webhook_deliveries_total{outcome="delivered"}[7d]))
+          /
+          clamp_min(
+            sum(rate(eveys_ocpp_webhook_deliveries_total{outcome=~"delivered|failed"}[7d])),
+            1
+          )
+      - record: slo:webhook_delivery:ratio_5m
+        expr: |
+          sum(rate(eveys_ocpp_webhook_deliveries_total{outcome="delivered"}[5m]))
+          /
+          clamp_min(
+            sum(rate(eveys_ocpp_webhook_deliveries_total{outcome=~"delivered|failed"}[5m])),
+            1
+          )

--- a/docs/04-contributing.md
+++ b/docs/04-contributing.md
@@ -101,6 +101,18 @@ When prod is on fire:
 5. Merge → tag → deploy.
 6. **Within 24h**, file a follow-up PR with the proper tests, docs, and post-mortem.
 
+## Breaking an SLO
+
+The five SLOs are catalogued in [`docs/14-slos.md`](./14-slos.md). When a panel on the [SLO dashboard](../deploy/grafana/dashboards/06-slos.json) goes red, follow the runbook:
+
+1. **Confirm it's real** — flick the dashboard's time-range to the long window (7d / 30d). Spikes in the 5m series often self-resolve before they touch the headline number.
+2. **Identify the SLI**. Each panel names which SLO it tracks; `docs/14-slos.md` has a per-SLO "common causes" sentence pointing at the right drill-down dashboard (Per-pod, Per-charger, Reconnect storms, Transactions).
+3. **Stop the bleed first**. If error-budget consumption is fast, prioritise stopping the regression over diagnosing it: revert the last deploy, scale the gateway out, etc.
+4. **Burn-rate triage**. SLO 4 (transaction durability) is **zero-tolerance** — wake the on-call engineer regardless of hour. The other four allow a measurable error budget; the rule of thumb is to act when ~25% of the window's budget is consumed in the first 10% of the window.
+5. **Post-mortem.** Any SLO breach gets a PIR within 48h per the [Communication](#communication) section. Even self-recovered breaches — the post-mortem documents *why* it self-recovered so we don't rely on luck twice.
+
+Today (Phase 4) the dashboard panels are the only signal. **Alerting on SLO breach is wired in Phase 7** when on-call is staffed (Alertmanager + paging integration). Until then this runbook assumes a human noticed the dashboard went red.
+
 ## Things that are easy to get wrong
 
 A few footguns in this codebase that have bitten contributors. Read once.

--- a/docs/14-slos.md
+++ b/docs/14-slos.md
@@ -1,0 +1,167 @@
+# Service-level objectives (SLOs)
+
+The five promises the gateway makes about its production behaviour. Each SLO is the **operator-facing** name; the SLI is the actual metric expression; the target is what we commit to; the window is over which interval; the consequence is what happens on breach.
+
+> Recording rules in [`deploy/prometheus/rules.yml`](../deploy/prometheus/rules.yml). Compliance dashboard in [`deploy/grafana/dashboards/06-slos.json`](../deploy/grafana/dashboards/06-slos.json) (Grafana UID `eveys-ocpp-slos`).
+
+> **Alerting on SLO breach is intentionally NOT wired** in Phase 4. Alertmanager + paging integration is deferred until on-call is staffed (Phase 7). The "consequence" column below describes what *should* fire when alerting lands; today the dashboards are the only signal.
+
+## Error budgets — quick reference
+
+| # | SLO | Target | Window | Error budget per window |
+| - | --- | --- | --- | --- |
+| 1 | Charger connection availability | ≥ 99.5% | 30d | ~3.6 hours of refused boots |
+| 2 | Authorize latency | ≤ 500ms (P95) | 7d | 5% of authorizes may exceed 500ms |
+| 3 | RemoteStart end-to-end | ≤ 3s (P95) | 7d | 5% of RemoteStarts may exceed 3s |
+| 4 | Transaction durability | = 100% | 30d | 0% — zero-tolerance |
+| 5 | Webhook delivery success | ≥ 99% | 7d | 1% — retries should absorb most hiccups |
+
+---
+
+## SLO 1 — Charger connection availability
+
+The gateway exists to accept charger connections. Every refused or crashed boot is a charger that's offline for billing.
+
+**SLI** — fraction of `BootNotification` decisions the gateway returned as `Accepted`:
+```promql
+sum(rate(eveys_ocpp_boot_notifications_total{decision="Accepted"}[30d]))
+/
+sum(rate(eveys_ocpp_boot_notifications_total[30d]))
+```
+Recorded as `slo:boot_acceptance:ratio_30d`.
+
+**Target** — `≥ 99.5%`.
+
+**Window** — rolling 30 days.
+
+**Error budget** — `0.5%` over 30 days. At the rough scale of 10k chargers each booting ~once per day, that's ~1,500 acceptable refusals per month, or roughly 3.6 hours of zero-acceptance time.
+
+**Consequence on breach (Phase 7)** — page on-call. Common causes: backend `register` endpoint is failing (check `eveys_ocpp_backend_circuit_state{endpoint="charge_points_register"}`), Postgres pool exhausted, idempotency cache wiped (Redis flushed).
+
+---
+
+## SLO 2 — Authorize latency
+
+RFID swipes are user-facing. Anything over 500ms feels like the charger is broken — drivers tap again, generating a duplicate Authorize.
+
+**SLI** — P95 of the backend's `/authorize` HTTP call, including circuit-breaker overhead:
+```promql
+histogram_quantile(
+  0.95,
+  sum by (le) (
+    rate(eveys_ocpp_backend_request_latency_seconds_bucket{endpoint="authorize"}[7d])
+  )
+)
+```
+Recorded as `slo:authorize_latency:p95_7d`.
+
+**Target** — `≤ 500ms`.
+
+**Window** — rolling 7 days. Shorter than SLO 1 because user-facing latency regressions need to surface quickly.
+
+**Error budget** — 5% of authorizes are allowed to exceed 500ms.
+
+**Consequence on breach (Phase 7)** — page on-call. The Authorize cache (E3-4) is the load shock-absorber; if its hit rate drops (`eveys_ocpp_authorize_cache_hits_total / (eveys_ocpp_authorize_cache_hits_total + eveys_ocpp_authorize_cache_misses_total)`), the SLO will follow. Verify backend latency upstream before assuming the cache is at fault.
+
+---
+
+## SLO 3 — RemoteStart end-to-end
+
+Matches the load-test pass criterion (E4-6, [docs/13-load-testing.md](./13-load-testing.md)).
+
+**SLI** — P95 of the gRPC `RemoteStart` RPC's wall-clock latency. The histogram already includes the OCPP CALL round-trip to the charger, so this measures the user-visible "tap RemoteStart, see charger respond" timeline:
+```promql
+histogram_quantile(
+  0.95,
+  sum by (le) (
+    rate(eveys_ocpp_grpc_request_latency_seconds_bucket{rpc="RemoteStart"}[7d])
+  )
+)
+```
+Recorded as `slo:remote_start_latency:p95_7d`.
+
+**Target** — `≤ 3s`.
+
+**Window** — rolling 7 days.
+
+**Error budget** — 5% of RemoteStarts may exceed 3s.
+
+**Consequence on breach (Phase 7)** — page on-call. RemoteStart latency is dominated by the charger's response time, but the gateway can compound it via the cross-pod bus path (`eveys_ocpp_bus_request_latency_seconds`) and Postgres look-ups (`eveys_ocpp_db_query_latency_seconds{op="select"}`). Drill in via the Per-pod dashboard.
+
+---
+
+## SLO 4 — Transaction durability
+
+Money flows on this. Any StopTransaction we received but didn't persist is a billing incident.
+
+**SLI** — fraction of received StopTransactions that landed in Postgres:
+```promql
+sum(rate(eveys_ocpp_stop_transactions_total[30d]))
+/
+(
+  sum(rate(eveys_ocpp_stop_transactions_total[30d]))
+  +
+  sum(rate(eveys_ocpp_handler_errors_total{action="StopTransaction"}[30d]))
+)
+```
+Recorded as `slo:transaction_durability:ratio_30d`.
+
+**Target** — `= 100%`. Zero-tolerance.
+
+**Window** — rolling 30 days.
+
+**Error budget** — `0%`. Every drop in this number is a postmortem.
+
+**Caveat (current implementation)** — we don't currently emit a separate "received but not persisted" counter. `eveys_ocpp_stop_transactions_total` is incremented after the handler's DB commit, so a stop that fails to persist gets counted in `eveys_ocpp_handler_errors_total{action="StopTransaction"}` instead. The SLI sums both as the denominator and only the persisted total as the numerator. **If a future task adds a dedicated `_received_total` counter, switch the denominator to that** — the recording rule has a comment pointing here.
+
+**Consequence on breach (Phase 7)** — wake the on-call engineer regardless of hour. Investigate via Sentry (E4-4) for the StopTransaction handler exception; cross-reference the `transaction_id` in OCPP charger replays via `eveys_ocpp_stop_transaction_replays_total` (a healthy idempotency cache absorbs most retries).
+
+---
+
+## SLO 5 — Webhook delivery success
+
+The webhook dispatcher is how the backend learns about gateway events. Its retry logic should absorb most transient hiccups; if it can't, the backend's view of the world drifts.
+
+**SLI** — fraction of envelopes the dispatcher successfully delivered, **excluding** `rejected` (4xx — the backend's bug, not ours):
+```promql
+sum(rate(eveys_ocpp_webhook_deliveries_total{outcome="delivered"}[7d]))
+/
+sum(rate(eveys_ocpp_webhook_deliveries_total{outcome=~"delivered|failed"}[7d]))
+```
+Recorded as `slo:webhook_delivery:ratio_7d`.
+
+**Target** — `≥ 99%`.
+
+**Window** — rolling 7 days.
+
+**Error budget** — 1% of envelopes may end up `failed` (retry budget exhausted) over a week.
+
+**Consequence on breach (Phase 7)** — page on-call. Common cause: backend webhook endpoint is failing (check the backend's own monitoring) or our retry budget is too tight. Look at `eveys_ocpp_webhook_attempts_total` — if many envelopes are exhausting their retry budget, raise it; if attempts are flat-lining, the dispatcher itself is wedged.
+
+---
+
+## What's intentionally NOT here
+
+- **Alerting on SLO breach.** Alertmanager + paging integration is its own task — deferred until on-call is staffed (Phase 7). The dashboard panels go yellow/red on breach but nothing pages.
+- **SLAs (the customer-facing version).** SLAs have contractual teeth and a different audience. Different document, different review path.
+- **Per-tenant SLO slicing.** All five SLOs are fleet-wide; there's no tenant dimension. Phase 6+ work if multi-tenant isolation lands.
+
+## Loading the recording rules
+
+Mount `deploy/prometheus/rules.yml` into your Prometheus container alongside its main config and reference it under `rule_files:`:
+
+```yaml
+# prometheus.yml
+rule_files:
+  - /etc/prometheus/rules/eveys-ocpp.yml
+```
+
+```yaml
+# docker-compose.yml additions for the operator's own Prometheus stack
+services:
+  prometheus:
+    volumes:
+      - ./deploy/prometheus/rules.yml:/etc/prometheus/rules/eveys-ocpp.yml:ro
+```
+
+The rules evaluate every 30 seconds (per the `interval:` field at the top of the group). Reload with `kill -HUP <prometheus-pid>` or `curl -X POST http://prometheus:9090/-/reload` after editing.

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ Documentation for **eveys/ocpp**, the OCPP gateway service of the Eveys EV-charg
 | 11 | [Configuration reference](./11-configuration-reference.md) | Every env var: category, default, range, stability, secret-flag, what it does, what changes if you change it (see ADR-0025) | Operators, SREs, anyone tuning the service |
 | 12 | [Connecting a real charger](./12-connecting-real-charger.md) | Operator/integrator guide: install, connect a real OCPP 1.6 device, watch activity in logs/Postgres/ClickHouse/Kafka, use the REST API from `curl` or Postman | Operators, integrators, anyone connecting a charger for the first time |
 | 13 | [Load testing](./13-load-testing.md) | The `tools/load` rig — how to drive the gateway at scale and capture pass/fail evidence per the Phase 4 exit criteria (E4-6) | SREs, anyone planning a staging load run |
+| 14 | [SLOs](./14-slos.md) | The five service-level objectives the gateway commits to — SLI math, targets, windows, error budgets, breach consequences (E4-8) | SREs, on-call, leadership |
 
 ## ADRs
 
@@ -152,6 +153,7 @@ The two hidden `{toctree}` directives below this section define the navigation. 
 11-configuration-reference
 12-connecting-real-charger
 13-load-testing
+14-slos
 ```
 
 ```{toctree}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dev = [
     "pre-commit>=3.8",
     "freezegun>=1.5",              # deterministic timestamps in tests
     "grpcio-tools>=1.66",          # protoc + grpc_tools.protoc for codegen (dev only)
+    "pyyaml>=6.0",                 # parse `deploy/prometheus/rules.yml` in the SLO sanity test (E4-8). Transitively present today via pre-commit, but declared here so the test stays green if pre-commit drops the dep.
 ]
 
 [project.scripts]

--- a/tests/unit/test_slo_recording_rules.py
+++ b/tests/unit/test_slo_recording_rules.py
@@ -1,0 +1,93 @@
+"""SLO recording-rule sanity check.
+
+Per E4-8 the SLOs are pure config, but a future hand-edit could
+typo a metric name, drop a rule, or misalign with the dashboard's
+record references. This test parses `deploy/prometheus/rules.yml`
+and asserts:
+
+  - the file is valid YAML with the expected `groups[0].rules` shape
+  - every rule we promise in `docs/14-slos.md` is present
+  - every recorded series referenced by `06-slos.json` resolves to
+    a `record:` line in the file (catches typos in either direction)
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RULES_PATH = REPO_ROOT / "deploy" / "prometheus" / "rules.yml"
+DASHBOARD_PATH = REPO_ROOT / "deploy" / "grafana" / "dashboards" / "06-slos.json"
+
+
+def test_rules_file_parses_and_has_one_group() -> None:
+    doc = yaml.safe_load(RULES_PATH.read_text())
+    assert isinstance(doc, dict)
+    groups = doc.get("groups")
+    assert isinstance(groups, list) and len(groups) == 1
+    assert groups[0]["name"] == "eveys_ocpp_slos"
+
+
+def _recorded_names() -> set[str]:
+    doc = yaml.safe_load(RULES_PATH.read_text())
+    return {r["record"] for r in doc["groups"][0]["rules"]}
+
+
+def test_every_promised_slo_has_a_record_rule() -> None:
+    """Each of the five SLOs from `docs/14-slos.md` has a long-window
+    recording rule. The 5m short-window companions are nice-to-have,
+    not load-bearing for the SLO contract — but they're checked too
+    so a future hand-edit doesn't drop one without notice."""
+    expected_long_window = {
+        "slo:boot_acceptance:ratio_30d",
+        "slo:authorize_latency:p95_7d",
+        "slo:remote_start_latency:p95_7d",
+        "slo:transaction_durability:ratio_30d",
+        "slo:webhook_delivery:ratio_7d",
+    }
+    expected_short_window = {
+        "slo:boot_acceptance:ratio_5m",
+        "slo:authorize_latency:p95_5m",
+        "slo:remote_start_latency:p95_5m",
+        # SLO 4 (durability) is single-window by design — a 5m
+        # durability number would be too noisy to be useful.
+        "slo:webhook_delivery:ratio_5m",
+    }
+    recorded = _recorded_names()
+    expected = expected_long_window | expected_short_window
+    missing = expected - recorded
+    assert not missing, f"missing recording rules: {sorted(missing)}"
+
+
+def test_dashboard_only_references_existing_records() -> None:
+    """Every `slo:...` series the dashboard panels read must
+    resolve to a recorded rule. Catches typos in either file."""
+    dashboard = json.loads(DASHBOARD_PATH.read_text())
+    referenced: set[str] = set()
+    pattern = re.compile(r"\bslo:[a-z0-9_:]+\b")
+    for panel in dashboard.get("panels", []):
+        for target in panel.get("targets", []) or []:
+            expr = target.get("expr") or ""
+            for match in pattern.findall(expr):
+                referenced.add(match)
+    recorded = _recorded_names()
+    unknown = referenced - recorded
+    assert not unknown, f"dashboard references unknown rules: {sorted(unknown)}"
+
+
+def test_records_use_known_eveys_ocpp_metrics() -> None:
+    """Each rule's expression should reference at least one
+    `eveys_ocpp_*` metric. Catches a refactor that accidentally
+    leaves a rule dangling on a renamed source metric."""
+    doc = yaml.safe_load(RULES_PATH.read_text())
+    rules = doc["groups"][0]["rules"]
+    for rule in rules:
+        expr = rule["expr"]
+        assert "eveys_ocpp_" in expr, (
+            f"rule {rule['record']!r} expression doesn't reference any "
+            f"eveys_ocpp_* metric — likely broken after a rename"
+        )


### PR DESCRIPTION
Closes #20. **Closes Phase 4 entirely** (#13–#20 all done once this lands).

## Summary

Define the five SLOs the gateway commits to, point the dashboards at them, and document them so operators can act when one breaks.

| # | SLO | Target | Window |
| - | --- | --- | --- |
| 1 | Charger connection availability | ≥ 99.5% | 30d |
| 2 | Authorize latency (P95) | ≤ 500ms | 7d |
| 3 | RemoteStart end-to-end (P95) | ≤ 3s | 7d |
| 4 | Transaction durability | = 100% | 30d |
| 5 | Webhook delivery success | ≥ 99% | 7d |

## Deliverables

- **\`docs/14-slos.md\`** — catalog with SLI math, target, window, error budget, and breach consequence per SLO. Wired into the docs index (rows table + toctree).
- **\`deploy/prometheus/rules.yml\`** — 9 recording rules. Each SLO has a long-window rule (the headline number we promise) and most also have a 5m sister so dashboards spot regressions before the long window catches up.
- **\`deploy/grafana/dashboards/06-slos.json\`** — 6th dashboard. Per-SLO stat panels with threshold colouring (red → yellow → green) and trend timeseries with the target drawn as a horizontal reference line.
- **\`docs/04-contributing.md\`** — new "Breaking an SLO" runbook section explaining what to do when a panel goes red (the spec asked for this explicitly).
- **\`tests/unit/test_slo_recording_rules.py\`** — sanity check that the YAML parses, every SLO has a record rule, every \`slo:*\` series the dashboard references resolves, and every rule references at least one \`eveys_ocpp_*\` source metric.

## Honest caveats (called out in \`14-slos.md\`)

1. **SLO 4 (transaction durability)** — we don't currently emit a separate "received but not persisted" counter. The SLI sums \`eveys_ocpp_stop_transactions_total\` (numerator + part of denominator) with \`eveys_ocpp_handler_errors_total{action="StopTransaction"}\` (rest of denominator). If a future task adds a dedicated \`_received_total\` counter, swap the denominator — \`rules.yml\` has a TODO-style comment pointing at \`docs/14-slos.md\`.

2. **Alerting on SLO breach is intentionally NOT wired.** Alertmanager + paging integration is deferred until on-call is staffed (Phase 7). Dashboard panels go yellow/red but **nothing pages**. The "Breaking an SLO" runbook spells this out so on-call rotations don't inherit a false sense of automation.

## Why \`pyyaml\` lands as a new dev dep

The new \`test_slo_recording_rules.py\` parses \`rules.yml\` to verify its shape. PyYAML was already transitively present via \`pre-commit\`, but I declared it explicitly so the test stays green if pre-commit ever drops the dep.

## Acceptance criteria (#20)

- [x] \`docs/14-slos.md\` enumerates all five SLOs with concrete SLI definitions
- [x] Sixth Grafana dashboard renders each SLO's compliance + error-budget reference
- [x] Prometheus recording rules load cleanly (sanity-checked by the new unit test; full Prometheus syntax check is what \`promtool check rules\` would do — out-of-scope here, the unit test is the cheaper proxy)
- [ ] **"Sane values from a 30-second simulator run"** — needs a live Prometheus instance scraping the gateway during a \`tools/load/run.sh --quick\` invocation. The dashboard + rules are wired correctly; producing the screenshot is operator-driven.

## Test plan

- [x] Unit: 4 new tests on rule presence, dashboard cross-references, and metric-name validity. Full suite: 512 passed (1 deselected, unrelated local-\`.env\` TLS verify)
- [x] mypy --strict clean; ruff + ruff-format clean across \`src tests scripts tools\`
- [x] Docs build clean (\`make html\` in \`docs/\`)
- [x] All 6 Grafana dashboards parse as JSON
- [x] \`rules.yml\` parses as YAML and produces 9 named recording rules
- [ ] Live operator smoke against a Prometheus that scrapes a running gateway — see acceptance criterion above