### PR TITLE
chore(ci): fix Dependabot — drop doubled scope, pin Python 3.13

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,12 @@
 #
 # Grouping reduces PR volume: a single "dev-dependencies" PR per week
 # beats five separate ruff / mypy / pytest bumps.
+#
+# Commit-prefix note: `prefix: "chore(deps)"` alone produces
+# `chore(deps): bump foo from x to y in /deploy`. Adding
+# `include: "scope"` would *append* the ecosystem name as a second
+# scope, producing the doubled `chore(deps)(deps):` we saw in PR #46
+# / #47 / #48. We deliberately omit `include: scope` here.
 
 version: 2
 
@@ -28,11 +34,7 @@ updates:
       - "dependencies"
       - "python"
     commit-message:
-      # Match the conventional-commit hook in pre-commit. `chore(deps)`
-      # is the closest fit: a maintenance change that touches no
-      # behaviour.
       prefix: "chore(deps)"
-      include: "scope"
     groups:
       # Dev tooling moves together; one weekly PR for the whole batch.
       dev-dependencies:
@@ -65,10 +67,16 @@ updates:
       - "github-actions"
     commit-message:
       prefix: "chore(deps)"
-      include: "scope"
 
   # Docker base images in deploy/. Currently only deploy/Dockerfile;
   # Dependabot will follow the FROM directives.
+  #
+  # Python *major* bumps are explicitly ignored — the project pins to
+  # Python 3.13 in three places (`requires-python` in pyproject.toml,
+  # `python_version = "3.13"` in mypy config, and the distroless
+  # runtime stage hard-copies `/usr/local/lib/python3.13/...` paths).
+  # A 3.14 base would fail CI immediately and need a deliberate human
+  # migration. Patch bumps within 3.13.x still flow.
   - package-ecosystem: "docker"
     directory: "/deploy"
     schedule:
@@ -82,4 +90,8 @@ updates:
       - "docker"
     commit-message:
       prefix: "chore(deps)"
-      include: "scope"
+    ignore:
+      - dependency-name: "python"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"


### PR DESCRIPTION
## Why

Two issues surfaced on the first batch of Dependabot PRs (#46, #47, #48):

### 1. Doubled commit prefix
PRs landed as \`chore(deps)(deps): bump …\` instead of \`chore(deps): bump …\`. \`prefix: \"chore(deps)\"\` together with \`include: \"scope\"\` makes Dependabot append the ecosystem name as a *second* scope. Drop \`include: scope\` everywhere. Commits become a clean \`chore(deps): bump foo from x to y in /deploy\`.

### 2. PR #48 (Python 3.14 bump) failed compose-smoke
The project pins to **Python 3.13** in three places:
- \`pyproject.toml\` — \`requires-python = \">=3.13\"\`
- \`pyproject.toml\` mypy — \`python_version = \"3.13\"\`
- \`deploy/Dockerfile\` — distroless runtime stage hard-copies \`/usr/local/lib/python3.13/...\` paths

A 3.14 base broke the build immediately. Closed #48; this PR adds an \`ignore\` block to the docker ecosystem so Python major *and* minor bumps don't get re-proposed every Monday until someone does the deliberate migration. Patch bumps within 3.13.x still flow (security updates typically land that way).

## What's in here

\`.github/dependabot.yml\`:
- Removed \`include: scope\` from all three ecosystems (pip, github-actions, docker).
- Added \`ignore\` for \`python\` in docker: skip \`version-update:semver-major\` and \`version-update:semver-minor\`.
- Inline comments explaining both decisions so a future contributor doesn't re-add them by reflex.

## Test plan

- [x] YAML parses (\`yaml.safe_load\` round-trips three update entries, no scope inclusion)
- [ ] Next Monday's Dependabot run produces \`chore(deps): …\` (single-scoped) commits
- [ ] No new Python 3.14 PR appears

## Side note: labels

GitHub previously warned about missing labels (\`dependencies\`, \`docker\`, \`python\`, \`github-actions\`). Created via \`gh label create\` in a separate operation; labels exist now.

---

Closes #58
