### PR TITLE
chore(compose): pass through REST_OPENAPI_ENABLED + REST_AUTH_DISABLED

### DIFF
--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -171,6 +171,13 @@ services:
       # shell or .env at compose-up time. Empty values disable cleanly
       # (the gateway falls back to its offline policies).
       EVEYS_OCPP_REST_INBOUND_TOKENS: ${EVEYS_OCPP_REST_INBOUND_TOKENS:-}
+      # Dev-only shortcuts for the REST surface. ADR-0026 keeps both off
+      # in production: OPENAPI_ENABLED publishes the schema discovery
+      # surface; AUTH_DISABLED removes bearer-token enforcement. Setting
+      # them in the developer's `.env` is the documented dev path so a
+      # laptop can hit Swagger UI without juggling tokens.
+      EVEYS_OCPP_REST_OPENAPI_ENABLED: ${EVEYS_OCPP_REST_OPENAPI_ENABLED:-false}
+      EVEYS_OCPP_REST_AUTH_DISABLED: ${EVEYS_OCPP_REST_AUTH_DISABLED:-false}
       EVEYS_OCPP_BACKEND_BASE_URL: ${EVEYS_OCPP_BACKEND_BASE_URL:-}
       EVEYS_OCPP_BACKEND_TOKEN: ${EVEYS_OCPP_BACKEND_TOKEN:-}
       EVEYS_OCPP_BACKEND_AUTHORIZE_FALLBACK: ${EVEYS_OCPP_BACKEND_AUTHORIZE_FALLBACK:-reject}


### PR DESCRIPTION
Both env vars are defined in Settings and documented in `.env.example`, but the compose file didn't pass them through. Setting either in a local `.env` had no effect — the gateway container ignored the values.

This adds the standard `${VAR:-default}` passthrough shape. Both default to `false` to keep production posture safe-by-default per ADR-0026.

Once this lands, the dev workflow for Swagger UI is:

```bash
echo 'EVEYS_OCPP_REST_OPENAPI_ENABLED=true' >> .env
echo 'EVEYS_OCPP_REST_AUTH_DISABLED=true' >> .env   # dev-only shortcut
make compose-up
# open http://localhost:8080/api/v1/docs
```

Closes #80