### PR TITLE
feature(compose): opt-in Grafana + Prometheus sidecar via `make grafana-up`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,18 @@ UV         ?= $(shell command -v uv)
 # substitution still uses the file when it's there.
 COMPOSE_ENV := $(if $(wildcard .env),--env-file .env,)
 COMPOSE    := docker compose -f deploy/compose/docker-compose.yml $(COMPOSE_ENV)
+# Observability sidecar (Grafana + Prometheus). Overlays the base
+# stack so Grafana joins the same Docker network and resolves the
+# datasources by service name. Opt-in via `make grafana-up`.
+COMPOSE_GRAFANA := docker compose \
+    -f deploy/compose/docker-compose.yml \
+    -f deploy/compose/docker-compose.grafana.yml \
+    $(COMPOSE_ENV)
 
 .PHONY: help doctor install format lint types tests e2e smoke compose-smoke precommit clean distclean \
         compose-up compose-down compose-status compose-down-volumes compose-wait \
         build-image protoc ch-migrate docs docs-clean config-export config-export-check config-schema \
-        openapi-export openapi-export-check audit get-token
+        openapi-export openapi-export-check audit get-token grafana-up grafana-down
 
 # ---- meta -------------------------------------------------------------------
 
@@ -47,6 +54,8 @@ help:
 	@echo "  make e2e                full e2e: compose-up + alembic + ch-migrate + e2e tests + compose-down"
 	@echo "  make compose-smoke      Tier-3 smoke: build image + bring real compose stack up + assert it stays up + drive a charger flow (see ADR-0024)"
 	@echo "  make get-token          print a bearer token from EVEYS_OCPP_REST_INBOUND_TOKENS (paste into Swagger UI Authorize)"
+	@echo "  make grafana-up         start Grafana + Prometheus sidecar on the compose network (http://localhost:3000)"
+	@echo "  make grafana-down       stop the Grafana + Prometheus sidecar (data volumes kept)"
 	@echo ""
 	@echo "Docs:"
 	@echo "  make docs               build the docs site (Sphinx + MyST)"
@@ -149,6 +158,27 @@ compose-up:
 	$(COMPOSE) up -d
 	@echo ""
 	@echo "Stack starting. Use 'make compose-status' to watch health."
+
+# Opt-in observability sidecar: Grafana + Prometheus joined to the
+# same compose network. The Grafana container pulls the ClickHouse
+# plugin on first boot — first run needs network, subsequent runs
+# read from the cached volume. The base stack must already be up
+# (`make compose-up` first) — Grafana's datasources resolve service
+# names like `prometheus` and `clickhouse` over the project network.
+grafana-up:
+	$(COMPOSE_GRAFANA) up -d prometheus grafana
+	@echo ""
+	@echo "Grafana:    http://localhost:3000  (anonymous Admin — dev only)"
+	@echo "Prometheus: http://localhost:9090"
+	@echo ""
+	@echo "Dashboards land under folder 'eveys/ocpp'. The per-charger"
+	@echo "drill-down (03) is the one most likely to have data on a fresh"
+	@echo "stack — it reads from ClickHouse, which the gateway populates"
+	@echo "as soon as a charger connects."
+
+grafana-down:
+	$(COMPOSE_GRAFANA) stop grafana prometheus
+	$(COMPOSE_GRAFANA) rm -f grafana prometheus
 
 # Print a bearer token an operator can paste into the Swagger UI's
 # "Authorize" dialog. Reads from the shell env first, then falls back

--- a/deploy/compose/docker-compose.grafana.yml
+++ b/deploy/compose/docker-compose.grafana.yml
@@ -1,0 +1,103 @@
+# Opt-in observability sidecar for the dev compose stack.
+#
+# Boots Grafana (with the ClickHouse plugin pre-installed) and a tiny
+# Prometheus scraping the gateway's `/metrics:9100`. Joins the same
+# Docker network as the rest of the stack so the datasources resolve
+# by service name (`http://prometheus:9090`, `clickhouse:9000`).
+#
+# Bring up via `make grafana-up`. Tear down via `make grafana-down`.
+# The default `make compose-up` does NOT include this — observability
+# is dev-only; production runs Grafana in its own monitoring namespace
+# (see `deploy/grafana/README.md § Mounting into Grafana (Kubernetes)`).
+#
+# Dev posture choices:
+#   - Anonymous Admin role so you don't juggle a login on a laptop.
+#     Never use this in production.
+#   - The CH plugin is pulled fresh on first boot (`GF_INSTALL_PLUGINS`).
+#     Network-required first-time only; the volume caches it.
+#   - Prometheus uses a hard-coded scrape config baked in at runtime
+#     via `command:` rather than a config file mount, so this sidecar
+#     is one self-contained file with no satellite mounts to chase.
+
+services:
+  prometheus:
+    image: prom/prometheus:v2.55.1
+    container_name: eveys-ocpp-prometheus
+    restart: unless-stopped
+    # The scrape target `ocpp:9100` resolves on the default project
+    # network. Hold a 7-day window in TSDB so the dashboards have
+    # something to render after a coffee break.
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.retention.time=7d
+      - --storage.tsdb.path=/prometheus
+    # Inline the scrape config via a heredoc-into-tmpfs trick: we
+    # write the file inside the container at boot using an `entrypoint`
+    # override. Avoids a satellite YAML next to this one.
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        cat > /etc/prometheus/prometheus.yml <<EOF
+        global:
+          scrape_interval: 15s
+        scrape_configs:
+          - job_name: eveys-ocpp
+            static_configs:
+              - targets: ['ocpp:9100']
+        EOF
+        exec /bin/prometheus \
+          --config.file=/etc/prometheus/prometheus.yml \
+          --storage.tsdb.retention.time=7d \
+          --storage.tsdb.path=/prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - prom-data:/prometheus
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--spider", "http://localhost:9090/-/ready"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  grafana:
+    image: grafana/grafana:11.0.0
+    container_name: eveys-ocpp-grafana
+    restart: unless-stopped
+    depends_on:
+      prometheus:
+        condition: service_healthy
+    ports:
+      - "3000:3000"
+    environment:
+      # Pulls the ClickHouse plugin on first boot. Cached on the
+      # `grafana-data` volume thereafter.
+      GF_INSTALL_PLUGINS: grafana-clickhouse-datasource
+      # Anonymous Admin so a laptop doesn't have to juggle a login.
+      # NEVER set this in production.
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
+      GF_AUTH_DISABLE_LOGIN_FORM: "true"
+      # These match the placeholder shape the provisioning files use
+      # (`${PROMETHEUS_URL}`, `${CLICKHOUSE_HOST}`, etc.). Within the
+      # compose network the service names resolve directly.
+      PROMETHEUS_URL: http://prometheus:9090
+      CLICKHOUSE_HOST: clickhouse
+      CLICKHOUSE_PORT: "9000"
+      CLICKHOUSE_DB: events
+    volumes:
+      # Live-mount the datasource + dashboard provisioning so an edit
+      # to a JSON file shows up after a refresh — Grafana's provider
+      # watches every 30 s.
+      - ../grafana/provisioning:/etc/grafana/provisioning:ro
+      - ../grafana/dashboards:/var/lib/grafana/dashboards/eveys:ro
+      - grafana-data:/var/lib/grafana
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--spider", "http://localhost:3000/api/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+
+volumes:
+  prom-data:
+  grafana-data:

--- a/deploy/grafana/README.md
+++ b/deploy/grafana/README.md
@@ -34,7 +34,22 @@ plugin. For Docker:
 `GF_INSTALL_PLUGINS=grafana-clickhouse-datasource`. For the official
 Helm chart: `grafana.plugins: [grafana-clickhouse-datasource]`.
 
-## Mounting into Grafana (Docker)
+## Local dev: `make grafana-up`
+
+For a developer hacking on this repo, the dashboards run against the local compose stack via an opt-in sidecar:
+
+```bash
+make compose-up                 # base stack (no Grafana)
+make grafana-up                 # adds Grafana + Prometheus on the same network
+# → http://localhost:3000  (anonymous Admin, dev-only)
+make grafana-down               # tear down the sidecar, keep the rest
+```
+
+The sidecar lives in `deploy/compose/docker-compose.grafana.yml` and overlays the base compose file. See [`docs/07-local-dev-setup.md § Optional: bring up Grafana`](../../docs/07-local-dev-setup.md#optional-bring-up-grafana) for the workflow and which dashboards have data on a fresh stack.
+
+## Mounting into Grafana (Docker, your own stack)
+
+If you're not using `make grafana-up` — e.g. you already run Grafana for other workloads and just want these dashboards loaded — mount the provisioning directly:
 
 ```yaml
 # add to your own docker-compose.yml that already runs grafana

--- a/deploy/grafana/provisioning/datasources/prometheus.yml
+++ b/deploy/grafana/provisioning/datasources/prometheus.yml
@@ -9,6 +9,11 @@ apiVersion: 1
 # Prometheus service.
 datasources:
   - name: Prometheus
+    # Stable UID — every dashboard JSON in this repo references
+    # `uid: prometheus`. Without this line Grafana auto-generates a
+    # random UID and every panel falls back to "default datasource"
+    # (or breaks outright).
+    uid: prometheus
     type: prometheus
     access: proxy
     url: ${PROMETHEUS_URL:-http://prometheus:9090}

--- a/docs/07-local-dev-setup.md
+++ b/docs/07-local-dev-setup.md
@@ -168,6 +168,40 @@ docker volume rm ocpp_postgres_data
 docker compose -f deploy/compose/docker-compose.yml up -d postgres
 ```
 
+### Optional: bring up Grafana
+
+The default `make compose-up` does **not** include Grafana — observability is dev-only and many workflows don't need it. When you do, the sidecar is one command:
+
+```bash
+make grafana-up
+```
+
+That overlays `deploy/compose/docker-compose.grafana.yml` on the running stack and brings up two extra containers:
+
+- **Grafana** at <http://localhost:3000> — anonymous Admin role, no login form. Six dashboards land under the `eveys/ocpp` folder, auto-provisioned.
+- **Prometheus** at <http://localhost:9090> — scrapes the gateway's `/metrics:9100` endpoint every 15 s, retains 7 days.
+
+The ClickHouse plugin (`grafana-clickhouse-datasource`) is pulled on first boot and cached on the `grafana-data` volume; subsequent restarts are offline.
+
+Stop the sidecar without touching the rest of the stack:
+
+```bash
+make grafana-down              # stops + removes the containers, keeps the volumes
+```
+
+**Which dashboards work on a fresh stack?**
+
+| Dashboard | Datasource | Has data right after `make compose-up`? |
+|---|---|---|
+| 01 Fleet overview | Prometheus | After ~15 s of scrape (always populated, even with no chargers) |
+| 02 Per-pod | Prometheus | Same |
+| 03 Per-charger drill-down | ClickHouse | Once a charger has connected and emitted at least one StatusNotification |
+| 04 Reconnect storms | Prometheus | Same as 01 |
+| 05 Transactions | Prometheus | After at least one StartTransaction has flowed through |
+| 06 SLOs | Prometheus | Needs the recording rules in `deploy/prometheus/rules.yml` (not yet wired into the sidecar — fleet metrics show, the `slo:*` recorded series do not) |
+
+**Production posture.** This sidecar is dev-only. Production runs Grafana in a separate `monitoring` namespace via `kube-prometheus-stack`; the dashboard JSONs in this repo ship as ConfigMaps that Grafana picks up on the operator's side. See [`deploy/grafana/README.md`](../deploy/grafana/README.md) for the k8s mounting pattern.
+
 ---
 
 ## Path B — k3d / kind


### PR DESCRIPTION
## Summary

Local-dev observability sidecar so a developer with this repo can see the dashboards in \`deploy/grafana/dashboards/\` without standing up their own Grafana. Closes the gap raised in #96.

- **\`deploy/compose/docker-compose.grafana.yml\`** — Grafana + Prometheus on the same Docker network as the base stack. Grafana on \`:3000\` (anonymous Admin, ClickHouse plugin pre-installed, mounts the existing provisioning + dashboards dirs); Prometheus on \`:9090\` scraping \`/metrics:9100\`, 7-day retention. Self-contained (Prometheus scrape config inlined via \`entrypoint:\` heredoc).
- **\`make grafana-up\` / \`make grafana-down\`** — opt-in. Default \`compose-up\` stays unchanged.
- **Docs** — new section in \`docs/07-local-dev-setup.md\` with the workflow + a table of which dashboards have data on a fresh stack. Mirrored one-line pointer in \`deploy/grafana/README.md\`.
- **Side-fix**: \`prometheus.yml\` provisioning was missing \`uid: prometheus\`. Grafana auto-generated a random UID; dashboards reference \`uid: prometheus\` directly, so panels silently fell back to the default datasource. Added the line.

## Production posture unchanged

Production runs Grafana in the \`monitoring\` namespace via \`kube-prometheus-stack\`. The dashboard JSONs ship as ConfigMaps. Documented in both READMEs.

## Test plan

- [x] \`make lint\` clean
- [x] \`make types\` clean
- [x] \`make test\` (650 passed, 84.3% coverage)
- [x] Manual against the running compose stack:
  - \`make grafana-up\` → both containers come up healthy
  - <http://localhost:3000/api/health> → 200
  - <http://localhost:9090/-/ready> → 200
  - \`/api/datasources\` lists ClickHouse (uid=\`clickhouse\`) + Prometheus (uid=\`prometheus\`) — both UIDs match what the dashboards expect
  - \`/api/search?type=dash-db\` lists all 6 dashboards under \`eveys/ocpp\`
  - \`make grafana-down\` cleanly stops + removes the sidecar containers

Closes #96