### PR TITLE
feature(security): E5-8 — pip-audit + Dependabot in CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,85 @@
+# Dependabot config (E5-8) — weekly bumps for Python deps and the GitHub
+# Actions we pin in workflows. Pairs with `.github/workflows/security.yml`:
+# pip-audit catches *known* CVEs in what we currently have; Dependabot
+# pulls us forward so we don't sit on stale versions where a CVE
+# eventually lands.
+#
+# Cadence: weekly. Daily would generate noise without a security win
+# (pip-audit already provides the daily-CVE signal). Monthly is too slow
+# for a security-track config — by the time a Dependabot PR lands, the
+# CVE may have been public for weeks.
+#
+# Grouping reduces PR volume: a single "dev-dependencies" PR per week
+# beats five separate ruff / mypy / pytest bumps.
+
+version: 2
+
+updates:
+  # Python — driven by pyproject.toml's runtime + [dev] extras.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      # Match the conventional-commit hook in pre-commit. `chore(deps)`
+      # is the closest fit: a maintenance change that touches no
+      # behaviour.
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      # Dev tooling moves together; one weekly PR for the whole batch.
+      dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+      # Runtime patches grouped so a 0.1.0 → 0.1.1 across several libs
+      # is one review, not five. Major and minor bumps stay individual
+      # so they get the attention they deserve.
+      runtime-patches:
+        dependency-type: "production"
+        update-types:
+          - "patch"
+
+  # GitHub Actions — pins like `actions/checkout@v4` get bumped here.
+  # The pinned major versions (`@v4`) accept patch updates implicitly,
+  # but Dependabot proposes the SHA-pinned form when a vulnerability
+  # in an action surfaces.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+
+  # Docker base images in deploy/. Currently only deploy/Dockerfile;
+  # Dependabot will follow the FROM directives.
+  - package-ecosystem: "docker"
+    directory: "/deploy"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,43 @@
+# Security gate (E5-8) — pip-audit scans the resolved Python environment
+# against the PyPI advisory DB (PyUp + OSV).
+#
+# Three triggers:
+#
+# 1. PR — every change runs the audit so a vulnerable transitive dep
+#    landing via dependency-bump PRs gets caught before merge.
+# 2. Push to main — defence in depth; covers direct pushes (rare per
+#    project policy) and merge commits with auto-resolved deps.
+# 3. Daily schedule (06:00 UTC) — surfaces a CVE that was disclosed
+#    after the last code change. The roadmap's Phase 5 exit gate asks
+#    for "new CVEs surface within 24h"; the daily run delivers that.
+#
+# The job is intentionally separate from `quality.yml` so a CVE finding
+# doesn't gate code-quality work, and so the daily schedule doesn't fire
+# the lint / type / config-reference jobs.
+name: security
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    # 06:00 UTC daily — chosen so it runs before EU working hours start,
+    # giving on-call a chance to triage before the team logs in.
+    - cron: "0 6 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  pip-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-python-venv
+      - name: pip-audit
+        # `--skip-editable` excludes the eveys-ocpp package itself
+        # (installed editable; not on PyPI). The trailing `.` tells
+        # pip-audit to audit the resolved environment from
+        # `pyproject.toml` rather than re-running pip resolution.
+        # `--strict` causes any unfixed advisory to fail the job.
+        run: .venv/bin/pip-audit --strict --skip-editable .

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ COMPOSE    := docker compose -f deploy/compose/docker-compose.yml $(COMPOSE_ENV)
 .PHONY: help doctor install format lint types tests e2e smoke compose-smoke precommit clean distclean \
         compose-up compose-down compose-status compose-down-volumes compose-wait \
         build-image protoc ch-migrate docs docs-clean config-export config-export-check config-schema \
-        openapi-export openapi-export-check
+        openapi-export openapi-export-check audit
 
 # ---- meta -------------------------------------------------------------------
 
@@ -33,6 +33,7 @@ help:
 	@echo "  make lint               run ruff check"
 	@echo "  make types              run mypy --strict on src/"
 	@echo "  make tests              full pre-commit gate: lint + types + pytest with coverage"
+	@echo "  make audit              pip-audit against resolved venv (E5-8)"
 	@echo "  make precommit          run all pre-commit hooks against every file (no commit needed)"
 	@echo ""
 	@echo "Local stack (data plane):"
@@ -122,6 +123,18 @@ types: install
 
 tests: lint types
 	$(VENV)/bin/pytest
+
+# E5-8 — pip-audit scans the resolved venv against the PyPI advisory DB
+# (PyUp / OSV). Local mirror of the CI job in .github/workflows/security.yml
+# so engineers can repro a CVE finding before pushing. Non-zero exit on
+# any unfixed advisory.
+#
+# `--skip-editable` excludes the eveys-ocpp package itself (it's installed
+# editable; pip-audit can't look it up on PyPI). The project path argument
+# tells pip-audit to audit the resolved environment from `pyproject.toml`,
+# which is the surface we actually ship.
+audit: install
+	$(VENV)/bin/pip-audit --strict --skip-editable .
 
 precommit: install
 	$(VENV)/bin/pre-commit run --all-files

--- a/docs/02-tasks.md
+++ b/docs/02-tasks.md
@@ -128,7 +128,7 @@ Integration shape locked in [ADR-0023](./adr/0023-backend-rest-integration.md) a
 | E5-5 | mTLS between internal services | Pod-to-pod requires valid cert |
 | E5-6 | Basic Auth at WS edge + per-CP password store | Bad creds rejected at edge |
 | E5-7 | Secrets in vault, mounted as env vars | No secrets in repo |
-| E5-8 | `pip-audit` + Dependabot in CI | New CVEs surface within 24h |
+| E5-8 | `pip-audit` + Dependabot in CI | ✅ done — `pip-audit` runs on PR + push to main + daily cron (06:00 UTC) via `.github/workflows/security.yml`; `make audit` mirrors it locally. Dependabot watches three ecosystems weekly: pip (pyproject), github-actions (workflow pins), docker (`deploy/Dockerfile`). Dev-dep bumps grouped into one PR/week; runtime patches grouped; minor/major runtime bumps stay individual. |
 | E5-9 | External pen test | Report received |
 | E5-10 | DR drill (kill DB / Redis / pods) | Recovery < SLO targets |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dev = [
     "freezegun>=1.5",              # deterministic timestamps in tests
     "grpcio-tools>=1.66",          # protoc + grpc_tools.protoc for codegen (dev only)
     "pyyaml>=6.0",                 # parse `deploy/prometheus/rules.yml` in the SLO sanity test (E4-8). Transitively present today via pre-commit, but declared here so the test stays green if pre-commit drops the dep.
+    "pip-audit>=2.7",              # E5-8: scan resolved deps against the PyPI advisory DB. Local-runnable via `make audit`; CI runs on PR + daily schedule.
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Why

Phase 5 hardening exit gate: **\"new CVEs surface within 24h\"**. Two signals together deliver that:

1. **pip-audit on a daily schedule** — catches a CVE disclosed *after* the last code change. Without this, we only learn about a vulnerable dep when someone happens to push a PR.
2. **Dependabot** — keeps us moving forward so we're not sitting on stale versions where the next CVE lands.

## What's in here

### \`.github/workflows/security.yml\`
- Runs \`pip-audit --strict --skip-editable .\` against the resolved venv.
- Triggers: PR + push to main + daily cron at 06:00 UTC (chosen to fire before EU working hours so on-call has triage time).
- Separate workflow from \`quality.yml\` so a CVE finding doesn't block code-quality work, and the daily schedule doesn't fire lint/types/etc.

### \`.github/dependabot.yml\`
- Three ecosystems: \`pip\` (pyproject.toml), \`github-actions\` (workflow pins), \`docker\` (\`deploy/Dockerfile\`).
- Weekly cadence (Monday 06:00 UTC). Daily would be noise; pip-audit already provides the daily security signal.
- **Grouping**: dev-deps batched into one PR/week. Runtime patches grouped. Runtime minor/major stay individual so they get the review attention they need.
- Commit prefix \`chore(deps)\` matches the existing conventional-commit hook.

### \`make audit\`
Local mirror of the CI job. Engineers can repro a CVE finding before pushing.

### \`pyproject.toml\`
\`pip-audit>=2.7\` added to \`[dev]\` extras.

## Notes

- The trailing \`.\` in the pip-audit invocation tells it to audit the resolved environment from \`pyproject.toml\` rather than re-running pip resolution. \`--skip-editable\` excludes the eveys-ocpp package itself (installed editable; not on PyPI).
- Baseline today: **zero advisories**. The first PR / scheduled run goes green.

## Test plan

- [x] \`make audit\` — runs locally, exits 0
- [x] \`make lint\` — clean
- [x] \`make types\` — clean (mypy strict)
- [x] \`pytest tests/unit/\` — 555 passed, coverage 82%
- [x] YAML files parse (\`yaml.safe_load\` on both)
- [ ] CI run on this PR confirms the \`pip-audit\` job runs and exits green
- [ ] Dependabot picks up the config on first scheduled run (Monday)