### PR TITLE
feature(api): swagger UI default-on in compose + get-token + bearerAuth in spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ COMPOSE    := docker compose -f deploy/compose/docker-compose.yml $(COMPOSE_ENV)
 .PHONY: help doctor install format lint types tests e2e smoke compose-smoke precommit clean distclean \
         compose-up compose-down compose-status compose-down-volumes compose-wait \
         build-image protoc ch-migrate docs docs-clean config-export config-export-check config-schema \
-        openapi-export openapi-export-check audit
+        openapi-export openapi-export-check audit get-token
 
 # ---- meta -------------------------------------------------------------------
 
@@ -46,6 +46,7 @@ help:
 	@echo "  make ch-migrate         apply ClickHouse migrations (E2-13, ADR-0020)"
 	@echo "  make e2e                full e2e: compose-up + alembic + ch-migrate + e2e tests + compose-down"
 	@echo "  make compose-smoke      Tier-3 smoke: build image + bring real compose stack up + assert it stays up + drive a charger flow (see ADR-0024)"
+	@echo "  make get-token          print a bearer token from EVEYS_OCPP_REST_INBOUND_TOKENS (paste into Swagger UI Authorize)"
 	@echo ""
 	@echo "Docs:"
 	@echo "  make docs               build the docs site (Sphinx + MyST)"
@@ -148,6 +149,25 @@ compose-up:
 	$(COMPOSE) up -d
 	@echo ""
 	@echo "Stack starting. Use 'make compose-status' to watch health."
+
+# Print a bearer token an operator can paste into the Swagger UI's
+# "Authorize" dialog. Reads from the shell env first, then falls back
+# to the repo-root `.env` file (the documented dev path). The
+# allowlist is CSV; we print the first entry.
+#
+# Quiet target — `@` on every line so the output is just the token,
+# safe to pipe into pbcopy / xclip.
+get-token:
+	@token="$$EVEYS_OCPP_REST_INBOUND_TOKENS"; \
+	if [ -z "$$token" ] && [ -f .env ]; then \
+	  token=$$(grep -E '^EVEYS_OCPP_REST_INBOUND_TOKENS=' .env | head -n1 | cut -d= -f2- | tr -d '"' | tr -d "'"); \
+	fi; \
+	if [ -z "$$token" ]; then \
+	  echo "ERROR: EVEYS_OCPP_REST_INBOUND_TOKENS is not set in shell env or .env" >&2; \
+	  echo "       Add a value to .env (e.g. EVEYS_OCPP_REST_INBOUND_TOKENS=dev-token) and re-run." >&2; \
+	  exit 1; \
+	fi; \
+	echo "$$token" | cut -d, -f1
 
 compose-down:
 	$(COMPOSE) down

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -171,12 +171,16 @@ services:
       # shell or .env at compose-up time. Empty values disable cleanly
       # (the gateway falls back to its offline policies).
       EVEYS_OCPP_REST_INBOUND_TOKENS: ${EVEYS_OCPP_REST_INBOUND_TOKENS:-}
-      # Dev-only shortcuts for the REST surface. ADR-0026 keeps both off
-      # in production: OPENAPI_ENABLED publishes the schema discovery
-      # surface; AUTH_DISABLED removes bearer-token enforcement. Setting
-      # them in the developer's `.env` is the documented dev path so a
-      # laptop can hit Swagger UI without juggling tokens.
-      EVEYS_OCPP_REST_OPENAPI_ENABLED: ${EVEYS_OCPP_REST_OPENAPI_ENABLED:-false}
+      # Dev-only shortcuts for the REST surface. ADR-0026 keeps both
+      # OFF in production: OPENAPI_ENABLED publishes the schema
+      # discovery surface; AUTH_DISABLED removes bearer-token
+      # enforcement. The COMPOSE default for OPENAPI_ENABLED is `true`
+      # so a fresh `make compose-up` already serves Swagger UI at
+      # `/api/v1/docs` — the production posture is governed by Helm /
+      # k8s, not this file. AUTH_DISABLED stays `false`: keep the
+      # bearer-token path exercised in dev (Swagger UI's "Authorize"
+      # button is the documented dev-laptop UX; see `make get-token`).
+      EVEYS_OCPP_REST_OPENAPI_ENABLED: ${EVEYS_OCPP_REST_OPENAPI_ENABLED:-true}
       EVEYS_OCPP_REST_AUTH_DISABLED: ${EVEYS_OCPP_REST_AUTH_DISABLED:-false}
       EVEYS_OCPP_BACKEND_BASE_URL: ${EVEYS_OCPP_BACKEND_BASE_URL:-}
       EVEYS_OCPP_BACKEND_TOKEN: ${EVEYS_OCPP_BACKEND_TOKEN:-}

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1247,6 +1247,13 @@
         "title": "ValidationError",
         "type": "object"
       }
+    },
+    "securitySchemes": {
+      "bearerAuth": {
+        "description": "Static bearer token from `EVEYS_OCPP_REST_INBOUND_TOKENS` (CSV allowlist). Run `make get-token` to print one from your local env.",
+        "scheme": "bearer",
+        "type": "http"
+      }
     }
   },
   "info": {
@@ -3239,5 +3246,10 @@
         ]
       }
     }
-  }
+  },
+  "security": [
+    {
+      "bearerAuth": []
+    }
+  ]
 }

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -834,6 +834,12 @@ components:
       - type
       title: ValidationError
       type: object
+  securitySchemes:
+    bearerAuth:
+      description: Static bearer token from `EVEYS_OCPP_REST_INBOUND_TOKENS` (CSV
+        allowlist). Run `make get-token` to print one from your local env.
+      scheme: bearer
+      type: http
 info:
   description: Inbound REST surface (E3-7 / E3-8). Backend services read charger and
     transaction state under `/api/v1/charge-points`, `/api/v1/transactions`, etc.,
@@ -2085,3 +2091,5 @@ paths:
       summary: Single-transaction detail
       tags:
       - transactions
+security:
+- bearerAuth: []

--- a/src/eveys_ocpp/api/_app.py
+++ b/src/eveys_ocpp/api/_app.py
@@ -197,7 +197,9 @@ def make_app(
 
 def _install_extra_schemas(app: FastAPI) -> None:
     """Inject request models referenced via `openapi_extra` into the
-    generated spec's `components.schemas` so the `$ref`s resolve.
+    generated spec's `components.schemas` so the `$ref`s resolve, and
+    declare the bearer-token security scheme so Swagger UI's
+    "Authorize" button is wired up.
 
     See the comment at the call site in `make_app` for the why. Wraps
     `app.openapi` so the spec is computed lazily on first read but the
@@ -222,6 +224,24 @@ def _install_extra_schemas(app: FastAPI) -> None:
                 schemas[model.__name__] = model.model_json_schema(
                     ref_template="#/components/schemas/{model}"
                 )
+        # Declare the bearer scheme + apply globally so Swagger UI
+        # shows the Authorize 🔒 button and reuses the token across
+        # every "Try it out" call. The middleware still does the real
+        # enforcement; this only teaches the spec how to ask.
+        security_schemes = components.setdefault("securitySchemes", {})
+        security_schemes.setdefault(
+            "bearerAuth",
+            {
+                "type": "http",
+                "scheme": "bearer",
+                "description": (
+                    "Static bearer token from `EVEYS_OCPP_REST_INBOUND_TOKENS` "
+                    "(CSV allowlist). Run `make get-token` to print one from "
+                    "your local env."
+                ),
+            },
+        )
+        spec.setdefault("security", [{"bearerAuth": []}])
         return spec
 
     app.openapi = custom_openapi  # type: ignore[method-assign]


### PR DESCRIPTION
## Summary

Three coordinated dev-UX improvements so a fresh \`make compose-up\` lands you in a working Swagger UI in three steps: open the URL, run \`make get-token\` to copy the token, paste into Authorize.

- **Compose default ON** — \`EVEYS_OCPP_REST_OPENAPI_ENABLED\` defaults to \`true\` in \`deploy/compose/docker-compose.yml\`. Production posture (\`Settings.rest_openapi_enabled = False\` + Helm/k8s) is unchanged; this only affects the local compose stack.
- **\`make get-token\`** — reads the bearer allowlist from the shell env first, then falls back to repo-root \`.env\`. Prints the first CSV entry. Fails loud if neither is set, with a hint about \`.env\`.
- **bearerAuth in the OpenAPI spec** — extends \`_install_extra_schemas\` to declare \`securitySchemes.bearerAuth\` (\`http\` / \`bearer\`) and a global \`security: [{bearerAuth: []}]\`. Swagger UI now renders the Authorize 🔒 button and reuses the token across every "Try it out" call. \`docs/api/openapi.{json,yaml}\` regenerated via \`make openapi-export\`.

## Test plan

- [x] \`make lint\` clean
- [x] \`make types\` clean
- [x] \`make test\` (641 passed, 83% coverage)
- [x] \`make get-token\` prints the token from \`.env\`
- [x] \`make openapi-export\` regenerated; spec carries \`securitySchemes.bearerAuth\` + global \`security\`
- [x] Manual: \`make compose-down && make build-image && make compose-up\` →
  - \`http://localhost:8080/api/v1/docs\` → 200, Swagger UI renders
  - Click Authorize, paste \`make get-token\` output, Try it out on \`/api/v1/charge-points\` → 200
  - Same endpoint without the Authorize → 401

Closes #90