### PR TITLE
docs: sync 00/01/14 + REST contract with shipped graceful drain

### DIFF
--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -69,7 +69,7 @@ These constraints don't fit a typical request/response service. `eveys/ocpp` is 
 ## Goals
 
 1. **Dedicated runtime for long-lived WS connections.** No shared loop with HTTP/cron workloads.
-2. **Survive rolling restarts.** No fleet-wide reconnect storms.
+2. **Survive rolling restarts.** No fleet-wide reconnect storms. Each pod exposes an auth-exempt `GET /api/v1/ready` probe that flips to 503 on SIGTERM; the load balancer drains the pod from rotation before the process exits, so chargers reconnecting during a deploy land on a healthy sibling pod without seeing connection refusals.
 3. **Linear scale-out** with charger count. From day-one fleet to 320k chargers on the same architecture.
 4. **Stable internal contract** (gRPC + Kafka). The rest of the platform doesn't touch sockets.
 5. **Observable** at per-charger granularity. Localize any incident in < 5 minutes.

--- a/docs/01-roadmap.md
+++ b/docs/01-roadmap.md
@@ -11,7 +11,7 @@
 | **2** | Full OCPP 1.6 Core | 2 weeks | All ~25 1.6 Core actions + gRPC API + Kafka events; integration tests passing |
 | **3** | Platform integration | 2 weeks | Backend REST integration: gateway calls backend `/authorize` + `/sessions/*`; gateway exposes `/api/v1/...` for read + commands; webhooks deliver async events. Specced in `docs/integration/` (ADR-0023). |
 | **4** | Observability + load test | 1 week | Dashboards live, 10k-charger swarm test passes |
-| **5** | Hardening | 2 weeks | Rate limits, reconnect-storm test, security review, pen test (core idempotency for `BootNotification`/`StopTransaction` already shipped in Phase 2 via E2-11; remaining handler-level idempotency hardening lands here) |
+| **5** | Hardening | 2 weeks | Graceful drain (rolling-deploy-safe shutdown), rate limits, reconnect-storm test, security review, pen test (core idempotency for `BootNotification`/`StopTransaction` already shipped in Phase 2 via E2-11; remaining handler-level idempotency hardening lands here) |
 | **6** | Staging soak | 1 week | 10 dev-fleet chargers running on `ocpp-gw` for 7 days, zero incidents |
 | **7** | Production rollout | 4 weeks | Wave ramp 10 → 100 → 1k → 10k → all chargers live |
 | **Parallel** | OCPP 2.0.1 + OCTT | 12 weeks (start week 4) | OCTT certification passes; 2.0.1 chargers supported |
@@ -120,6 +120,7 @@ The integration shape is documented in [`docs/integration/`](./integration/READM
 
 | Deliverable | Done when |
 |---|---|
+| Graceful drain on SIGTERM (`/api/v1/ready` flips, LB removes pod from rotation, then teardown) | Rolling restart causes no charger connection refusals |
 | Per-IP rate limit on WS upgrade (Envoy) | DoS test from one IP gets throttled |
 | Per-charger message rate cap | Flooding charger triggers backpressure, not crash |
 | Sanity-range validation on `MeterValues` | Charger reporting 100 MWh tx is quarantined |

--- a/docs/14-slos.md
+++ b/docs/14-slos.md
@@ -140,6 +140,15 @@ Recorded as `slo:webhook_delivery:ratio_7d`.
 
 ---
 
+## Related observability — graceful drain
+
+Not a separate SLO (the failure mode rolls up into SLO 1 — a refused charger boot during a deploy looks the same as any other refused boot in the SLI). Worth flagging because the mechanism is its own moving part:
+
+- `GET /api/v1/ready` returns 200 normally and 503 once the pod is draining. The load balancer's readiness probe reads this; a 503 removes the pod from rotation before the process exits.
+- The drain itself isn't directly metric'd today — it surfaces through the readiness endpoint and through SLO 1's acceptance ratio. If rolling deploys ever start showing as a dip in `slo:boot_acceptance:ratio_30d`, the LB-side probe interval is the first thing to check (must be ≤ `shutdown_readiness_propagation_seconds`, default 10 s).
+
+---
+
 ## What's intentionally NOT here
 
 - **Alerting on SLO breach.** Alertmanager + paging integration is its own task — deferred until on-call is staffed (Phase 7). The dashboard panels go yellow/red on breach but nothing pages.

--- a/docs/integration/02-gateway-rest-api.md
+++ b/docs/integration/02-gateway-rest-api.md
@@ -456,6 +456,26 @@ When a downstream component is degraded, `components.<name>` becomes `degraded` 
 
 ---
 
+## `GET /api/v1/ready`
+
+Readiness probe — distinct from `/health`. Returns `200` when the pod is accepting new connections, `503` once the pod has begun draining for shutdown.
+
+```json
+{ "status": "ready", "request_id": "<uuid>" }
+```
+
+When draining (SIGTERM received, drain mechanism engaged):
+
+```json
+{ "status": "draining", "request_id": "<uuid>", "draining_for_seconds": 4.2 }
+```
+
+Auth-exempt — the load balancer's readiness probe doesn't carry a bearer token. Used by Kubernetes / Envoy / any LB that respects HTTP readiness probes: a 503 here removes the pod from the rotation pool before the process actually exits, so chargers don't get connection refusals during rolling deploys.
+
+`/health` reports component liveness (Postgres, Redis); `/ready` reports willingness to accept new connections. Monitor both.
+
+---
+
 ## Error responses
 
 Errors return a consistent shape (not the success-shape envelope):


### PR DESCRIPTION
## Why

Audit of code-vs-docs found four mismatches around PR #43 (graceful drain, merged). PR #43 added the code and regenerated the auto-generated docs (OpenAPI snapshot, configuration reference) but didn't update the hand-written prose docs that describe the system shape. This catches them up.

## What's in here

| Doc | Change |
|---|---|
| \`docs/integration/02-gateway-rest-api.md\` | New \`/api/v1/ready\` section after \`/health\`. Response shapes for ready / draining, auth-exempt note, distinct-from-/health framing. |
| \`docs/00-overview.md\` | Goal #2 expanded — describes the actual /ready + LB-drain mechanism instead of just stating the goal. |
| \`docs/01-roadmap.md\` | Phase 5 row + deliverables table both mention graceful drain. |
| \`docs/14-slos.md\` | New "Related observability — graceful drain" section. Not a separate SLO (failures roll up into SLO 1 boot acceptance) but operators get a pointer to /ready and the LB-probe-interval invariant. |

## Out of scope

- **E5-4 doc updates** (meter sanity quarantine counter). PR #53 is open and not merged; its docs land with its code, not here.
- **Configuration reference / OpenAPI snapshot.** Already regenerated in PR #43.
- **Tasks doc** (\`docs/02-tasks.md\`). E5-8 + E5-4 status already in there from their respective PRs.

## Test plan

- [x] \`make docs\` — Sphinx build clean
- [x] /ready snippet matches the actual implementation (`src/eveys_ocpp/api/ready.py:30-58`)
- [x] OpenAPI snapshot already contains /ready (regenerated in PR #43)
- [x] No code changes; nothing to lint/type/test

---

Closes #57
