### PR TITLE
fix(envoy): upstream healthy from a cold compose boot (catch in CI)

### DIFF
--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -203,6 +203,29 @@ services:
       redis: { condition: service_healthy }
       kafka: { condition: service_healthy }
       clickhouse: { condition: service_healthy }
+    # Envoy's first health-check fires the moment it starts and a
+    # network-level failure on attempt #1 puts the upstream in a
+    # state Envoy doesn't always reschedule from. Adding a
+    # healthcheck here lets Envoy's `depends_on: condition:
+    # service_healthy` wait until /api/v1/ready answers 200 before
+    # Envoy boots — first health-check is then guaranteed to land
+    # on a ready REST listener.
+    healthcheck:
+      test:
+        - CMD
+        - python3.13
+        - -c
+        - |
+          import urllib.request, sys
+          try:
+              with urllib.request.urlopen("http://127.0.0.1:8080/api/v1/ready", timeout=2) as r:
+                  sys.exit(0 if r.status == 200 else 1)
+          except Exception:
+              sys.exit(1)
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 5s
 
   # Sidecar consumer for the Kafka → ClickHouse pipeline (E2-14, ADR-0020).
   # Reuses the same image as the gateway — entry point is overridden to run
@@ -247,11 +270,22 @@ services:
     container_name: eveys-ocpp-envoy
     ports:
       - "19443:443"     # wss:// — TLS-fronted entry point
+      # Admin (local-dev only). The distroless envoy image has no
+      # shell tools to probe admin from `docker exec`, so we bind it
+      # to 0.0.0.0 inside the container (envoy.local.yaml) and map
+      # it here for `curl http://localhost:19901/clusters` triage.
+      # Production envoy.yaml keeps the loopback-only bind.
+      - "19901:9901"    # admin/triage — DO NOT mirror this to production
     volumes:
       - ../envoy/envoy.local.yaml:/etc/envoy/envoy.yaml:ro
       - ../envoy/certs:/etc/envoy/certs:ro
     depends_on:
-      ocpp: { condition: service_started }
+      # Wait for the gateway to be HEALTHY (REST listener answering
+      # /api/v1/ready), not just STARTED. Without this, Envoy fires
+      # its first health-check while the gateway is still binding
+      # ports, the network-level failure poisons the upstream, and
+      # Envoy never recovers without a manual restart.
+      ocpp: { condition: service_healthy }
     restart: unless-stopped
 
 volumes:

--- a/deploy/envoy/envoy.local.yaml
+++ b/deploy/envoy/envoy.local.yaml
@@ -19,11 +19,13 @@
 # with ADR-0007's "consequences" section.
 
 admin:
-  # Powerful interface — bound to localhost only so the admin port
-  # never escapes the container. `docker exec envoy ...` is how an
-  # operator reaches it during dev triage.
+  # Local-dev: bound to 0.0.0.0 so the host can reach it on the
+  # mapped 19901 port for triage (`curl localhost:19901/clusters`).
+  # The Envoy distroless image ships without nc/curl/wget so
+  # docker-exec'ing a probe is impractical. Production envoy.yaml
+  # keeps the loopback-only bind.
   address:
-    socket_address: { address: 127.0.0.1, port_value: 9901 }
+    socket_address: { address: 0.0.0.0, port_value: 9901 }
 
 static_resources:
   # ---------------------------------------------------------------
@@ -194,9 +196,22 @@ static_resources:
                     # Compose service DNS — k8s production overrides
                     # this with EDS-discovered endpoints.
                     socket_address: { address: ocpp, port_value: 9000 }
+                  # `host:` in `http_health_check` only sets the HTTP
+                  # `Host` header — it does NOT change the destination
+                  # port. To health-check a different port than the
+                  # cluster's traffic port, use
+                  # `health_check_config.port_value` here on the
+                  # endpoint. We route WS traffic to :9000 (the WS
+                  # server) but health-check :8080 (the REST
+                  # /api/v1/ready endpoint).
+                  health_check_config:
+                    port_value: 8080
       # Health check the gateway's readiness endpoint (PR #43).
       # Envoy stops routing to a pod whose /api/v1/ready returns
-      # 503, which is exactly the graceful-drain signal.
+      # 503, which is exactly the graceful-drain signal. The WS
+      # server on :9000 doesn't speak HTTP, so we point Envoy at
+      # the REST surface on :8080 via `health_check_config.port_value`
+      # above.
       health_checks:
         - timeout: 2s
           interval: 3s
@@ -204,11 +219,6 @@ static_resources:
           healthy_threshold: 1
           http_health_check:
             path: /api/v1/ready
-            host: ocpp:8080
-        # The healthcheck speaks HTTP/1.1 to :8080 (REST surface),
-        # not the WS port. Envoy can't health-check a WS upgrade
-        # path directly; targeting /api/v1/ready is intentional and
-        # better — it mirrors what k8s readiness probes will use.
       # Apply slow-start to the cluster so a recovering pod ramps.
       # 60 s is generous; tune down if rolling-deploy churn is
       # well-paced and the fleet is small.

--- a/deploy/envoy/envoy.yaml
+++ b/deploy/envoy/envoy.yaml
@@ -106,6 +106,13 @@ static_resources:
                     socket_address:
                       address: gateway-headless.eveys-ocpp.svc.cluster.local
                       port_value: 9000
+                  # `host:` in `http_health_check` only sets the HTTP
+                  # `Host` header, not the destination port. Use
+                  # `health_check_config.port_value` here so Envoy
+                  # health-checks :8080 (REST /api/v1/ready) while
+                  # WS traffic still goes to :9000.
+                  health_check_config:
+                    port_value: 8080
       # E5-5 — client-side TLS to the gateway. Pairs with the
       # gateway's ws_mtls_enabled=True mode (settings.py). Cert
       # paths are mounted from a TLS Secret by the Helm chart;
@@ -134,4 +141,3 @@ static_resources:
           healthy_threshold: 1
           http_health_check:
             path: /api/v1/ready
-            host: gateway-headless.eveys-ocpp.svc.cluster.local:8080

--- a/deploy/helm/eveys-ocpp/files/envoy.yaml
+++ b/deploy/helm/eveys-ocpp/files/envoy.yaml
@@ -106,6 +106,13 @@ static_resources:
                     socket_address:
                       address: gateway-headless.eveys-ocpp.svc.cluster.local
                       port_value: 9000
+                  # `host:` in `http_health_check` only sets the HTTP
+                  # `Host` header, not the destination port. Use
+                  # `health_check_config.port_value` here so Envoy
+                  # health-checks :8080 (REST /api/v1/ready) while
+                  # WS traffic still goes to :9000.
+                  health_check_config:
+                    port_value: 8080
       # E5-5 — client-side TLS to the gateway. Pairs with the
       # gateway's ws_mtls_enabled=True mode (settings.py). Cert
       # paths are mounted from a TLS Secret by the Helm chart;
@@ -134,4 +141,3 @@ static_resources:
           healthy_threshold: 1
           http_health_check:
             path: /api/v1/ready
-            host: gateway-headless.eveys-ocpp.svc.cluster.local:8080

--- a/tests/compose_smoke/conftest.py
+++ b/tests/compose_smoke/conftest.py
@@ -58,6 +58,7 @@ _EXPECTED_CONTAINERS = (
     "eveys-ocpp-clickhouse",
     "eveys-ocpp-clickhouse-ingestor",
     "eveys-ocpp",
+    "eveys-ocpp-envoy",
 )
 
 # Host ports the compose file publishes. Used by tests that drive the
@@ -67,6 +68,9 @@ HOST_PG_PORT = 5432
 # Compose remaps CH HTTP from the canonical 8123 to 8124 to dodge a
 # Homebrew `clickhouse server` already on the laptop (issue #24).
 HOST_CH_HTTP_PORT = 8124
+# Envoy edge — TLS-fronted entry point + admin port.
+HOST_ENVOY_TLS_PORT = 19443
+HOST_ENVOY_ADMIN_PORT = 19901
 
 # Where the published ports actually answer. On a laptop this is
 # `localhost`. Under GitLab Docker-in-Docker the test process and the

--- a/tests/compose_smoke/test_compose_stack.py
+++ b/tests/compose_smoke/test_compose_stack.py
@@ -28,6 +28,8 @@ from ocpp.v16 import call
 from websockets.asyncio.client import connect
 
 from tests.compose_smoke.conftest import (
+    HOST_ENVOY_ADMIN_PORT,
+    HOST_ENVOY_TLS_PORT,
     HOST_WS_PORT,
     PUBLISHED_HOST,
     _container_logs,
@@ -240,6 +242,99 @@ async def test_full_charger_flow_against_running_container() -> None:
             assert stop.id_tag_info["status"] == "Accepted"
         finally:
             loop.cancel()
+
+
+# ---- Envoy edge --------------------------------------------------------
+
+
+def test_envoy_upstream_is_healthy() -> None:
+    """The Envoy edge must report its `ocpp_gateway` upstream cluster
+    as `healthy` against a real running gateway. Catches the class of
+    bug where the YAML validates fine (`envoy --mode validate`) but
+    the wiring is wrong at runtime — e.g. health-checking the wrong
+    port, an upstream cluster pointing at a stale service name, or
+    mTLS misconfiguration on the upstream leg.
+
+    Without this test, an Envoy that 503s every request because every
+    upstream is unhealthy would still pass CI, because the existing
+    `envoy-validate` job is YAML-schema only.
+    """
+    import urllib.request
+
+    # Wait up to 15 s for the first health-check pass — Envoy's
+    # interval is 3 s and `healthy_threshold` is 1, so a healthy
+    # gateway should flip to healthy within the first interval.
+    deadline = 15.0
+    poll_every = 1.0
+    elapsed = 0.0
+    last_flags = "<unknown>"
+    while elapsed < deadline:
+        try:
+            with urllib.request.urlopen(
+                f"http://{PUBLISHED_HOST}:{HOST_ENVOY_ADMIN_PORT}/clusters",
+                timeout=2,
+            ) as resp:
+                body = resp.read().decode()
+        except Exception as exc:
+            last_flags = f"admin unreachable: {exc}"
+            elapsed += poll_every
+            import time
+
+            time.sleep(poll_every)
+            continue
+        for line in body.splitlines():
+            if "ocpp_gateway::" in line and "::health_flags::" in line:
+                last_flags = line.rsplit("::health_flags::", 1)[1].strip()
+                if last_flags == "healthy":
+                    return  # success
+                break
+        elapsed += poll_every
+        import time
+
+        time.sleep(poll_every)
+    raise AssertionError(
+        f"Envoy upstream `ocpp_gateway` did not become healthy within "
+        f"{deadline:.0f}s — last health_flags: {last_flags!r}. "
+        f"This usually means the http_health_check is misconfigured "
+        f"(wrong port / wrong path) or the gateway's /api/v1/ready "
+        f"isn't returning 200."
+    )
+
+
+def test_envoy_proxies_websocket_upgrade() -> None:
+    """A WebSocket upgrade through the TLS edge (`:19443`) must NOT
+    return `503 no healthy upstream`. The downstream charger flow has
+    its own auth (Basic Auth at the WS edge — E5-6) which may reject
+    a synthetic upgrade attempt with 401, but a 503 specifically
+    means Envoy's upstream is down — exactly the bug class this test
+    exists to catch.
+    """
+    import ssl
+    import urllib.request
+
+    # Don't validate the self-signed cert in compose.
+    ctx = ssl._create_unverified_context()
+    req = urllib.request.Request(
+        f"https://{PUBLISHED_HOST}:{HOST_ENVOY_TLS_PORT}/ocpp/SMOKE_PROBE",
+        headers={
+            "Connection": "Upgrade",
+            "Upgrade": "websocket",
+            "Sec-WebSocket-Key": "dGVzdA==",
+            "Sec-WebSocket-Version": "13",
+        },
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5, context=ctx) as resp:
+            status = resp.status
+    except urllib.error.HTTPError as exc:
+        status = exc.code
+
+    assert status != 503, (
+        f"Envoy returned 503 for a WebSocket upgrade — upstream is unhealthy. "
+        f"Check `http://{PUBLISHED_HOST}:{HOST_ENVOY_ADMIN_PORT}/clusters` for "
+        f"the `ocpp_gateway::*::health_flags` line."
+    )
 
 
 # ---- end-to-end pipeline (Kafka → ClickHouse via ingestor) ----------------


### PR DESCRIPTION
## Summary

Two stacked bugs were causing every request through the Envoy edge to return \`503 no healthy upstream\` on a fresh \`make compose-up\`. Both fixed here, plus compose-smoke tests so this class of regression fails CI going forward.

### Bug 1 — wrong port (config)

\`http_health_check.host: ocpp:8080\` looks like a port redirect but only sets the HTTP \`Host\` header. The destination port stayed at the cluster endpoint's \`9000\` (WebSocket), so Envoy was HTTP-health-checking the WS port. The right Envoy idiom is \`endpoint.health_check_config.port_value\` to override the HC port without touching traffic routing. Fixed in three files:
- \`deploy/envoy/envoy.local.yaml\`
- \`deploy/envoy/envoy.yaml\`
- \`deploy/helm/eveys-ocpp/files/envoy.yaml\` (production sibling — same bug, masked in prod by k8s readiness probes also flipping pod state)

### Bug 2 — race on cold boot

Even after #1, a cold \`compose-up\` had Envoy's first HC fire before the gateway's REST listener on :8080 was bound. Network-level rejection on attempt #1 put the upstream in a stuck \`failed_active_hc\` state with no retries. Fix: gateway gets a Docker-level healthcheck polling \`/api/v1/ready\`; Envoy's \`depends_on\` switches from \`service_started\` → \`service_healthy\`.

### Tests (the part that matters)

The existing \`compose-smoke\` job didn't even know Envoy existed (\`_EXPECTED_CONTAINERS\` omitted it). Now:

- \`test_envoy_upstream_is_healthy\` — polls Envoy admin until \`health_flags == healthy\`. Would have failed instantly on this bug.
- \`test_envoy_proxies_websocket_upgrade\` — WS upgrade through \`:19443\` must not 503. Auth rejections (401) are fine; 503 specifically means upstream is down.

I built the fix, then **deliberately reverted it locally** to confirm both new tests fail loud on the broken state — they do. Then re-applied the fix and confirmed they pass. Reproducible locally with \`COMPOSE_SMOKE=1 pytest tests/compose_smoke/test_compose_stack.py::test_envoy_upstream_is_healthy\`.

### Side-improvement (lifted scope but in the diff)

Local Envoy admin bound to \`0.0.0.0\` and exposed on host \`:19901\`. The distroless Envoy image ships without nc/curl/wget, so triaging via \`docker exec\` was impractical. Production keeps loopback-only.

## Test plan

- [x] \`make lint\` clean
- [x] \`make types\` clean
- [x] Cold-boot reproducibility: \`make compose-down && make compose-up\` → Envoy admin reports \`health_flags::healthy\`, both new compose-smoke tests pass.
- [x] Manual WS upgrade through \`:19443\` no longer returns 503 (gets a 401/500 from the gateway-level WS Basic Auth, which is a separate pre-existing bug — unrelated to Envoy).

Closes #98