### PR TITLE
docs(make): swagger + swagger-serve targets for static Swagger UI

### DIFF
--- a/docs/15-openapi.md
+++ b/docs/15-openapi.md
@@ -44,6 +44,37 @@ ls docs/api/
 
 CI runs `make openapi-export-check` to fail builds where the committed file drifts from the FastAPI app — same pattern as `config-export-check`.
 
+## Quickstart — static Swagger UI site
+
+A `make` target ships a self-contained Swagger UI site rendered from the committed `docs/api/openapi.json`. No Docker, no compose, no gateway running — just static HTML/CSS/JS you can serve locally or copy to any web host.
+
+```bash
+cd docs
+make swagger          # build static site to docs/_build/swagger/
+make swagger-serve    # build (if needed) + serve on http://localhost:8000
+```
+
+`make swagger-serve` blocks the terminal while the server runs. Stop with `Ctrl+C`. Override the port via `make swagger-serve SWAGGER_PORT=8765` if 8000 is taken.
+
+The output at `docs/_build/swagger/` is a flat directory of HTML/CSS/JS that you can:
+
+- copy to S3 / GitHub Pages / an internal nginx for a persistent URL
+- `rsync` to a server on your LAN
+- open `index.html` directly in a browser (most browsers block `fetch("openapi.json")` from a `file://` URL, so the served path is the reliable option)
+
+The Swagger UI version is pinned in `docs/Makefile` (`SWAGGER_UI_VERSION`); bump it deliberately and re-run `make swagger`.
+
+The spec served here is the **same** `docs/api/openapi.json` that `make openapi-export` regenerates from the live FastAPI app — there's only ever one source of truth.
+
+### When to use which surface
+
+| Surface | When |
+|---|---|
+| `make swagger-serve` (this PR) | Browse the contract without a running gateway. Cheapest UI. |
+| Runtime Swagger UI (`/api/v1/docs` on a running gateway) | Verify *this specific deploy*'s contract — useful when investigating drift between an old build and the latest spec. |
+| `docs/api/openapi.yaml` import to Postman | Generate a request collection for manual testing. |
+| `editor.swagger.io` paste | Quick view from any laptop without cloning the repo. |
+
 ## What's in the spec
 
 - **All 28 routes** under `/api/v1/`: health, charge-points (list + detail), transactions (list + detail), reservations, charging-profiles, time-series (meter-values + status-history), and 19 commands.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -13,14 +13,25 @@ VENV_PY       = $(VENV)/bin/python
 VENV_PIP      = $(VENV)/bin/pip
 SPHINXBUILD   = $(VENV)/bin/sphinx-build
 
-.PHONY: help html clean install venv
+.PHONY: help html clean install venv swagger swagger-serve
+
+# Swagger UI dist — pinned to a known-good release. Update by bumping
+# the version + the SHA below; CI's docs job catches a download
+# regression because make-html doesn't build past a missing tarball.
+SWAGGER_UI_VERSION ?= 5.20.0
+SWAGGER_UI_TARBALL = swagger-ui-$(SWAGGER_UI_VERSION).tar.gz
+SWAGGER_UI_URL     = https://github.com/swagger-api/swagger-ui/archive/refs/tags/v$(SWAGGER_UI_VERSION).tar.gz
+SWAGGER_OUT        = $(BUILDDIR)/swagger
+SWAGGER_PORT      ?= 8000
 
 help:
 	@echo "Targets:"
-	@echo "  make install   create $(VENV)/ and install Sphinx + extensions"
-	@echo "  make html      build the HTML site into $(BUILDDIR)/html"
-	@echo "  make clean     remove $(BUILDDIR)/"
-	@echo "  make distclean remove $(BUILDDIR)/ and $(VENV)/"
+	@echo "  make install        create $(VENV)/ and install Sphinx + extensions"
+	@echo "  make html           build the HTML site into $(BUILDDIR)/html"
+	@echo "  make swagger        build a static Swagger UI into $(SWAGGER_OUT)/"
+	@echo "  make swagger-serve  build (if needed) + serve on http://localhost:$(SWAGGER_PORT)"
+	@echo "  make clean          remove $(BUILDDIR)/"
+	@echo "  make distclean      remove $(BUILDDIR)/ and $(VENV)/"
 
 $(VENV)/bin/activate:
 	@if [ -z "$(PYTHON)" ]; then \
@@ -45,3 +56,73 @@ clean:
 
 distclean: clean
 	rm -rf "$(VENV)"
+
+# ---- Swagger UI -------------------------------------------------------------
+# Renders the committed OpenAPI spec (api/openapi.json) as a static
+# Swagger UI site at $(SWAGGER_OUT)/index.html. No Node.js, no Python
+# deps — just curl + tar to fetch the swagger-ui-dist release tarball,
+# then a thin index.html that points the bundle at openapi.json.
+#
+# The result is a self-contained directory you can:
+#   - serve locally via `make swagger-serve`
+#   - copy to any web host (S3, GitHub Pages, an internal nginx)
+#   - rsync to a server on your LAN
+#
+# OPTION-NOTE: this target deliberately does NOT depend on `install`.
+# Sphinx + the docs venv are unrelated — Swagger UI is plain HTML/JS.
+# Keeping the dependency narrow means a fresh clone can `make swagger`
+# without paying the Sphinx install cost.
+
+swagger: $(SWAGGER_OUT)/index.html
+
+$(SWAGGER_OUT)/index.html: api/openapi.json
+	@mkdir -p "$(SWAGGER_OUT)"
+	@if [ ! -d "$(BUILDDIR)/_swagger-ui-src" ]; then \
+		echo "Fetching swagger-ui $(SWAGGER_UI_VERSION)..."; \
+		mkdir -p "$(BUILDDIR)/_swagger-ui-src"; \
+		curl -fsSL "$(SWAGGER_UI_URL)" \
+			| tar -xz --strip-components=1 -C "$(BUILDDIR)/_swagger-ui-src"; \
+	fi
+	@echo "Assembling static site at $(SWAGGER_OUT)/"
+	@cp "$(BUILDDIR)/_swagger-ui-src/dist/"*.{js,css,png,html} "$(SWAGGER_OUT)/" 2>/dev/null || true
+	@cp api/openapi.json "$(SWAGGER_OUT)/openapi.json"
+	@# Overwrite the bundle's stock index.html with a version that points
+	@# at our spec. The stock index.html points at petstore.swagger.io.
+	@printf '%s\n' \
+		'<!doctype html>' \
+		'<html lang="en">' \
+		'<head>' \
+		'  <meta charset="utf-8" />' \
+		'  <title>eveys/ocpp — REST API</title>' \
+		'  <link rel="stylesheet" href="swagger-ui.css" />' \
+		'  <link rel="icon" type="image/png" href="favicon-32x32.png" sizes="32x32" />' \
+		'  <link rel="icon" type="image/png" href="favicon-16x16.png" sizes="16x16" />' \
+		'</head>' \
+		'<body>' \
+		'  <div id="swagger-ui"></div>' \
+		'  <script src="swagger-ui-bundle.js" charset="UTF-8"></script>' \
+		'  <script src="swagger-ui-standalone-preset.js" charset="UTF-8"></script>' \
+		'  <script>' \
+		'    window.onload = () => {' \
+		'      window.ui = SwaggerUIBundle({' \
+		'        url: "openapi.json",' \
+		'        dom_id: "#swagger-ui",' \
+		'        deepLinking: true,' \
+		'        presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],' \
+		'        layout: "StandaloneLayout"' \
+		'      });' \
+		'    };' \
+		'  </script>' \
+		'</body>' \
+		'</html>' \
+		> "$(SWAGGER_OUT)/index.html"
+	@echo "Built: $(SWAGGER_OUT)/index.html"
+
+swagger-serve: swagger
+	@echo "Serving Swagger UI at http://localhost:$(SWAGGER_PORT)/"
+	@echo "Stop with Ctrl+C."
+	@if [ -n "$(PYTHON)" ]; then \
+		$(PYTHON) -m http.server $(SWAGGER_PORT) --bind 0.0.0.0 --directory $(SWAGGER_OUT); \
+	else \
+		python3 -m http.server $(SWAGGER_PORT) --bind 0.0.0.0 --directory $(SWAGGER_OUT); \
+	fi


### PR DESCRIPTION
## Why

Operators and integrators want to browse the gateway's REST contract without spinning up the full compose stack + flipping \`OPENAPI_ENABLED\`. The committed \`docs/api/openapi.json\` is readable but has no UI; \`editor.swagger.io\` works but is an external dependency.

This adds a \`make swagger\` / \`make swagger-serve\` flow analogous to \`make html\` — static site, no gateway, no Docker.

## Workflow

\`\`\`bash
cd docs
make swagger          # build static site at docs/_build/swagger/
make swagger-serve    # build + serve on http://localhost:8000
# override the port if 8000 is taken:
make swagger-serve SWAGGER_PORT=8765
\`\`\`

Output at \`docs/_build/swagger/\` is plain HTML/CSS/JS; copy to S3, GitHub Pages, an internal nginx, or rsync to a LAN server for a persistent URL.

## What's in the build

- Swagger UI dist (pinned to v\`5.20.0\`, downloaded via \`curl\` from the official GitHub release).
- The committed \`docs/api/openapi.json\` copied as the spec.
- A thin \`index.html\` that points the bundle at \`openapi.json\` (overrides the stock index that points at petstore.swagger.io).

## Why pinned + curl, not npm

- No Node.js runtime requirement (matches the rest of the docs build — Sphinx + venv only).
- Pinned version makes spec-UI compatibility deliberate; bumps go through review.
- The existing \`make html\` target stays unaffected — Swagger has its own narrow target chain.

## Test plan

- [x] \`make swagger\` produces \`docs/_build/swagger/index.html\` + the bundle files
- [x] \`make swagger-serve\` serves on the configured port; \`curl http://localhost:8765/openapi.json\` returns the spec
- [x] Sphinx \`make html\` still clean (the new target doesn't break the existing toctree)
- [x] \`docs/_build/\` already gitignored — no risk of accidentally committing the build output

Closes #82