### PR TITLE
chore: phase 3/4 audit — fix stale phase status + .env-leak in tests

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -46,7 +46,7 @@ Current:
 | Field | Value |
 |---|---|
 | Project | `eveys/ocpp` |
-| Phase | Phase 3 (platform integration) — Phase 0 + 2 closed; long-tail E2-1 + Phase 3 in progress |
+| Phase | Phase 5 (hardening) next — Phases 0–4 complete (2026-05-07); long-tail OCPP 1.6 Core handlers (E2-1) continue alongside as new handlers slot into the existing pipeline |
 | Tech lead | TBD |
 | Source of architecture truth | The ADRs (see [Architecture decisions](./05-architecture-decisions.md)) |
 | License | Proprietary — Eveys |

--- a/tests/unit/platform/test_client.py
+++ b/tests/unit/platform/test_client.py
@@ -54,7 +54,11 @@ def _settings_for_test(**overrides: Any) -> Settings:
         "backend_circuit_breaker_cooldown_seconds": 30.0,
     }
     base.update(overrides)
-    return Settings(**base)
+    # `_env_file=None` so a developer's local `.env` (which may flip
+    # `outbound_tls_verify=false` for self-signed dev backends) doesn't
+    # leak in and fail TLS-defaults-related tests. CI has no `.env`
+    # checked in, so this only manifests locally.
+    return Settings(_env_file=None, **base)
 
 
 def _client_against_mock(
@@ -385,6 +389,7 @@ def test_from_settings_propagates_tls_verify_flag() -> None:
     import ssl
 
     settings = Settings(
+        _env_file=None,
         backend_base_url="https://backend.test",
         backend_token="t",
         outbound_tls_verify=False,
@@ -405,6 +410,7 @@ def test_from_settings_keeps_tls_verify_on_by_default() -> None:
     import ssl
 
     settings = Settings(
+        _env_file=None,
         backend_base_url="https://backend.test",
         backend_token="t",
     )

--- a/tests/unit/webhooks/test_delivery_integration.py
+++ b/tests/unit/webhooks/test_delivery_integration.py
@@ -42,7 +42,8 @@ def _settings(**overrides: Any) -> Settings:
         "webhook_secret": "shared-secret",
     }
     base.update(overrides)
-    return Settings(**base)
+    # See test_dispatcher._settings for why `_env_file=None`.
+    return Settings(_env_file=None, **base)
 
 
 def _make_boot_envelope() -> events_pb2.EventEnvelope:

--- a/tests/unit/webhooks/test_dispatcher.py
+++ b/tests/unit/webhooks/test_dispatcher.py
@@ -28,7 +28,12 @@ def _settings(**overrides: Any) -> Settings:
         "webhook_secret": "shared-secret",
     }
     base.update(overrides)
-    return Settings(**base)
+    # `_env_file=None` so a developer's local `.env` (which may set
+    # `webhook_url_cp_boot=...` overrides for their dev backend) doesn't
+    # leak in and fail this test. CI has no `.env` checked in, so this
+    # only manifests on local laptops; the explicit None makes the test
+    # behave the same in both environments.
+    return Settings(_env_file=None, **base)
 
 
 def _envelope(payload_kind: str, **fields: Any) -> events_pb2.EventEnvelope:


### PR DESCRIPTION
Per the user's audit-everything request after the Phase 3/4 docs sync (PR #40). Two issues found, two issues fixed.

## Audit summary

I cross-checked every claim made by docs about Phase 3/4 against the code, ADRs, tests, and config files. **15 out of 16 claim categories verified clean.** Two real issues found:

| # | Severity | Where | Issue |
| - | --- | --- | --- |
| 1 | BLOCKER | `docs/README.md:49` | Phase status still said "Phase 3 in progress" — contradicts `01-roadmap.md`, `02-tasks.md`, `06-implementation-plan.md` which all mark Phase 3/4 complete (2026-05-07). |
| 2 | real bug | `tests/unit/{platform,webhooks}/` | Four tests leaked a developer's local `.env` into `Settings(...)` construction — fail on laptops, pass in CI. |

### Verified clean (no fix needed)

- ADR-0023 (backend REST integration) ↔ `src/eveys_ocpp/platform/`
- ADR-0026 (gateway REST API) ↔ `src/eveys_ocpp/api/_app.py:84-86` (\`docs_url=None\`, \`redoc_url=None\`, \`openapi_url=None\` still in place)
- ADR-0027 (webhook delivery) ↔ `src/eveys_ocpp/webhooks/`
- ADR-0028 (ingestor fail-fast) ↔ `src/eveys_ocpp/clickhouse/ingestor.py`
- SLO metric names in `deploy/prometheus/rules.yml` ↔ `src/eveys_ocpp/metrics/registry.py`
- All six Grafana dashboards present in `deploy/grafana/dashboards/`
- All five backend-contract endpoints in `BackendHTTPClient` ↔ `docs/integration/01-backend-rest-contract.md`
- 18 POST + 1 GET gateway command routes in `src/eveys_ocpp/api/commands.py`
- Mock backend implements the five contract endpoints
- Test count claims: E3-3 (12→18 actual), E3-5 (12→32), E3-6 (14→14 ✅), E3-8 (43→43 ✅), E3-9 (29→29 ✅), E3-10 (14→14 ✅), E4-* counts. **Undercounts in docs are snapshots at landing time and not misleading**, so left alone.
- `python scripts/render_config_reference.py --check` passes (no settings drift).
- Memory under `~/.claude/projects/.../memory/` carries no dead file references.

## What this PR fixes

### 1. Stale phase status

\`docs/README.md:49\`:

\`\`\`diff
-| Phase | Phase 3 (platform integration) — Phase 0 + 2 closed; long-tail E2-1 + Phase 3 in progress |
+| Phase | Phase 5 (hardening) next — Phases 0–4 complete (2026-05-07); long-tail OCPP 1.6 Core handlers (E2-1) continue alongside as new handlers slot into the existing pipeline |
\`\`\`

### 2. \`.env\` leak in unit tests

Four tests across \`tests/unit/webhooks/test_dispatcher.py\`, \`test_delivery_integration.py\`, and \`tests/unit/platform/test_client.py\` constructed \`Settings(...)\` while passing only the fields they care about. Pydantic-settings' default is to read \`.env\` from cwd, so a developer with \`EVEYS_OCPP_OUTBOUND_TLS_VERIFY=false\` (for self-signed dev backends) or \`webhook_url_cp_boot=...\` (their dev backend) had four tests fail on every local run. CI doesn't have \`.env\` checked in so it never caught this.

Fix: pass \`_env_file=None\` to every \`Settings(...)\` in the affected test factories. Comments explain why.

## Test plan

- [x] \`pytest tests/unit\` — **542 passed**, was 538 before; the +4 are the previously-failing \`.env\`-leak tests now passing in both environments
- [x] coverage **81.10%** (above the 80% gate)
- [x] \`pytest tests/e2e\` against \`make compose-up\` — **34 passed**
- [x] \`mypy --strict\` clean
- [x] \`ruff check\` + \`ruff format --check\` clean
- [x] \`make html\` in \`docs/\` builds clean
- [x] \`scripts/render_config_reference.py --check\` clean