### PR TITLE
feature(grafana): per-charger drill-down dashboard, ClickHouse-backed

### DIFF
--- a/deploy/grafana/README.md
+++ b/deploy/grafana/README.md
@@ -1,26 +1,38 @@
 # Grafana provisioning
 
-Five dashboards covering the gateway's `eveys_ocpp_*` metrics, plus a
-Prometheus datasource provisioning file. These ship as deploy artifacts
-— the gateway's compose stack does not run Grafana itself; you mount
-these files into your own Grafana instance.
+Six dashboards covering the gateway's `eveys_ocpp_*` metrics + the
+per-charger event tables in ClickHouse, plus Prometheus + ClickHouse
+datasource provisioning files. These ship as deploy artifacts — the
+gateway's compose stack does not run Grafana itself; you mount these
+files into your own Grafana instance.
 
 ## What's here
 
 | File | Purpose |
 | --- | --- |
 | `provisioning/datasources/prometheus.yml` | Default Prometheus datasource (URL via `${PROMETHEUS_URL}`, defaults to `http://prometheus:9090`) |
+| `provisioning/datasources/clickhouse.yml` | ClickHouse datasource for the per-charger dashboard. Plugin: `grafana-clickhouse-datasource`. URL via `${CLICKHOUSE_HOST}` / `${CLICKHOUSE_PORT}` (default `clickhouse:9000`). |
 | `provisioning/dashboards/eveys.yml` | Auto-loads dashboards from `/var/lib/grafana/dashboards/eveys` into the `eveys/ocpp` folder |
 | `dashboards/01-fleet-overview.json` | Fleet-wide rollup — first stop when triaging |
 | `dashboards/02-per-pod.json` | One pod under the lens (templated `pod_id` picker) |
-| `dashboards/03-per-charger.json` | Per-charger context — note: handler metrics are intentionally **not** labelled by `cp_id` (cardinality), so this dashboard pairs Prometheus with logs/Postgres/ClickHouse for true per-charger drill-down |
+| `dashboards/03-per-charger.json` | Per-charger drill-down (templated `$cp_id` picker, ClickHouse-backed). Last-seen, errors/min, msg/min, status timeline, BootNotification rate, MeterValues sample rate. Phase 6 prep. |
 | `dashboards/04-reconnect-storms.json` | Reconnect / handshake / heartbeat health — the page-at-3am view |
 | `dashboards/05-transactions.json` | Charging-session lifecycle: starts, stops, Kafka publish, webhook delivery, consumer lag |
+| `dashboards/06-slos.json` | Five SLOs (E4-8 recording rules) — the contractual view |
 
-All dashboards reference the `prometheus` datasource UID. If your
-Grafana already has a Prometheus datasource with a different UID,
-either override it via this provisioning file or rename your existing
-datasource UID to `prometheus`.
+Datasource UIDs:
+
+- Prometheus → `prometheus` (used by every dashboard except 03)
+- ClickHouse → `clickhouse` (used by 03 only)
+
+If your Grafana already has Prometheus / ClickHouse datasources with
+different UIDs, either override the provisioning files here or rename
+your existing UIDs.
+
+The ClickHouse datasource needs the `grafana-clickhouse-datasource`
+plugin. For Docker:
+`GF_INSTALL_PLUGINS=grafana-clickhouse-datasource`. For the official
+Helm chart: `grafana.plugins: [grafana-clickhouse-datasource]`.
 
 ## Mounting into Grafana (Docker)
 
@@ -34,6 +46,10 @@ services:
       - ./deploy/grafana/dashboards:/var/lib/grafana/dashboards/eveys:ro
     environment:
       - PROMETHEUS_URL=http://prometheus:9090
+      - CLICKHOUSE_HOST=clickhouse
+      - CLICKHOUSE_PORT=9000
+      - CLICKHOUSE_DB=events
+      - GF_INSTALL_PLUGINS=grafana-clickhouse-datasource
 ```
 
 ## Mounting into Grafana (Kubernetes)

--- a/deploy/grafana/dashboards/03-per-charger.json
+++ b/deploy/grafana/dashboards/03-per-charger.json
@@ -1,166 +1,284 @@
 {
-  "annotations": {
+  "title": "eveys/ocpp — Per-charger drill-down",
+  "uid": "eveys-ocpp-per-charger",
+  "schemaVersion": 38,
+  "version": 1,
+  "editable": true,
+  "graphTooltip": 1,
+  "refresh": "1m",
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "tags": ["eveys-ocpp", "per-charger", "phase-6"],
+  "templating": {
     "list": [
       {
-        "builtIn": 1,
-        "datasource": {"type": "grafana", "uid": "-- Grafana --"},
-        "enable": true,
-        "hide": true,
-        "iconColor": "rgba(0, 211, 255, 1)",
-        "name": "Annotations & Alerts",
-        "type": "dashboard"
+        "name": "cp_id",
+        "type": "query",
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "clickhouse"
+        },
+        "query": {
+          "rawSql": "SELECT DISTINCT cp_id FROM cp_status WHERE occurred_at >= now() - INTERVAL 30 DAY ORDER BY cp_id",
+          "format": 1
+        },
+        "refresh": 1,
+        "includeAll": false,
+        "multi": false,
+        "label": "charger",
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "description": "Pick a charger that has been active in the last 30 days. The list is bounded by the cp_status partition window — chargers older than that need a longer lookup."
       }
     ]
   },
-  "description": "One charge point under the lens. Drill into a specific cp_id when an operator says 'this charger is misbehaving' — answers 'what's this charger sending, how is it being routed, are its writes succeeding?' NOTE: handler/registry metrics are NOT labelled by cp_id (that would blow up cardinality), so this dashboard mostly shows aggregated views filtered by labels we DO carry: action, endpoint, topic.",
-  "editable": true,
-  "fiscalYearStartMonth": 0,
-  "graphTooltip": 1,
-  "links": [
-    {"title": "Fleet overview", "type": "link", "url": "/d/eveys-ocpp-fleet", "targetBlank": false}
-  ],
-  "liveNow": false,
   "panels": [
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "id": 1,
       "type": "text",
-      "gridPos": {"h": 3, "w": 24, "x": 0, "y": 0},
-      "id": 100,
+      "title": "",
+      "gridPos": {"h": 4, "w": 24, "x": 0, "y": 0},
       "options": {
         "mode": "markdown",
-        "content": "**Per-charger view caveat.** OCPP metrics in this stack are deliberately **not** labelled by `cp_id` — a single warehouse can run thousands of chargers, and a per-`cp_id` Prometheus series for every action/outcome combo would explode cardinality. To trace one charger end-to-end, **also** check:\n\n- **Logs** — `kubectl logs -l app=eveys-ocpp -f | jq 'select(.cp_id==\"<cp_id>\")'`\n- **Postgres** — `SELECT * FROM charge_points WHERE cp_id = '<cp_id>'; SELECT * FROM transactions WHERE charge_point_id = '<cp_id>' ORDER BY id DESC LIMIT 10;`\n- **ClickHouse** — `SELECT * FROM cp.meter WHERE cp_id = '<cp_id>' ORDER BY ts DESC LIMIT 50;`\n\nThe panels below show fleet-wide aggregates that contextualise the single-charger picture you'll build from logs + DB."
+        "content": "## Per-charger drill-down\n\nProduction Prometheus metrics deliberately carry **no `cp_id` label** (cardinality blow-up at 1000+ chargers; see `src/eveys_ocpp/metrics/registry.py`). Per-charger panels here read directly from the ClickHouse event tables (`cp_boot`, `cp_status`, `cp_meter`, `tx_started`) that the gateway's Kafka→CH ingestor writes (E2-13, E2-14).\n\nUse this dashboard to drill into a specific charger after the fleet view (01) flagged it. **Last seen** is the cheapest liveness signal — Prometheus's `eveys_ocpp_registry_online_chargers` is fleet-wide, so the per-charger online state is inferred from recent activity rather than a presence ping."
       }
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "unit": "ops"}},
-      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 3},
-      "id": 1,
-      "title": "Inbound CALL rate by action (fleet)",
-      "type": "timeseries",
-      "options": {"legend": {"displayMode": "table", "placement": "right"}},
-      "targets": [
-        {
-          "expr": "sum by (action) (rate(eveys_ocpp_ws_messages_in_total[1m]))",
-          "legendFormat": "{{action}}",
-          "refId": "A",
-          "datasource": {"type": "prometheus", "uid": "prometheus"}
-        }
-      ]
-    },
-    {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "unit": "ops"}},
-      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 3},
       "id": 2,
-      "title": "StatusNotification by status (fleet)",
-      "type": "timeseries",
-      "options": {"legend": {"displayMode": "table", "placement": "right"}},
+      "type": "stat",
+      "title": "Last seen",
+      "description": "Most recent occurred_at across cp_status / cp_meter for this charger. A green colour means activity in the last 5 min; yellow within the hour; red after.",
+      "gridPos": {"h": 5, "w": 6, "x": 0, "y": 4},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "clickhouse"},
+      "fieldConfig": {
+        "defaults": {
+          "unit": "dateTimeFromNow",
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "red", "value": null},
+              {"color": "yellow", "value": -3600},
+              {"color": "green", "value": -300}
+            ]
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "value",
+        "colorMode": "background"
+      },
       "targets": [
         {
-          "expr": "sum by (status, error_code) (rate(eveys_ocpp_status_notifications_total[5m]))",
-          "legendFormat": "{{status}} ({{error_code}})",
           "refId": "A",
-          "datasource": {"type": "prometheus", "uid": "prometheus"}
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "clickhouse"},
+          "rawSql": "SELECT max(occurred_at) AS last_seen FROM (SELECT occurred_at FROM cp_status WHERE cp_id = '$cp_id' UNION ALL SELECT occurred_at FROM cp_meter WHERE cp_id = '$cp_id') WHERE occurred_at >= now() - INTERVAL 7 DAY",
+          "format": 1
         }
       ]
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "unit": "ops"}},
-      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 12},
       "id": 3,
-      "title": "Authorize results (accepted / invalid / expired / blocked / concurrent)",
-      "type": "timeseries",
-      "options": {"legend": {"displayMode": "table", "placement": "right"}},
+      "type": "stat",
+      "title": "Boots in window",
+      "description": "BootNotification events for this charger in the dashboard time range. Many boots in a tight window = power-cycle storm or firmware loop.",
+      "gridPos": {"h": 5, "w": 6, "x": 6, "y": 4},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "clickhouse"},
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 5},
+              {"color": "red", "value": 20}
+            ]
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "value"
+      },
       "targets": [
         {
-          "expr": "sum by (status) (rate(eveys_ocpp_authorize_total[5m]))",
-          "legendFormat": "{{status}}",
           "refId": "A",
-          "datasource": {"type": "prometheus", "uid": "prometheus"}
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "clickhouse"},
+          "rawSql": "SELECT count() FROM cp_boot WHERE cp_id = '$cp_id' AND occurred_at >= $__fromTime AND occurred_at <= $__toTime",
+          "format": 1
         }
       ]
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "unit": "ops"}},
-      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 12},
       "id": 4,
-      "title": "Authorize cache hits vs misses",
-      "type": "timeseries",
-      "options": {"legend": {"displayMode": "table", "placement": "right"}},
+      "type": "stat",
+      "title": "Transactions started",
+      "description": "StartTransaction count for this charger across the dashboard window.",
+      "gridPos": {"h": 5, "w": 6, "x": 12, "y": 4},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "clickhouse"},
+      "fieldConfig": {
+        "defaults": {"unit": "short"}
+      },
+      "options": {
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "value"
+      },
       "targets": [
         {
-          "expr": "sum(rate(eveys_ocpp_authorize_cache_hits_total[5m]))",
-          "legendFormat": "hits",
           "refId": "A",
-          "datasource": {"type": "prometheus", "uid": "prometheus"}
-        },
-        {
-          "expr": "sum(rate(eveys_ocpp_authorize_cache_misses_total[5m]))",
-          "legendFormat": "misses",
-          "refId": "B",
-          "datasource": {"type": "prometheus", "uid": "prometheus"}
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "clickhouse"},
+          "rawSql": "SELECT count() FROM tx_started WHERE cp_id = '$cp_id' AND occurred_at >= $__fromTime AND occurred_at <= $__toTime",
+          "format": 1
         }
       ]
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "unit": "ops"}},
-      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 21},
       "id": 5,
-      "title": "Start / Stop transactions",
-      "type": "timeseries",
-      "options": {"legend": {"displayMode": "table", "placement": "right"}},
+      "type": "stat",
+      "title": "Errors in window",
+      "description": "StatusNotification rows where error_code != 'NoError'. Sustained non-zero = page-worthy.",
+      "gridPos": {"h": 5, "w": 6, "x": 18, "y": 4},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "clickhouse"},
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 1},
+              {"color": "red", "value": 10}
+            ]
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "value",
+        "colorMode": "background"
+      },
       "targets": [
         {
-          "expr": "sum(rate(eveys_ocpp_start_transactions_total[5m]))",
-          "legendFormat": "starts",
           "refId": "A",
-          "datasource": {"type": "prometheus", "uid": "prometheus"}
-        },
-        {
-          "expr": "sum by (reason) (rate(eveys_ocpp_stop_transactions_total[5m]))",
-          "legendFormat": "stops ({{reason}})",
-          "refId": "B",
-          "datasource": {"type": "prometheus", "uid": "prometheus"}
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "clickhouse"},
+          "rawSql": "SELECT count() FROM cp_status WHERE cp_id = '$cp_id' AND error_code != 'NoError' AND occurred_at >= $__fromTime AND occurred_at <= $__toTime",
+          "format": 1
         }
       ]
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "unit": "ops"}},
-      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 21},
       "id": 6,
-      "title": "MeterValues — messages & individual samples",
       "type": "timeseries",
-      "options": {"legend": {"displayMode": "table", "placement": "right"}},
+      "title": "Inbound message rate (msg/min)",
+      "description": "All inbound traffic for this charger: StatusNotifications + MeterValues + BootNotifications, bucketed per minute. Watch for sustained zeros (silent charger) or spikes (chatty charger / loop).",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 9},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "clickhouse"},
+      "fieldConfig": {
+        "defaults": {"unit": "mpm", "custom": {"drawStyle": "line", "lineInterpolation": "linear", "fillOpacity": 10}}
+      },
+      "options": {"legend": {"showLegend": true, "displayMode": "table", "placement": "bottom"}},
       "targets": [
         {
-          "expr": "sum(rate(eveys_ocpp_meter_values_total[5m]))",
-          "legendFormat": "messages",
           "refId": "A",
-          "datasource": {"type": "prometheus", "uid": "prometheus"}
-        },
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "clickhouse"},
+          "rawSql": "SELECT toStartOfMinute(occurred_at) AS t, 'status' AS source, count() AS c FROM cp_status WHERE cp_id = '$cp_id' AND $__timeFilter(occurred_at) GROUP BY t UNION ALL SELECT toStartOfMinute(occurred_at) AS t, 'meter' AS source, count() AS c FROM cp_meter WHERE cp_id = '$cp_id' AND $__timeFilter(occurred_at) GROUP BY t UNION ALL SELECT toStartOfMinute(occurred_at) AS t, 'boot' AS source, count() AS c FROM cp_boot WHERE cp_id = '$cp_id' AND $__timeFilter(occurred_at) GROUP BY t ORDER BY t",
+          "format": 0
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Error rate (errors/min)",
+      "description": "StatusNotifications with non-NoError error_code, per minute. Annotated by error_code so a flapping vendor_error pattern is visible.",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 9},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "clickhouse"},
+      "fieldConfig": {
+        "defaults": {"unit": "errors/min", "custom": {"drawStyle": "line", "lineInterpolation": "linear", "fillOpacity": 10}}
+      },
+      "options": {"legend": {"showLegend": true, "displayMode": "table", "placement": "bottom"}},
+      "targets": [
         {
-          "expr": "sum(rate(eveys_ocpp_meter_value_samples_total[5m]))",
-          "legendFormat": "samples",
-          "refId": "B",
-          "datasource": {"type": "prometheus", "uid": "prometheus"}
+          "refId": "A",
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "clickhouse"},
+          "rawSql": "SELECT toStartOfMinute(occurred_at) AS t, error_code, count() AS c FROM cp_status WHERE cp_id = '$cp_id' AND error_code != 'NoError' AND $__timeFilter(occurred_at) GROUP BY t, error_code ORDER BY t",
+          "format": 0
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "state-timeline",
+      "title": "Status by connector",
+      "description": "Each connector's StatusNotification stream — Available / Preparing / Charging / Faulted / Unavailable etc. The whole story of what the charger has been doing in one strip.",
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 17},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "clickhouse"},
+      "fieldConfig": {
+        "defaults": {"custom": {"fillOpacity": 80, "lineWidth": 0}}
+      },
+      "options": {
+        "showValue": "auto",
+        "alignValue": "left",
+        "rowHeight": 0.9,
+        "mergeValues": true,
+        "legend": {"showLegend": true, "displayMode": "list", "placement": "bottom"}
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "clickhouse"},
+          "rawSql": "SELECT occurred_at AS t, concat('connector_', toString(connector_id)) AS connector, status FROM cp_status WHERE cp_id = '$cp_id' AND $__timeFilter(occurred_at) ORDER BY t",
+          "format": 0
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Reconnects (BootNotifications/min)",
+      "description": "BootNotification rate for this charger. Spikes correlate with power glitches, network instability, or firmware reboot loops. The gateway's idempotency cache de-duplicates retries (E2-11), so each row here is a logical boot, not a retry.",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 25},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "clickhouse"},
+      "fieldConfig": {
+        "defaults": {"unit": "boots/min", "custom": {"drawStyle": "bars", "lineWidth": 1, "fillOpacity": 60}}
+      },
+      "options": {"legend": {"showLegend": false}},
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "clickhouse"},
+          "rawSql": "SELECT toStartOfMinute(occurred_at) AS t, count() AS boots FROM cp_boot WHERE cp_id = '$cp_id' AND $__timeFilter(occurred_at) GROUP BY t ORDER BY t",
+          "format": 0
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "MeterValues sample rate (samples/min)",
+      "description": "Charger-reported MeterValues rate. Every transaction-active charger should be reporting — a flat zero during what should be a charging session is a clue.",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 25},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "clickhouse"},
+      "fieldConfig": {
+        "defaults": {"unit": "samples/min", "custom": {"drawStyle": "line", "lineInterpolation": "linear", "fillOpacity": 10}}
+      },
+      "options": {"legend": {"showLegend": false}},
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "clickhouse"},
+          "rawSql": "SELECT toStartOfMinute(occurred_at) AS t, count() AS samples FROM cp_meter WHERE cp_id = '$cp_id' AND $__timeFilter(occurred_at) GROUP BY t ORDER BY t",
+          "format": 0
         }
       ]
     }
-  ],
-  "refresh": "30s",
-  "schemaVersion": 38,
-  "tags": ["eveys", "ocpp", "charger"],
-  "templating": {"list": []},
-  "time": {"from": "now-1h", "to": "now"},
-  "timepicker": {},
-  "timezone": "",
-  "title": "eveys/ocpp — Per-charger context",
-  "uid": "eveys-ocpp-charger",
-  "version": 1,
-  "weekStart": ""
+  ]
 }

--- a/deploy/grafana/provisioning/datasources/clickhouse.yml
+++ b/deploy/grafana/provisioning/datasources/clickhouse.yml
@@ -1,0 +1,38 @@
+apiVersion: 1
+
+# ClickHouse datasource — required by `dashboards/03-per-charger.json`
+# for true per-cp_id drill-down. Per-charger metrics deliberately
+# carry NO cp_id Prometheus label (cardinality bomb at 1000+
+# chargers; see `src/eveys_ocpp/metrics/registry.py`), so per-charger
+# panels read the same data straight from the `cp_meter` /
+# `cp_status` tables that the gateway's Kafka→ClickHouse ingestor
+# writes (E2-13, E2-14).
+#
+# Plugin: `grafana-clickhouse-datasource` (Altinity's official). The
+# operator's Grafana must have it installed — for compose-based dev
+# add `GF_INSTALL_PLUGINS=grafana-clickhouse-datasource` to the
+# Grafana service env. For Helm, the chart values usually carry
+# `grafana.plugins:`.
+#
+# Native protocol port (9000) is the default; HTTP (8123) works too
+# but the native protocol is what the gateway's read client uses, so
+# keeping the same path here keeps the connection-failure surface
+# small.
+datasources:
+  - name: ClickHouse
+    uid: clickhouse
+    type: grafana-clickhouse-datasource
+    access: proxy
+    isDefault: false
+    editable: false
+    jsonData:
+      host: ${CLICKHOUSE_HOST:-clickhouse}
+      port: ${CLICKHOUSE_PORT:-9000}
+      protocol: native
+      defaultDatabase: ${CLICKHOUSE_DB:-events}
+      tlsSkipVerify: false
+    secureJsonData:
+      # Empty for compose / single-tenant dev. In production, mount
+      # the password via a Secret and template into the env that
+      # backs ${CLICKHOUSE_PASSWORD}.
+      password: ${CLICKHOUSE_PASSWORD:-}

--- a/docs/01-roadmap.md
+++ b/docs/01-roadmap.md
@@ -142,7 +142,7 @@ The integration shape is documented in [`docs/integration/`](./integration/READM
 | Deliverable | Done when |
 |---|---|
 | 10 dev-fleet chargers configured against `ocpp-gw` staging endpoint | Chargers connect, heartbeat, transact for 7 days |
-| Per-charger health dashboards (error rate, msg/s, reconnects) | Dashboard live during soak |
+| Per-charger health dashboards (error rate, msg/s, reconnects) | ✅ JSON shipped (`deploy/grafana/dashboards/03-per-charger.json` rebuilt around `$cp_id`, ClickHouse-backed). Live-against-staging validation gates on real fleet traffic in this phase. |
 | Rollback runbook tested — disconnect a charger from `ocpp-gw` in < 2 min | Drill performed and timed |
 
 **Exit**: 10 real chargers run on `ocpp-gw` in staging for 7 consecutive days with zero incidents.

--- a/tests/unit/test_per_charger_dashboard.py
+++ b/tests/unit/test_per_charger_dashboard.py
@@ -1,0 +1,113 @@
+"""Per-charger dashboard sanity check.
+
+`deploy/grafana/dashboards/03-per-charger.json` reads from ClickHouse
+event tables (`cp_status`, `cp_meter`, `cp_boot`, `tx_started`) for
+true per-cp_id drill-down — the Prometheus metrics deliberately
+carry no `cp_id` label. A future edit could typo a table name, drop
+the `$cp_id` filter (cardinality bomb), or wire to the wrong
+datasource.
+
+This test parses the dashboard JSON and asserts:
+
+  - every panel references the `clickhouse` datasource UID
+  - every CH table referenced exists in the DDL under
+    `src/eveys_ocpp/clickhouse/ddl/`
+  - every panel's SQL filters by the `$cp_id` template variable
+    (the whole point of the dashboard) — exception: the template
+    query itself which populates the dropdown
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DASHBOARD_PATH = REPO_ROOT / "deploy" / "grafana" / "dashboards" / "03-per-charger.json"
+DDL_DIR = REPO_ROOT / "src" / "eveys_ocpp" / "clickhouse" / "ddl"
+
+
+def _dashboard() -> dict:
+    return json.loads(DASHBOARD_PATH.read_text())
+
+
+def _known_tables() -> set[str]:
+    """Parse `CREATE TABLE` names out of the DDL files. Source of
+    truth for which tables exist."""
+    pattern = re.compile(r"CREATE TABLE IF NOT EXISTS\s+(\w+)", re.IGNORECASE)
+    tables: set[str] = set()
+    for f in DDL_DIR.glob("*.sql"):
+        for match in pattern.finditer(f.read_text()):
+            tables.add(match.group(1))
+    return tables
+
+
+def _query_panels(spec: dict) -> list[tuple[str, str]]:
+    """Return (panel_title, rawSql) tuples for every panel target.
+    Skips the markdown text panel."""
+    out: list[tuple[str, str]] = []
+    for panel in spec.get("panels", []):
+        if panel.get("type") == "text":
+            continue
+        for target in panel.get("targets", []):
+            sql = target.get("rawSql")
+            if sql:
+                out.append((panel["title"], sql))
+    return out
+
+
+def test_dashboard_is_valid_json() -> None:
+    spec = _dashboard()
+    assert spec["uid"] == "eveys-ocpp-per-charger"
+    assert spec["templating"]["list"][0]["name"] == "cp_id"
+
+
+def test_every_query_panel_uses_clickhouse_datasource() -> None:
+    spec = _dashboard()
+    for panel in spec["panels"]:
+        if panel.get("type") == "text":
+            continue
+        ds = panel.get("datasource", {})
+        assert ds.get("uid") == "clickhouse", (
+            f"panel {panel['title']!r} references {ds!r}, expected clickhouse"
+        )
+
+
+def test_every_referenced_ch_table_exists_in_ddl() -> None:
+    """Catches a typo like `cp_meters` → would silently produce no
+    data on a real query and a green test otherwise."""
+    known = _known_tables()
+    # Grep table names out of the FROM / UNION ALL clauses in every
+    # rawSql. Restrict to the leading `cp_*` / `tx_*` shape so we
+    # don't false-positive on subqueries, ORDER BY, etc.
+    table_pattern = re.compile(r"\bFROM\s+(\w+)\b", re.IGNORECASE)
+    referenced: set[str] = set()
+    for _, sql in _query_panels(_dashboard()):
+        referenced.update(table_pattern.findall(sql))
+    # Drop the `(SELECT ...)` subquery alias case — `FROM (SELECT ...`
+    # captures `(` which is not a table.
+    referenced = {t for t in referenced if t.isidentifier()}
+    missing = referenced - known
+    assert not missing, (
+        f"dashboard references unknown CH tables: {sorted(missing)}; known: {sorted(known)}"
+    )
+
+
+def test_every_panel_filters_by_cp_id() -> None:
+    """The whole purpose of the dashboard is the per-charger filter.
+    A panel without it would scan the entire fleet and either time
+    out or quietly drown in noise."""
+    for title, sql in _query_panels(_dashboard()):
+        assert "$cp_id" in sql, f"panel {title!r} SQL does not filter by $cp_id: {sql!r}"
+
+
+def test_template_variable_query_targets_cp_status() -> None:
+    """The cp_id picker reads from cp_status (smaller table than
+    cp_meter, same partition window). A future edit pointing it at
+    cp_meter would still work but be slower; check it stays put."""
+    spec = _dashboard()
+    var = spec["templating"]["list"][0]
+    sql = var["query"]["rawSql"]
+    assert "FROM cp_status" in sql
+    assert "DISTINCT cp_id" in sql


### PR DESCRIPTION
## Summary

Phase 6 prep — \`Per-charger health dashboards (error rate, msg/s, reconnects)\` from \`docs/01-roadmap.md\`. Existing \`03-per-charger.json\` was misnamed (fleet-wide, no cp_id selector); README acknowledged it should be ClickHouse-backed but the JSON wasn't.

- **ClickHouse Grafana datasource** — new \`provisioning/datasources/clickhouse.yml\`. Plugin: \`grafana-clickhouse-datasource\`. URL via \`\${CLICKHOUSE_HOST}\` / \`\${CLICKHOUSE_PORT}\` / \`\${CLICKHOUSE_DB}\`, same parameter shape as the existing Prometheus one.
- **Rebuilt \`03-per-charger.json\`** — \`\$cp_id\` template variable populated from \`SELECT DISTINCT cp_id FROM cp_status WHERE occurred_at >= now() - INTERVAL 30 DAY\`. Ten panels covering last-seen, errors/transactions/boots-in-window, msg/min by source, errors/min by error_code, status timeline by connector, BootNotifications/min (= logical reconnects after E2-11 dedup), MeterValues sample rate.
- **Sanity test** — \`tests/unit/test_per_charger_dashboard.py\` (5 tests): every panel uses the CH datasource UID; every table referenced exists in the DDL under \`src/eveys_ocpp/clickhouse/ddl/\`; every query SQL filters by \`\$cp_id\` (catches a future fleet-wide cardinality regression); the cp_id picker reads from \`cp_status\` (smallest of the candidate tables).
- README updated; roadmap line marks the JSON shipped (live-against-staging validation gates on real fleet traffic in the actual phase).

## Why ClickHouse, not Prometheus

Production Prometheus metrics deliberately carry no \`cp_id\` label (cardinality blow-up at 1000+ chargers; see \`src/eveys_ocpp/metrics/registry.py\`). The Kafka→CH ingestor (E2-13/E2-14) already writes per-event rows tagged with \`cp_id\`, so the CH event tables are the natural source for per-charger drill-down.

## Test plan

- [x] \`make lint\` clean
- [x] \`make types\` clean
- [x] \`make test\` (650 passed, 84.3% coverage; +5 new dashboard sanity tests)
- [x] \`python -c \"import json; json.load(open('deploy/grafana/dashboards/03-per-charger.json'))\"\` — valid JSON, 10 panels
- [ ] Manual on a Grafana with the CH plugin: drop the dashboard JSON in, pick a cp_id from the dropdown, panels render against the live \`cp_status\` / \`cp_meter\` / \`cp_boot\` / \`tx_started\` tables

Closes #94