### PR TITLE
feature(api): admin runtime-config endpoint (GET / PATCH / DELETE)

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1194,6 +1194,19 @@
         "title": "TransactionListResponse",
         "type": "object"
       },
+      "UpdateBody": {
+        "description": "PATCH body. The keys in `updates` must be allowlisted; the\nvalues are coerced per the allowlist's `coerce` callable.",
+        "properties": {
+          "updates": {
+            "additionalProperties": true,
+            "description": "Map of `field_name \u2192 new_value` for allowlisted fields.",
+            "title": "Updates",
+            "type": "object"
+          }
+        },
+        "title": "UpdateBody",
+        "type": "object"
+      },
       "ValidationError": {
         "properties": {
           "ctx": {
@@ -1243,6 +1256,114 @@
   },
   "openapi": "3.1.0",
   "paths": {
+    "/api/v1/admin/config": {
+      "get": {
+        "operationId": "get_config_api_v1_admin_config_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Config Api V1 Admin Config Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "GET effective runtime configuration",
+        "tags": [
+          "admin"
+        ]
+      },
+      "patch": {
+        "operationId": "patch_config_api_v1_admin_config_patch",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Patch Config Api V1 Admin Config Patch",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "PATCH allowlisted runtime overrides",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/api/v1/admin/config/overrides/{key}": {
+      "delete": {
+        "operationId": "delete_override_api_v1_admin_config_overrides__key__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "key",
+            "required": true,
+            "schema": {
+              "title": "Key",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Delete Override Api V1 Admin Config Overrides  Key  Delete",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "DELETE a single runtime override (revert to env-driven default)",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
     "/api/v1/charge-points": {
       "get": {
         "operationId": "list_charge_points_route_api_v1_charge_points_get",

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -796,6 +796,18 @@ components:
       - request_id
       title: TransactionListResponse
       type: object
+    UpdateBody:
+      description: 'PATCH body. The keys in `updates` must be allowlisted; the
+
+        values are coerced per the allowlist''s `coerce` callable.'
+      properties:
+        updates:
+          additionalProperties: true
+          description: Map of `field_name → new_value` for allowlisted fields.
+          title: Updates
+          type: object
+      title: UpdateBody
+      type: object
     ValidationError:
       properties:
         ctx:
@@ -833,6 +845,75 @@ info:
   version: 0.0.0
 openapi: 3.1.0
 paths:
+  /api/v1/admin/config:
+    get:
+      operationId: get_config_api_v1_admin_config_get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Get Config Api V1 Admin Config Get
+                type: object
+          description: Successful Response
+      summary: GET effective runtime configuration
+      tags:
+      - admin
+    patch:
+      operationId: patch_config_api_v1_admin_config_patch
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateBody'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Patch Config Api V1 Admin Config Patch
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: PATCH allowlisted runtime overrides
+      tags:
+      - admin
+  /api/v1/admin/config/overrides/{key}:
+    delete:
+      operationId: delete_override_api_v1_admin_config_overrides__key__delete
+      parameters:
+      - in: path
+        name: key
+        required: true
+        schema:
+          title: Key
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Delete Override Api V1 Admin Config Overrides  Key  Delete
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: DELETE a single runtime override (revert to env-driven default)
+      tags:
+      - admin
   /api/v1/charge-points:
     get:
       operationId: list_charge_points_route_api_v1_charge_points_get

--- a/docs/integration/02-gateway-rest-api.md
+++ b/docs/integration/02-gateway-rest-api.md
@@ -476,6 +476,77 @@ Auth-exempt — the load balancer's readiness probe doesn't carry a bearer token
 
 ---
 
+## Admin runtime config — `GET / PATCH / DELETE /api/v1/admin/config`
+
+Per-pod runtime overrides for a tightly-scoped allowlist of `Settings` fields. The gateway's `Settings` is frozen (env vars are the source of truth and most fields bind into a SQLAlchemy engine / TCP socket / Kafka producer at boot), but a small set is read fresh on every use and can be flipped without a rolling deploy. This surface is the operator UX for those.
+
+**Per-pod scope.** Hitting these endpoints on pod A doesn't affect pod B. Cluster-wide propagation via Redis pub/sub is a future enhancement; for fleet-wide changes, deploy a new env value and roll out.
+
+### `GET /api/v1/admin/config`
+
+Returns the current effective `Settings` dump (secrets auto-redact via E5-7) plus the in-process overrides currently in effect plus the allowlist for `PATCH`.
+
+```json
+{
+  "settings": {
+    "log_level": "INFO",
+    "ws_rate_limit_enabled": true,
+    "rest_inbound_tokens": "**********",
+    "db_url": "**********",
+    "...": "..."
+  },
+  "overrides": { "log_level": "DEBUG" },
+  "allowlist": {
+    "log_level": "stdlib logging level applied to every emit.",
+    "ws_rate_limit_enabled": "Per-charger CALL rate limiter (E5-3) kill-switch.",
+    "backend_authorize_cache_enabled": "Per-pod Authorize cache (E3-4) kill-switch."
+  },
+  "scope": "per-pod",
+  "request_id": "<uuid>"
+}
+```
+
+### `PATCH /api/v1/admin/config`
+
+Body: `{"updates": {"<field>": <value>, ...}}`. Each field must be in the allowlist. Non-allowlisted fields → `400 BAD_REQUEST` with the allowed list in the message.
+
+Tolerant value coercion: bools accept `true` / `"true"` / `1`; `log_level` is validated against the same `Literal[...]` as `Settings.log_level`. Atomicity is **not** promised — if a PATCH carries one allowed and one rejected field, the allowed one stays in effect and the response surfaces both halves so the operator can revert deliberately.
+
+`log_level` updates take effect immediately via `logging.getLogger().setLevel(...)`. The other fields' read sites consult overrides per-call, so the next message / next Authorize / next CALL picks up the new value.
+
+```json
+{
+  "applied": { "log_level": "DEBUG" },
+  "overrides": { "log_level": "DEBUG" },
+  "scope": "per-pod",
+  "request_id": "<uuid>"
+}
+```
+
+### `DELETE /api/v1/admin/config/overrides/{key}`
+
+Clears one override. Subsequent reads fall back to the boot-time `Settings` value. Idempotent: clearing a key that was never set returns `cleared: false` rather than 404.
+
+```json
+{
+  "cleared": true,
+  "key": "log_level",
+  "overrides": {},
+  "scope": "per-pod",
+  "request_id": "<uuid>"
+}
+```
+
+### Allowlist criteria
+
+A field gets allowlisted when:
+1. The runtime read site reads it fresh on every use (not cached at boot).
+2. The value is operator-meaningful at runtime (not `db_url` / `ws_port` / `kafka_brokers` — those bind to a socket / producer at boot and changing them via PATCH would either be a no-op or a bug).
+
+Adding a new allowlisted field is a deliberate `runtime_overrides.py` edit plus a matching `get_override(...)` call site.
+
+---
+
 ## Error responses
 
 Errors return a consistent shape (not the success-shape envelope):

--- a/src/eveys_ocpp/api/_app.py
+++ b/src/eveys_ocpp/api/_app.py
@@ -38,6 +38,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from eveys_ocpp import __version__
 from eveys_ocpp.api import (
+    admin,
     charge_points,
     charging_profiles,
     commands,
@@ -189,6 +190,7 @@ def make_app(
     app.include_router(charging_profiles.router, prefix="/api/v1")
     app.include_router(commands.router, prefix="/api/v1")
     app.include_router(timeseries.router, prefix="/api/v1")
+    app.include_router(admin.router, prefix="/api/v1")
 
     return app
 

--- a/src/eveys_ocpp/api/admin.py
+++ b/src/eveys_ocpp/api/admin.py
@@ -1,0 +1,149 @@
+"""Admin endpoints — runtime config GET / SET / DELETE.
+
+Three endpoints under `/api/v1/admin/config`:
+
+  GET    /api/v1/admin/config
+    Returns the current effective Settings dump (SecretStr fields
+    auto-redact via E5-7) plus an `overrides` block listing
+    in-process overrides currently in effect, plus an `allowlist`
+    block listing fields the PATCH endpoint accepts.
+
+  PATCH  /api/v1/admin/config
+    Body: `{"updates": {"<field>": <value>, ...}}`. Validates each
+    field against the closed allowlist in
+    `eveys_ocpp.runtime_overrides`. Rejects non-allowlisted fields
+    with a 400 + the allowed list.
+
+  DELETE /api/v1/admin/config/overrides/{key}
+    Removes a single override. Subsequent reads fall back to the
+    boot-time Settings value.
+
+**Per-pod scope.** Hitting these endpoints on pod A doesn't affect
+pod B. Cluster-wide propagation via Redis pub/sub is a future
+enhancement; for v0 the rolling deploy is the canonical mechanism
+for fleet-wide changes. This is documented in the response envelope
+so the operator UI can surface it.
+
+**Auth.** Reuses the existing bearer-token middleware on
+`/api/v1/*` (E3-7 / ADR-0026). No new auth surface; the operator
+needs the same token any other admin caller uses.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Request
+from pydantic import BaseModel, Field
+
+from eveys_ocpp.api._errors import ERR_BAD_REQUEST, ApiError
+from eveys_ocpp.observability import apply_log_level, get_logger
+from eveys_ocpp.runtime_overrides import (
+    OverrideNotAllowedError,
+    all_overrides,
+    allowlist,
+    clear_override,
+    set_override,
+)
+
+log = get_logger(__name__)
+
+router = APIRouter(tags=["admin"])
+
+
+class UpdateBody(BaseModel):
+    """PATCH body. The keys in `updates` must be allowlisted; the
+    values are coerced per the allowlist's `coerce` callable."""
+
+    updates: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Map of `field_name → new_value` for allowlisted fields.",
+    )
+
+
+def _settings_snapshot(request: Request) -> dict[str, Any]:
+    """Render `Settings.model_dump(mode='json')`. SecretStr fields
+    auto-redact to `**********` thanks to E5-7."""
+    settings = request.app.state.settings
+    # `mode='json'` ensures SecretStr serialises to its redacted
+    # string form rather than the raw object.
+    return dict(settings.model_dump(mode="json"))
+
+
+@router.get(
+    "/admin/config",
+    summary="GET effective runtime configuration",
+)
+async def get_config(request: Request) -> dict[str, Any]:
+    return {
+        "settings": _settings_snapshot(request),
+        "overrides": all_overrides(),
+        "allowlist": allowlist(),
+        "scope": "per-pod",
+        "request_id": request.state.request_id,
+    }
+
+
+@router.patch(
+    "/admin/config",
+    summary="PATCH allowlisted runtime overrides",
+)
+async def patch_config(request: Request, body: UpdateBody) -> dict[str, Any]:
+    if not body.updates:
+        raise ApiError(
+            status_code=400,
+            error_code=ERR_BAD_REQUEST,
+            message="`updates` must be non-empty.",
+        )
+
+    applied: dict[str, Any] = {}
+    rejected: dict[str, str] = {}
+    for name, raw_value in body.updates.items():
+        try:
+            applied[name] = set_override(name, raw_value)
+        except OverrideNotAllowedError as exc:
+            rejected[name] = str(exc)
+        except ValueError as exc:
+            rejected[name] = str(exc)
+
+    if rejected:
+        # All-or-nothing on the rejection: any rejected field aborts
+        # with 400 BUT we report what was already applied so the
+        # operator can decide whether to revert. The applied set is
+        # already in effect — this is "atomicity is not promised"
+        # honesty, not silent partial-write.
+        raise ApiError(
+            status_code=400,
+            error_code=ERR_BAD_REQUEST,
+            message=(
+                f"rejected: {rejected}; applied (still in effect): "
+                f"{applied}; allowed: {sorted(allowlist())}"
+            ),
+        )
+
+    # Side effects for fields that need more than just storing the
+    # value (log_level reconfigures stdlib logging immediately).
+    if "log_level" in applied:
+        apply_log_level(applied["log_level"])
+
+    return {
+        "applied": applied,
+        "overrides": all_overrides(),
+        "scope": "per-pod",
+        "request_id": request.state.request_id,
+    }
+
+
+@router.delete(
+    "/admin/config/overrides/{key}",
+    summary="DELETE a single runtime override (revert to env-driven default)",
+)
+async def delete_override(request: Request, key: str) -> dict[str, Any]:
+    existed = clear_override(key)
+    return {
+        "cleared": existed,
+        "key": key,
+        "overrides": all_overrides(),
+        "scope": "per-pod",
+        "request_id": request.state.request_id,
+    }

--- a/src/eveys_ocpp/connection.py
+++ b/src/eveys_ocpp/connection.py
@@ -187,7 +187,16 @@ class EveysChargePoint(Cpv16):
             pass
         metrics_registry.WS_MESSAGES_IN_TOTAL.labels(action=action).inc()
 
-        if is_call and self.rate_limiter is not None:
+        # Hot-checked via the runtime-override layer so an admin can
+        # flip the rate limiter without a pod restart. Default is
+        # the boot-time setting; the override takes precedence when
+        # set via PATCH /api/v1/admin/config.
+        from eveys_ocpp.runtime_overrides import get_override
+
+        rate_limit_enabled = get_override(
+            "ws_rate_limit_enabled", self.settings.ws_rate_limit_enabled
+        )
+        if is_call and self.rate_limiter is not None and rate_limit_enabled:
             allowed = await self.rate_limiter.check(self.id)
             if not allowed:
                 await self.rate_limiter.record_throttled(action=action)

--- a/src/eveys_ocpp/observability/__init__.py
+++ b/src/eveys_ocpp/observability/__init__.py
@@ -36,6 +36,7 @@ from eveys_ocpp.observability.tracing import (
 )
 
 __all__ = [
+    "apply_log_level",
     "bind_contextvars",
     "bind_sentry_scope",
     "clear_contextvars",
@@ -114,3 +115,24 @@ def get_logger(name: str | None = None) -> structlog.stdlib.BoundLogger:
     """Return a configured logger. Use module `__name__` as the argument."""
     logger: structlog.stdlib.BoundLogger = structlog.get_logger(name)
     return logger
+
+
+def apply_log_level(level: str) -> None:
+    """Apply a runtime log-level change to stdlib loggers.
+
+    The structlog filtering wrapper class is fixed at
+    `configure_logging` time and can't be re-bound without
+    reconfiguring every cached logger — but most output flows
+    through stdlib (asyncpg, websockets, the structlog mirror at
+    `logging.basicConfig`), so flipping the stdlib level catches
+    the bulk of what an operator wants when they bump verbosity
+    via the admin endpoint.
+
+    A future improvement could swap the structlog wrapper too, at
+    the cost of dropping the `cache_logger_on_first_use=True`
+    optimisation. Not worth it for v0.
+    """
+    numeric = getattr(logging, level.upper(), None)
+    if not isinstance(numeric, int):
+        raise ValueError(f"unknown log level: {level!r}")
+    logging.getLogger().setLevel(numeric)

--- a/src/eveys_ocpp/platform/cache.py
+++ b/src/eveys_ocpp/platform/cache.py
@@ -76,7 +76,15 @@ class AuthorizeCache:
         outage / malformed value. The caller continues to the backend
         on None (cache miss is indistinguishable from "no Redis").
         """
-        if not self._settings.backend_authorize_cache_enabled:
+        # Read fresh per call so an admin override on
+        # backend_authorize_cache_enabled takes effect without a pod
+        # restart.
+        from eveys_ocpp.runtime_overrides import get_override
+
+        if not get_override(
+            "backend_authorize_cache_enabled",
+            self._settings.backend_authorize_cache_enabled,
+        ):
             return None
 
         try:
@@ -116,7 +124,12 @@ class AuthorizeCache:
         TTL of 0 (disabled via the boolean knob) makes this a no-op;
         callers don't need to gate the call.
         """
-        if not self._settings.backend_authorize_cache_enabled:
+        from eveys_ocpp.runtime_overrides import get_override
+
+        if not get_override(
+            "backend_authorize_cache_enabled",
+            self._settings.backend_authorize_cache_enabled,
+        ):
             return
 
         payload = json.dumps(

--- a/src/eveys_ocpp/runtime_overrides.py
+++ b/src/eveys_ocpp/runtime_overrides.py
@@ -1,0 +1,218 @@
+"""Per-pod runtime overrides for a tightly-scoped set of Settings fields.
+
+`Settings` is frozen (ADR-0001) — env vars are the source of truth and
+most fields are read once at boot, baking the value into a SQLAlchemy
+engine, an aiokafka producer, a TCP socket bind, etc. Mutating those
+at runtime would either be a no-op or a bug.
+
+A small subset of Settings fields **are** read fresh per call site,
+which makes them safe to flip at runtime. This module is the
+in-memory store for those overrides. Read sites that opt in consult
+`get(name, default=settings.foo)` instead of `settings.foo` directly.
+
+**Per-pod scope.** Hitting the admin endpoint on pod A doesn't
+affect pod B. Cluster-wide propagation via Redis pub/sub is a
+future enhancement; for v0 the rolling deploy with a new env value
+is the canonical mechanism for fleet-wide config changes.
+
+**In-memory only.** A pod restart reverts to env. Documented; no
+persistence.
+
+**Thread-safety.** A single `threading.Lock` around the dict is enough
+for the API surface — writes are admin-rate (manual operator action),
+reads are per-request but the GIL plus the lock are cheap. We don't
+use `asyncio.Lock` because some read sites (instrumentation, logging)
+aren't async.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from eveys_ocpp.observability import get_logger
+
+log = get_logger(__name__)
+
+
+# Closed allowlist of fields the admin endpoint will accept on PATCH.
+# Adding a field is a deliberate decision: the call site has to be
+# verified to read fresh on every use, *and* the value has to make
+# sense to flip without a restart. New entries pair with a new
+# `read_setting(...)` call at the matching read site.
+@dataclass(frozen=True, slots=True)
+class _AllowlistEntry:
+    """One allowlisted field plus the validator that coerces an
+    incoming JSON value to the right Python type. Validators keep the
+    REST API tolerant — operators can send `"true"`, `True`, or `1`
+    for a bool — without losing type discipline at the read site.
+    """
+
+    name: str
+    coerce: Callable[[Any], Any]
+    description: str
+
+
+def _coerce_log_level(value: Any) -> str:
+    """Validate against the same Literal as Settings.log_level."""
+    allowed = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
+    if not isinstance(value, str) or value not in allowed:
+        raise ValueError(f"log_level must be one of {sorted(allowed)}; got {value!r}")
+    return value
+
+
+def _coerce_bool(value: Any) -> bool:
+    """Tolerant bool coercion. JSON, form-encoded clients, and
+    operator-typed CLI all produce different shapes; reduce them to
+    one Python bool."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        if value.lower() in ("true", "1", "yes", "on"):
+            return True
+        if value.lower() in ("false", "0", "no", "off"):
+            return False
+    if isinstance(value, int):
+        return bool(value)
+    raise ValueError(f"expected boolean, got {value!r}")
+
+
+# The allowlist itself. See the module docstring for the criteria.
+_ALLOWLIST: dict[str, _AllowlistEntry] = {
+    "log_level": _AllowlistEntry(
+        name="log_level",
+        coerce=_coerce_log_level,
+        description="stdlib logging level applied to every emit.",
+    ),
+    "ws_rate_limit_enabled": _AllowlistEntry(
+        name="ws_rate_limit_enabled",
+        coerce=_coerce_bool,
+        description="Per-charger CALL rate limiter (E5-3) kill-switch.",
+    ),
+    "backend_authorize_cache_enabled": _AllowlistEntry(
+        name="backend_authorize_cache_enabled",
+        coerce=_coerce_bool,
+        description="Per-pod Authorize cache (E3-4) kill-switch.",
+    ),
+}
+
+
+class OverrideNotAllowedError(ValueError):
+    """Raised when an admin write hits a field that isn't in the
+    allowlist. The endpoint translates this into a 400 with a clear
+    error envelope so the operator sees what *is* allowed."""
+
+
+class _RuntimeOverrides:
+    """Single in-process store. Constructed once; the public-module
+    `_singleton` instance is the one read sites and the admin
+    endpoint consult."""
+
+    def __init__(self) -> None:
+        self._values: dict[str, Any] = {}
+        self._lock = threading.Lock()
+
+    def set(self, name: str, value: Any) -> Any:
+        """Validate and store an override. Returns the coerced value
+        actually written so callers can echo it back to the operator.
+
+        Raises `OverrideNotAllowedError` if the field isn't allow-
+        listed, or `ValueError` if the value fails coercion."""
+        entry = _ALLOWLIST.get(name)
+        if entry is None:
+            raise OverrideNotAllowedError(
+                f"{name} is not in the runtime-override allowlist; allowed: {sorted(_ALLOWLIST)}"
+            )
+        coerced = entry.coerce(value)
+        with self._lock:
+            self._values[name] = coerced
+        log.info("runtime_override.set", field=name, value=coerced)
+        return coerced
+
+    def clear(self, name: str) -> bool:
+        """Remove an override. Returns True if a value was removed,
+        False if there wasn't one. Read sites fall back to Settings
+        on the next read."""
+        with self._lock:
+            existed = name in self._values
+            self._values.pop(name, None)
+        if existed:
+            log.info("runtime_override.clear", field=name)
+        return existed
+
+    def get(self, name: str, default: Any) -> Any:
+        """Read site shim. Returns the override if set, otherwise
+        the caller's default (typically `settings.<name>`)."""
+        with self._lock:
+            return self._values.get(name, default)
+
+    def all(self) -> dict[str, Any]:
+        """Snapshot of all currently-set overrides. The admin GET
+        endpoint embeds this in its response. Empty dict means "no
+        overrides; everything reads from Settings."""
+        with self._lock:
+            return dict(self._values)
+
+
+# Module-level singleton. The admin endpoint and any read site that
+# wants override-awareness import this name directly. We don't expose
+# the class itself — there's exactly one store per process.
+_singleton = _RuntimeOverrides()
+
+
+def set_override(name: str, value: Any) -> Any:
+    """Public setter. Wraps the singleton's `set`."""
+    return _singleton.set(name, value)
+
+
+def clear_override(name: str) -> bool:
+    """Public clearer. Wraps the singleton's `clear`."""
+    return _singleton.clear(name)
+
+
+def get_override(name: str, default: Any) -> Any:
+    """Public reader. Wraps the singleton's `get`. Used by code
+    paths that opt in to runtime overrides."""
+    return _singleton.get(name, default)
+
+
+def all_overrides() -> dict[str, Any]:
+    """Snapshot of currently-set overrides. Public for the admin
+    GET endpoint."""
+    return _singleton.all()
+
+
+def allowlist() -> dict[str, str]:
+    """The allowlist as a `{name: description}` map, for the admin
+    endpoint to expose to operators (so a 400 error tells them what
+    *is* allowed)."""
+    return {entry.name: entry.description for entry in _ALLOWLIST.values()}
+
+
+__all__ = [
+    "OverrideNotAllowedError",
+    "all_overrides",
+    "allowlist",
+    "clear_override",
+    "get_override",
+    "set_override",
+]
+
+
+# Test seam — let unit tests reset state between cases without
+# reaching into private internals.
+def _reset_for_tests() -> None:  # pragma: no cover - used by tests only
+    """Clear all overrides. Intended for `pytest` fixtures only."""
+    with _singleton._lock:
+        _singleton._values.clear()
+
+
+# Type stubs for the literal allowlist names — mypy can spot a typo
+# on a `get_override("log_levle", ...)` call site this way.
+AllowlistName = Literal[
+    "log_level",
+    "ws_rate_limit_enabled",
+    "backend_authorize_cache_enabled",
+]

--- a/tests/unit/api/test_admin.py
+++ b/tests/unit/api/test_admin.py
@@ -1,0 +1,186 @@
+"""Tests for the admin runtime-config endpoints (GET / PATCH / DELETE
+under `/api/v1/admin/config`)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import httpx
+import pytest
+
+from eveys_ocpp.runtime_overrides import _reset_for_tests
+
+
+@pytest.fixture(autouse=True)
+def reset_overrides() -> Iterator[None]:
+    """Each test starts and ends with no overrides set so they don't
+    bleed across the suite. The override store is a module-level
+    singleton; tests need this isolation explicitly."""
+    _reset_for_tests()
+    yield
+    _reset_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_get_returns_settings_with_secrets_redacted(
+    client: httpx.AsyncClient,
+) -> None:
+    response = await client.get("/api/v1/admin/config")
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert "settings" in body
+    assert "overrides" in body
+    assert "allowlist" in body
+    assert body["scope"] == "per-pod"
+
+    # SecretStr fields auto-redact in model_dump(mode="json").
+    # The conftest fixture sets `rest_inbound_tokens="test-token-foundation"`;
+    # if that value leaks the redaction is broken.
+    assert "test-token-foundation" not in response.text
+    # The redacted form is what SecretStr emits.
+    assert body["settings"]["rest_inbound_tokens"] == "**********"
+
+    # No overrides initially.
+    assert body["overrides"] == {}
+
+    # Allowlist exposes what PATCH will accept — the operator UI / CLI
+    # uses this to render the right form.
+    assert "log_level" in body["allowlist"]
+    assert "ws_rate_limit_enabled" in body["allowlist"]
+    assert "backend_authorize_cache_enabled" in body["allowlist"]
+
+
+@pytest.mark.asyncio
+async def test_patch_applies_allowlisted_field(
+    client: httpx.AsyncClient,
+) -> None:
+    response = await client.patch(
+        "/api/v1/admin/config",
+        json={"updates": {"log_level": "DEBUG"}},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["applied"] == {"log_level": "DEBUG"}
+    assert body["overrides"] == {"log_level": "DEBUG"}
+
+    # GET reflects the override.
+    follow_up = (await client.get("/api/v1/admin/config")).json()
+    assert follow_up["overrides"] == {"log_level": "DEBUG"}
+
+
+@pytest.mark.asyncio
+async def test_patch_applies_bool_with_tolerant_coercion(
+    client: httpx.AsyncClient,
+) -> None:
+    """Operators send `true` / `"true"` / `1` interchangeably; the
+    coerce layer absorbs the difference so the runtime sees a real
+    bool either way."""
+    response = await client.patch(
+        "/api/v1/admin/config",
+        json={"updates": {"ws_rate_limit_enabled": "false"}},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["applied"] == {"ws_rate_limit_enabled": False}
+
+
+@pytest.mark.asyncio
+async def test_patch_rejects_non_allowlisted_field(
+    client: httpx.AsyncClient,
+) -> None:
+    response = await client.patch(
+        "/api/v1/admin/config",
+        json={"updates": {"db_url": "postgresql://attacker/..."}},
+    )
+
+    assert response.status_code == 400, response.text
+    body = response.json()
+    assert body["error_code"] == "BAD_REQUEST"
+    # The error message tells the operator what *is* allowed.
+    assert "log_level" in body["error"]
+
+
+@pytest.mark.asyncio
+async def test_patch_rejects_invalid_log_level(
+    client: httpx.AsyncClient,
+) -> None:
+    """Coercion rejects values outside the Literal."""
+    response = await client.patch(
+        "/api/v1/admin/config",
+        json={"updates": {"log_level": "VERBOSE"}},
+    )
+
+    assert response.status_code == 400, response.text
+    assert "VERBOSE" in response.json()["error"]
+
+
+@pytest.mark.asyncio
+async def test_patch_with_mixed_allowed_and_rejected_aborts_with_partial(
+    client: httpx.AsyncClient,
+) -> None:
+    """Atomicity isn't promised — applied fields stay applied even if
+    a sibling fails. The error message tells the operator both what
+    landed and what didn't, so they can revert deliberately."""
+    response = await client.patch(
+        "/api/v1/admin/config",
+        json={
+            "updates": {
+                "log_level": "DEBUG",  # allowed
+                "db_url": "postgresql://attacker",  # rejected
+            }
+        },
+    )
+
+    assert response.status_code == 400
+    body = response.json()
+    # The applied field stays in effect — visible via GET.
+    follow_up = (await client.get("/api/v1/admin/config")).json()
+    assert follow_up["overrides"] == {"log_level": "DEBUG"}
+    # The error message names both halves.
+    assert "applied" in body["error"]
+    assert "rejected" in body["error"]
+
+
+@pytest.mark.asyncio
+async def test_patch_with_empty_updates_400s(
+    client: httpx.AsyncClient,
+) -> None:
+    response = await client.patch("/api/v1/admin/config", json={"updates": {}})
+
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_delete_clears_a_single_override(
+    client: httpx.AsyncClient,
+) -> None:
+    # Set then clear.
+    set_response = await client.patch(
+        "/api/v1/admin/config",
+        json={"updates": {"log_level": "DEBUG"}},
+    )
+    assert set_response.status_code == 200
+
+    del_response = await client.delete("/api/v1/admin/config/overrides/log_level")
+    assert del_response.status_code == 200, del_response.text
+    body = del_response.json()
+    assert body["cleared"] is True
+    assert body["overrides"] == {}
+
+    # GET confirms.
+    follow_up = (await client.get("/api/v1/admin/config")).json()
+    assert follow_up["overrides"] == {}
+
+
+@pytest.mark.asyncio
+async def test_delete_on_unset_key_is_idempotent(
+    client: httpx.AsyncClient,
+) -> None:
+    """Clearing a key that was never set returns `cleared: false`
+    rather than 404 — DELETE is idempotent at this layer."""
+    response = await client.delete("/api/v1/admin/config/overrides/log_level")
+
+    assert response.status_code == 200
+    assert response.json()["cleared"] is False


### PR DESCRIPTION
## Why

Operators need (1) a way to inspect the running gateway's effective configuration without shelling into the pod, and (2) a way to flip a small set of runtime kill-switches without a rolling deploy. \`docker exec env | grep EVEYS_OCPP_\` and "wait for the next deploy" aren't great answers when something's on fire.

## Scope

Three endpoints under \`/api/v1/admin/config\`:

| Method | Path | What |
|---|---|---|
| GET    | \`/api/v1/admin/config\` | Full \`Settings\` dump (SecretStr auto-redacts via E5-7) + current overrides + the PATCH allowlist |
| PATCH  | \`/api/v1/admin/config\` | Apply allowlisted overrides; rejects non-allowlisted with 400 |
| DELETE | \`/api/v1/admin/config/overrides/{key}\` | Clear one override; idempotent |

Allowlist for v0 — the three fields whose read sites consult them per call site, not at boot:

| Field | Why allowlisted |
|---|---|
| \`log_level\` | Read on every log emit; \`apply_log_level\` rebinds stdlib level immediately |
| \`ws_rate_limit_enabled\` | One-line check per CALL in \`route_message\` |
| \`backend_authorize_cache_enabled\` | Per-call gate in \`platform/cache.py\` |

## Why per-pod, in-memory only

\`Settings\` is **frozen** (ADR-0001) — env vars are the source of truth. Most fields bind into a SQLAlchemy engine / TCP socket / Kafka producer at boot, so trying to mutate them via REST would either be a no-op or a bug.

The \`RuntimeOverrides\` layer is the smallest abstraction that makes \`get_override(name, settings.foo)\` work at the call sites that benefit. Read sites that haven't opted in still read \`settings.foo\` directly and aren't affected.

**Per-pod scope.** Hitting PATCH on pod A doesn't affect pod B. Documented in every response. Cluster-wide propagation via Redis pub/sub is a future enhancement; for fleet-wide changes, deploy a new env value and roll out — the canonical mechanism.

**In-memory only.** Restart reverts to env. Documented; persistence complicates the multi-pod story.

## What's deliberately out of scope

- Persistence across restarts.
- Cluster-wide override broadcast.
- Mutating boot-bound fields (\`db_url\`, \`ws_port\`, \`kafka_brokers\`, etc.) — never allowlistable.
- A "reset all" endpoint — \`DELETE\` per-key is enough for v0.
- New auth surface — reuses the existing bearer-token middleware on \`/api/v1/*\`.

## Test plan

- [x] 9 new unit tests (GET secrets redacted, PATCH allowed, tolerant bool coercion, non-allowlisted rejected, invalid log level rejected, mixed allowed-rejected partial apply, empty updates 400, DELETE clears, DELETE idempotent)
- [x] \`pytest tests/unit/\` — 620 passed, coverage 82.75%
- [x] \`make lint\` clean
- [x] \`make types\` clean (mypy --strict)
- [x] OpenAPI snapshot regenerated; \`make docs\` clean
- [ ] CI confirms full pipeline green
- [ ] Manual smoke: \`curl -H "Authorization: Bearer ..." -X PATCH localhost:8080/api/v1/admin/config -d '{"updates":{"log_level":"DEBUG"}}'\` against a running compose stack flips logging immediately.

Closes #76