### PR TITLE
fix(api): bypass auth for /api/v1/docs (Swagger UI)

### DIFF
--- a/docs/14-slos.md
+++ b/docs/14-slos.md
@@ -153,7 +153,6 @@ Not a separate SLO (the failure mode rolls up into SLO 1 — a refused charger b
 
 - **Alerting on SLO breach.** Alertmanager + paging integration is its own task — deferred until on-call is staffed (Phase 7). The dashboard panels go yellow/red on breach but nothing pages.
 - **SLAs (the customer-facing version).** SLAs have contractual teeth and a different audience. Different document, different review path.
-- **Per-tenant SLO slicing.** All five SLOs are fleet-wide; there's no tenant dimension. Phase 6+ work if multi-tenant isolation lands.
 
 ## Loading the recording rules
 

--- a/docs/17-sizing.md
+++ b/docs/17-sizing.md
@@ -137,7 +137,7 @@ peak, with (1) as the always-on baseline.
 ## Per-component memory budget at 1000 CP
 
 This is the all-in steady-state RAM budget when every component
-runs on the same host (the "co-tenant" shape — what 1-node and the
+runs on the same host (the "co-located" shape — what 1-node and the
 data-plane node of 2-node and 3-node configs all use).
 
 | Component | RAM | Notes |
@@ -203,7 +203,7 @@ random-IO-bound at peak.
 
 For 500–1000 CP on the same LAN: **1 GbE is sufficient**. Peak
 inter-node traffic is ClickHouse + Kafka replication; in a 3-node
-co-tenant shape the cross-node bandwidth tops out around 50 Mbps
+co-located shape the cross-node bandwidth tops out around 50 Mbps
 under a heavy storm. **2.5 GbE or 10 GbE** is over-spec'd for the
 fleet size but cheap insurance against a hot follow-up workload
 (a sibling service that wants to consume Kafka at line rate).

--- a/src/eveys_ocpp/api/_auth.py
+++ b/src/eveys_ocpp/api/_auth.py
@@ -16,9 +16,18 @@ Three modes:
 3. `rest_auth_disabled=False` AND allowlist non-empty → exact-match
    the bearer against the parsed list.
 
-`/api/v1/health` is the one endpoint that bypasses auth (it's a probe;
-the operator's load balancer needs it to dial the pod regardless of
+`/api/v1/health` and `/api/v1/ready` bypass auth (probes; the
+operator's load balancer needs them to dial the pod regardless of
 token configuration).
+
+When `rest_openapi_enabled=True` (dev / staging / behind a VPN),
+the docs surface (`/api/v1/docs`, `/api/v1/redoc`,
+`/api/v1/openapi.json`) also bypasses auth so an operator can
+load the Swagger / ReDoc UI in a browser without first injecting
+a token. The actual API endpoints exposed below those UIs still
+require a token — only the schema fetch and the static UI bundle
+are open. Production keeps `rest_openapi_enabled=False`, which
+makes the bypass moot (the routes don't exist).
 """
 
 from __future__ import annotations
@@ -44,6 +53,13 @@ _BEARER_PREFIX = "Bearer "
 # raw URL — the routers are added under the `/api/v1` prefix.
 _AUTH_BYPASS_PATHS = frozenset({"/api/v1/health", "/api/v1/ready"})
 
+# Additional bypass paths only enabled when `rest_openapi_enabled=True`
+# (dev / staging). The Swagger / ReDoc UIs are static HTML + a JSON
+# spec fetch — neither leaks runtime data, and forcing a token to load
+# the UI itself is hostile UX. The protected API endpoints below the
+# UI still require a token via the standard middleware path.
+_OPENAPI_BYPASS_PATHS = frozenset({"/api/v1/docs", "/api/v1/redoc", "/api/v1/openapi.json"})
+
 
 def parse_token_allowlist(raw: str) -> set[str]:
     """Turn a CSV `rest_inbound_tokens` value into a deduped set of
@@ -65,6 +81,7 @@ def make_bearer_auth_middleware(
     # closure, never in a Settings dump.
     allowlist = parse_token_allowlist(settings.rest_inbound_tokens.get_secret_value())
     auth_disabled = settings.rest_auth_disabled
+    openapi_enabled = settings.rest_openapi_enabled
 
     if auth_disabled:
         log.warning(
@@ -81,7 +98,10 @@ def make_bearer_auth_middleware(
         request: Request,
         call_next: Callable[[Request], Awaitable[JSONResponse]],
     ) -> JSONResponse:
-        if auth_disabled or request.url.path in _AUTH_BYPASS_PATHS:
+        path = request.url.path
+        if auth_disabled or path in _AUTH_BYPASS_PATHS:
+            return await call_next(request)
+        if openapi_enabled and path in _OPENAPI_BYPASS_PATHS:
             return await call_next(request)
 
         header = request.headers.get("authorization", "")

--- a/tests/unit/api/test_auth.py
+++ b/tests/unit/api/test_auth.py
@@ -152,6 +152,38 @@ async def test_health_bypasses_auth(app_with_settings: Any) -> None:
 
 
 @pytest.mark.asyncio
+async def test_openapi_paths_bypass_auth_when_enabled(
+    app_with_settings: Any,
+) -> None:
+    """Swagger UI + ReDoc + the spec itself must load without a token
+    when `rest_openapi_enabled=True`. Loading the docs page is hostile
+    UX otherwise — and the spec leaks no runtime data, only schema.
+    The actual API endpoints below the UI still require a token."""
+    client = await app_with_settings(rest_openapi_enabled=True, rest_inbound_tokens="secret")
+
+    for path in ("/api/v1/docs", "/api/v1/redoc", "/api/v1/openapi.json"):
+        response = await client.get(path)
+        assert response.status_code == 200, f"path={path}"
+
+    # And the actual API still requires a token.
+    rejected = await client.get("/api/v1/charge-points")
+    assert rejected.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_openapi_paths_404_when_disabled(app_with_settings: Any) -> None:
+    """With `rest_openapi_enabled=False` (production default) the docs
+    routes don't exist at all — the bypass is moot."""
+    client = await app_with_settings(rest_inbound_tokens="secret")
+
+    response = await client.get("/api/v1/docs")
+    # Either 404 (route doesn't exist) or 401 (caught by middleware
+    # before the not-found check) is acceptable as long as the docs
+    # surface isn't actually served.
+    assert response.status_code in (401, 404)
+
+
+@pytest.mark.asyncio
 async def test_csv_allowlist_rotation(app_with_settings: Any) -> None:
     """Multi-token allowlist supports rotation."""
     client = await app_with_settings(rest_inbound_tokens="t1,t2,t3")


### PR DESCRIPTION
## Summary

- Bypass the bearer-token middleware for the three OpenAPI surface paths (\`/api/v1/docs\`, \`/api/v1/redoc\`, \`/api/v1/openapi.json\`) when \`rest_openapi_enabled=True\`. Loading the Swagger UI in a browser was returning 401 because the browser doesn't send an Authorization header on the bare URL fetch.
- The runtime API endpoints below the UI still require a token. The spec is schema-only (no runtime data); production keeps the toggle off, which makes the bypass moot.
- Drops a couple of leftover \"tenant\" / \"co-tenant\" wordings in \`docs/14-slos.md\` and \`docs/17-sizing.md\` to align with the no-multi-tenant direction.

## Test plan

- [x] \`make lint\` clean
- [x] \`make types\` clean
- [x] \`make test\` (641 passed, 83% coverage)
- [x] Two new middleware tests: docs paths load without a token, runtime endpoint still 401s; with the toggle off the docs paths return 401/404.
- [ ] Manual: \`EVEYS_OCPP_REST_OPENAPI_ENABLED=True make compose-up\` → load \`http://localhost:8080/api/v1/docs\` in a browser, confirm Swagger UI renders.

Closes #88