### PR TITLE
fix(clickhouse): use asynch's {name} placeholder shape in read client

### DIFF
--- a/src/eveys_ocpp/clickhouse/read_client.py
+++ b/src/eveys_ocpp/clickhouse/read_client.py
@@ -78,6 +78,10 @@ class ClickHouseReadClient:
 
         # ARRAY JOIN flattens the Nested column; the route caller pages
         # with `limit + 1` for next-page detection.
+        #
+        # `asynch` substitutes via `query.format(**escape_params(params))`,
+        # so placeholders are `{name}` — NOT the DB-API `%(name)s` shape.
+        # See `fetch_latest_connector_statuses` for the same convention.
         sql = """
             SELECT
                 event_id,
@@ -95,9 +99,9 @@ class ClickHouseReadClient:
                 sv.unit AS unit
             FROM cp_meter
             ARRAY JOIN sampled_values AS sv
-            WHERE cp_id = %(cp_id)s
-              AND occurred_at >= %(from_ts)s
-              AND occurred_at <= %(to_ts)s
+            WHERE cp_id = {cp_id}
+              AND occurred_at >= {from_ts}
+              AND occurred_at <= {to_ts}
         """
         params: dict[str, Any] = {
             "cp_id": cp_id,
@@ -105,12 +109,12 @@ class ClickHouseReadClient:
             "to_ts": started_to,
         }
         if connector_id is not None:
-            sql += " AND connector_id = %(connector_id)s"
+            sql += " AND connector_id = {connector_id}"
             params["connector_id"] = connector_id
         if measurand is not None:
-            sql += " AND measurand = %(measurand)s"
+            sql += " AND measurand = {measurand}"
             params["measurand"] = measurand
-        sql += " ORDER BY occurred_at, event_id LIMIT %(limit)s"
+        sql += " ORDER BY occurred_at, event_id LIMIT {limit}"
         params["limit"] = limit
 
         async with self._conn.cursor() as cursor:
@@ -196,6 +200,10 @@ class ClickHouseReadClient:
         [from, to]. One row per transition (no ARRAY JOIN needed)."""
         assert self._conn is not None  # narrowed by start()
 
+        # Same `{name}` placeholder convention as `fetch_meter_values` /
+        # `fetch_latest_connector_statuses` — `asynch` uses
+        # `query.format(**escape_params(params))`, not DB-API
+        # `%(name)s`.
         sql = """
             SELECT
                 event_id,
@@ -209,9 +217,9 @@ class ClickHouseReadClient:
                 vendor_error_code,
                 charger_reported_at
             FROM cp_status
-            WHERE cp_id = %(cp_id)s
-              AND occurred_at >= %(from_ts)s
-              AND occurred_at <= %(to_ts)s
+            WHERE cp_id = {cp_id}
+              AND occurred_at >= {from_ts}
+              AND occurred_at <= {to_ts}
         """
         params: dict[str, Any] = {
             "cp_id": cp_id,
@@ -219,9 +227,9 @@ class ClickHouseReadClient:
             "to_ts": started_to,
         }
         if connector_id is not None:
-            sql += " AND connector_id = %(connector_id)s"
+            sql += " AND connector_id = {connector_id}"
             params["connector_id"] = connector_id
-        sql += " ORDER BY occurred_at, event_id LIMIT %(limit)s"
+        sql += " ORDER BY occurred_at, event_id LIMIT {limit}"
         params["limit"] = limit
 
         async with self._conn.cursor() as cursor:

--- a/tests/unit/test_clickhouse_read_client.py
+++ b/tests/unit/test_clickhouse_read_client.py
@@ -1,0 +1,143 @@
+"""Read-client unit tests — placeholder shape sanity (issue #92).
+
+The route-layer tests mock the client wholesale, so they never see
+the SQL. That left a real bug in production: `asynch` substitutes
+parameters via `query.format(**escape_params(params))` — i.e. Python
+`str.format` `{name}` placeholders, NOT the DB-API `%(name)s`
+paramstyle. The two read methods used `%(name)s` and got 500s on
+every real call (ClickHouse parses the literal `%`).
+
+These tests stub the cursor at the boundary and assert the SQL we
+*hand* to the server is well-formed under `asynch`'s substitution
+rules — catches the regression at unit-test speed without booting
+ClickHouse.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from asynch.proto.utils.escape import escape_params
+
+from eveys_ocpp.clickhouse.read_client import ClickHouseReadClient
+
+
+def _client_with_fake_cursor() -> tuple[ClickHouseReadClient, MagicMock]:
+    """Build a client whose `Connection.cursor()` yields an
+    AsyncMock cursor. Tests inspect `cursor.execute.await_args` to
+    see the SQL + params actually sent."""
+
+    class _FakeSettings:
+        clickhouse_host = "ch"
+        clickhouse_port = 9000
+        clickhouse_db = "events"
+
+    cursor = MagicMock()
+    cursor.execute = AsyncMock()
+    cursor.fetchall = AsyncMock(return_value=[])
+    cursor.description = []
+    cursor.__aenter__ = AsyncMock(return_value=cursor)
+    cursor.__aexit__ = AsyncMock(return_value=None)
+
+    conn = MagicMock()
+    conn.cursor = MagicMock(return_value=cursor)
+
+    client = ClickHouseReadClient(_FakeSettings())  # type: ignore[arg-type]
+    client._conn = conn  # type: ignore[attr-defined]
+    return client, cursor
+
+
+def _substitute(sql: str, params: dict[str, Any]) -> str:
+    """Apply `asynch`'s exact substitution path — fails loud if the
+    SQL has the wrong placeholder shape."""
+    return sql.format(**escape_params(params))
+
+
+@pytest.mark.asyncio
+async def test_fetch_meter_values_uses_asynch_placeholder_shape() -> None:
+    client, cursor = _client_with_fake_cursor()
+
+    await client.fetch_meter_values(
+        cp_id="CP_42",
+        started_from=datetime(2026, 5, 1, tzinfo=UTC),
+        started_to=datetime(2026, 5, 8, tzinfo=UTC),
+        connector_id=1,
+        measurand="Energy.Active.Import.Register",
+        limit=1000,
+    )
+
+    sql, params = cursor.execute.await_args.args
+    # The SQL must round-trip through asynch's `str.format` substitution
+    # cleanly. If a `%(name)s` slipped back in, this raises KeyError /
+    # IndexError on the format call — which is exactly the bug.
+    rendered = _substitute(sql, params)
+    assert "'CP_42'" in rendered
+    assert "'2026-05-01 00:00:00'" in rendered
+    assert "connector_id = 1" in rendered
+    assert "measurand = 'Energy.Active.Import.Register'" in rendered
+    assert "LIMIT 1000" in rendered
+    assert "%(" not in rendered  # no DB-API placeholders should leak
+
+
+@pytest.mark.asyncio
+async def test_fetch_meter_values_skips_optional_filters_when_none() -> None:
+    client, cursor = _client_with_fake_cursor()
+
+    await client.fetch_meter_values(
+        cp_id="CP_42",
+        started_from=datetime(2026, 5, 1, tzinfo=UTC),
+        started_to=datetime(2026, 5, 8, tzinfo=UTC),
+        connector_id=None,
+        measurand=None,
+        limit=500,
+    )
+
+    sql, params = cursor.execute.await_args.args
+    rendered = _substitute(sql, params)
+    # `connector_id` and `measurand` are selected columns, so they
+    # show up in the SELECT list. What we care about is that no
+    # optional WHERE filter was added.
+    assert "AND connector_id =" not in rendered
+    assert "AND measurand =" not in rendered
+    assert "LIMIT 500" in rendered
+
+
+@pytest.mark.asyncio
+async def test_fetch_status_history_uses_asynch_placeholder_shape() -> None:
+    client, cursor = _client_with_fake_cursor()
+
+    await client.fetch_status_history(
+        cp_id="CP_42",
+        started_from=datetime(2026, 5, 1, tzinfo=UTC),
+        started_to=datetime(2026, 5, 8, tzinfo=UTC),
+        connector_id=2,
+        limit=1000,
+    )
+
+    sql, params = cursor.execute.await_args.args
+    rendered = _substitute(sql, params)
+    assert "'CP_42'" in rendered
+    assert "connector_id = 2" in rendered
+    assert "LIMIT 1000" in rendered
+    assert "%(" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_fetch_latest_connector_statuses_uses_asynch_placeholder_shape() -> None:
+    """The third read method already used `{name}` correctly — pin it
+    so a future refactor doesn't regress it the way the other two
+    drifted."""
+    client, cursor = _client_with_fake_cursor()
+    cursor.fetchall = AsyncMock(return_value=[])
+    cursor.description = []
+
+    await client.fetch_latest_connector_statuses(cp_ids=["CP_A", "CP_B"])
+
+    sql, params = cursor.execute.await_args.args
+    rendered = _substitute(sql, params)
+    assert "'CP_A'" in rendered
+    assert "'CP_B'" in rendered
+    assert "%(" not in rendered


### PR DESCRIPTION
## Summary

- The two broken read methods (\`fetch_meter_values\`, \`fetch_status_history\`) used the DB-API \`%(name)s\` paramstyle. \`asynch\` substitutes via \`str.format\`, which passes that through verbatim — ClickHouse then 500s on the literal \`%\`. Switched both to \`{name}\` to match the third method (\`fetch_latest_connector_statuses\`) and \`asynch\`'s actual contract.
- Added four unit tests for \`read_client.py\` (none existed) that pin the placeholder shape at the cursor boundary. They render the SQL through \`asynch\`'s exact substitution path and assert no \`%(\` leaks — a future regression would fail loud.
- Verified live against the running compose stack: both \`/meter-values\` and \`/status-history\` now return 200 with the user's exact \`from\`/\`to\` query (date-only and full-ISO forms both work).

## Test plan

- [x] \`make lint\` clean
- [x] \`make types\` clean
- [x] \`make test\` (645 passed, 84.3% coverage)
- [x] Live curl (compose stack):
  - \`GET .../status-history?from=2026-05-01T00:00:00&to=2026-05-08T00:00:00\` → 200, returns transitions
  - \`GET .../meter-values?from=2026-05-04&to=2026-05-08\` → 200, returns \`{\"meter_values\":[]}\` (no rows in window)

Closes #92