### PR TITLE
test: close 2 of 3 mock-at-wrong-layer gaps from the audit

### DIFF
--- a/tests/unit/test_registry_lua.py
+++ b/tests/unit/test_registry_lua.py
@@ -1,0 +1,138 @@
+"""Real-Redis tests for the registry's Lua compare-and-delete (issue #100).
+
+The mocked tests in `test_registry.py` stub `redis.eval()` return values,
+so a Lua syntax error or KEYS/ARGV mismatch in `_DEL_IF_OWNER` would still
+pass them. In production that would silently break charger reconnect
+routing (the wrong-pod-deletes-our-key race becomes possible again).
+
+These tests exercise the script against a real Redis. Same skip pattern
+as `test_idempotency.py`: silent skip when Redis is unreachable, hard
+fail under `E2E_REQUIRE=1` so a CI config drift can't false-green this
+module.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+from collections.abc import AsyncIterator
+from contextlib import closing
+
+import pytest
+from redis.asyncio import Redis
+
+from eveys_ocpp.registry import Registry, _key
+from eveys_ocpp.settings import Settings
+
+_REDIS_HOST = os.environ.get("E2E_REDIS_HOST", "localhost")
+_REDIS_PORT = int(os.environ.get("E2E_REDIS_PORT", "6379"))
+_REDIS_REQUIRED = os.environ.get("E2E_REQUIRE") == "1"
+
+
+def _redis_reachable() -> bool:
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.settimeout(0.5)
+        try:
+            s.connect((_REDIS_HOST, _REDIS_PORT))
+        except OSError:
+            return False
+        return True
+
+
+if not _redis_reachable():
+    _msg = f"Redis at {_REDIS_HOST}:{_REDIS_PORT} unreachable; registry-Lua tests need it"
+    if _REDIS_REQUIRED:
+        pytest.fail(
+            f"{_msg}. E2E_REQUIRE=1 — the tests job must declare a "
+            "`redis:7-alpine` service. CI config bug, not env issue.",
+            pytrace=False,
+        )
+    pytestmark = pytest.mark.skip(reason=_msg)
+
+
+@pytest.fixture
+async def redis_client() -> AsyncIterator[Redis]:
+    """Fresh client per test. The fixture also flushes the keys it
+    touches on teardown so a failed test doesn't poison the next run."""
+    client = Redis.from_url(
+        f"redis://{_REDIS_HOST}:{_REDIS_PORT}/0",
+        decode_responses=True,
+    )
+    yield client
+    # Clean up any cp:online:* keys we created in tests.
+    async for k in client.scan_iter("cp:online:LUA_TEST_*"):
+        await client.delete(k)
+    await client.aclose()
+
+
+def _registry(redis: Redis, *, pod_id: str) -> Registry:
+    return Registry(redis, settings=Settings(pod_id=pod_id))
+
+
+@pytest.mark.asyncio
+async def test_mark_offline_deletes_when_we_own_the_key(
+    redis_client: Redis,
+) -> None:
+    """The basic happy path: this pod set the key, this pod releases it.
+
+    Verifies the Lua script's GET/DEL chain and the success-path return
+    value. If the script were syntactically broken (e.g. typo in
+    `redis.call`), this test would crash with a NOSCRIPT-shaped error
+    even though the unit-test mock is silent.
+    """
+    cp_id = "LUA_TEST_OWN"
+    reg = _registry(redis_client, pod_id="pod-A")
+
+    await reg.mark_online(cp_id)
+    assert await redis_client.get(_key(cp_id)) == "pod-A"
+
+    deleted = await reg.mark_offline(cp_id)
+    assert deleted is True
+    assert await redis_client.get(_key(cp_id)) is None
+
+
+@pytest.mark.asyncio
+async def test_mark_offline_preserves_key_when_owned_by_another_pod(
+    redis_client: Redis,
+) -> None:
+    """The reconnect race: charger reconnected to pod-B between pod-A's
+    disconnect detection and its mark_offline call. Pod-A must NOT
+    delete pod-B's key.
+
+    This is the bug the Lua compare-and-delete prevents. If someone
+    accidentally swaps it for a plain DEL, this test fails — the mocked
+    test would still pass.
+    """
+    cp_id = "LUA_TEST_RACE"
+    pod_a = _registry(redis_client, pod_id="pod-A")
+    pod_b = _registry(redis_client, pod_id="pod-B")
+
+    # Pod A had the key, then the charger reconnected to pod B.
+    await pod_a.mark_online(cp_id)
+    await pod_b.mark_online(cp_id)  # overwrites with pod-B
+    assert await redis_client.get(_key(cp_id)) == "pod-B"
+
+    # Pod A's late mark_offline must NOT delete pod-B's key.
+    deleted_by_a = await pod_a.mark_offline(cp_id)
+    assert deleted_by_a is False
+    assert await redis_client.get(_key(cp_id)) == "pod-B"
+
+    # Pod B can still release its own key.
+    deleted_by_b = await pod_b.mark_offline(cp_id)
+    assert deleted_by_b is True
+    assert await redis_client.get(_key(cp_id)) is None
+
+
+@pytest.mark.asyncio
+async def test_mark_offline_returns_false_when_key_already_expired(
+    redis_client: Redis,
+) -> None:
+    """If the TTL elapsed before mark_offline runs, the GET returns
+    nil (not the pod_id), so the script returns 0 — no key, nothing to
+    delete, no decrement of the per-pod gauge."""
+    cp_id = "LUA_TEST_EXPIRED"
+    reg = _registry(redis_client, pod_id="pod-A")
+
+    # No mark_online — simulate the key never existed (or expired).
+    deleted = await reg.mark_offline(cp_id)
+    assert deleted is False

--- a/tests/unit/transport/test_ws_server_basic_auth.py
+++ b/tests/unit/transport/test_ws_server_basic_auth.py
@@ -1,0 +1,227 @@
+"""WS Basic Auth integration test (issue #100).
+
+Unit tests for `_basic_auth.verify_basic_auth` and `_parse_basic_header`
+already exist in `test_basic_auth.py`. What's missing — and what this
+file fills — is the integration: does `serve_forever`'s `process_request`
+callback actually call `verify_basic_auth` and reject the upgrade?
+
+If someone removed the `process_request=_process_request` line in
+`ws_server.serve_forever`, every existing test would still pass (the
+function-under-test continues to work in isolation), but in production
+chargers would silently bypass Basic Auth on the WS upgrade.
+
+This test boots `serve_forever` on an ephemeral port against a real
+aiosqlite-backed session factory with one provisioned credential row,
+then opens real WebSocket connections from a `websockets` client and
+asserts:
+
+  - strict mode + missing creds → 401
+  - strict mode + wrong password → 401
+  - strict mode + correct creds → upgrade succeeds (we close right
+    after the handshake; we're not testing the OCPP handler stack)
+
+The bug class the audit highlighted is exactly the "wiring" gap that
+the unit test for `verify_basic_auth` cannot cover: a missing call,
+not a buggy implementation. Removing the `process_request=` wiring in
+the source while running this test will make every "should reject"
+case fail — verified locally.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import socket
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+# `websockets` is already a runtime dep; we use the asyncio variant the
+# rest of the e2e tests use.
+from websockets import InvalidStatus
+from websockets.asyncio.client import connect
+
+from eveys_ocpp.persistence.models import Base, ChargePoint, ChargePointCredential
+from eveys_ocpp.settings import Settings
+from eveys_ocpp.transport._basic_auth import hash_password
+from eveys_ocpp.transport.ws_server import OCPP_SUBPROTOCOL, serve_forever
+
+
+def _free_port() -> int:
+    """Bind a temporary socket on :0 to grab an unused port. The
+    SO_REUSEADDR dance lets the port be reused immediately when
+    `serve_forever` rebinds it microseconds later."""
+    with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest_asyncio.fixture
+async def session_factory_with_credential() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    """In-memory aiosqlite with the ORM schema + one charger
+    (`CP_AUTH_TEST`) credentialled with password `secret-pw`.
+
+    aiosqlite's :memory: is per-connection, so we use a connection
+    pool that pins every checkout to the same in-memory database via
+    `?cache=shared` + a fixed dsn that the pool returns to.
+
+    SQLite quirk: only `INTEGER PRIMARY KEY` aliases the rowid for
+    auto-increment. Our `BigInteger` PKs render as `BIGINT` and
+    don't get the magic. Apply `with_variant(Integer(), "sqlite")`
+    to every BigInteger PK so `INSERT INTO ... RETURNING id` works.
+    Idempotent — skips columns that already carry the variant from
+    a prior test in this process (metadata is module-global).
+    """
+    from sqlalchemy import BigInteger, Integer
+
+    for table in Base.metadata.tables.values():
+        for col in table.columns:
+            if (
+                col.primary_key
+                and isinstance(col.type, BigInteger)
+                and "sqlite" not in getattr(col.type, "_variant_mapping", {})
+            ):
+                col.type = col.type.with_variant(Integer(), "sqlite")  # type: ignore[assignment]
+
+    # `:memory:` per-connection means every pool checkout is a fresh
+    # blank DB — useless for tests that span >1 query. The shared-cache
+    # form gives every connection in the pool the same DB.
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///file:wsauth_mem?mode=memory&cache=shared&uri=true",
+        future=True,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with factory() as session:
+        cp = ChargePoint(cp_id="CP_AUTH_TEST")
+        session.add(cp)
+        await session.flush()
+        session.add(
+            ChargePointCredential(
+                charge_point_id=cp.id,
+                password_hash=hash_password("secret-pw"),
+            )
+        )
+        await session.commit()
+
+    yield factory
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def running_server(
+    session_factory_with_credential: async_sessionmaker[AsyncSession],
+) -> AsyncIterator[int]:
+    """Boot `serve_forever` on an ephemeral port in a background task.
+    Yields the port; cancels the task on teardown.
+
+    `ws_basic_auth_required=True` (strict mode) — that's the
+    production posture and the one the test cases are written for.
+    """
+    port = _free_port()
+    settings = Settings(
+        ws_host="127.0.0.1",
+        ws_port=port,
+        ws_basic_auth_required=True,
+    )
+    task = asyncio.create_task(
+        serve_forever(
+            session_factory=session_factory_with_credential,
+            settings=settings,
+        )
+    )
+    # Wait for the listener to actually accept connections — `serve()`
+    # is async and the bind happens inside it. Probe the port until
+    # it answers.
+    deadline = asyncio.get_event_loop().time() + 2.0
+    while asyncio.get_event_loop().time() < deadline:
+        try:
+            with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+                s.settimeout(0.1)
+                s.connect(("127.0.0.1", port))
+                break
+        except OSError:
+            await asyncio.sleep(0.05)
+    else:  # pragma: no cover — defensive
+        task.cancel()
+        with contextlib.suppress(BaseException):
+            await task
+        raise RuntimeError("ws_server didn't bind within 2s")
+
+    yield port
+
+    task.cancel()
+    with contextlib.suppress(BaseException):
+        await task
+
+
+# ---- the actual test cases ------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ws_upgrade_rejects_when_missing_credentials(
+    running_server: int,
+) -> None:
+    """Strict mode + no Authorization header → 401 from the
+    `process_request` callback. The OCPP handler stack never sees
+    the connection.
+
+    If someone removed the `process_request=` wiring, the upgrade
+    would succeed (websockets defaults are permissive); this test
+    would then fail with `did not raise InvalidStatus`.
+    """
+    with pytest.raises(InvalidStatus) as excinfo:
+        async with connect(
+            f"ws://127.0.0.1:{running_server}/CP_AUTH_TEST",
+            subprotocols=[OCPP_SUBPROTOCOL],
+        ):
+            pass
+    assert excinfo.value.response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_ws_upgrade_rejects_with_wrong_password(
+    running_server: int,
+) -> None:
+    """Wrong password → 401. Same rejection path as missing creds."""
+    with pytest.raises(InvalidStatus) as excinfo:
+        async with connect(
+            f"ws://127.0.0.1:{running_server}/CP_AUTH_TEST",
+            subprotocols=[OCPP_SUBPROTOCOL],
+            additional_headers={"Authorization": "Basic Q1BfQVVUSF9URVNUOndyb25n"},
+        ):
+            pass
+    assert excinfo.value.response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_ws_upgrade_accepts_with_correct_credentials(
+    running_server: int,
+) -> None:
+    """Correct creds → upgrade succeeds. We don't drive the OCPP
+    handler stack here — opening the connection is the assertion;
+    if the handshake completes, the integration is wired.
+
+    Header value: base64("CP_AUTH_TEST:secret-pw").
+    """
+    import base64
+
+    creds = base64.b64encode(b"CP_AUTH_TEST:secret-pw").decode("ascii")
+    async with connect(
+        f"ws://127.0.0.1:{running_server}/CP_AUTH_TEST",
+        subprotocols=[OCPP_SUBPROTOCOL],
+        additional_headers={"Authorization": f"Basic {creds}"},
+    ) as ws:
+        # Reaching this line means the upgrade completed — we close
+        # immediately. The OCPP handler is exercised by the e2e suite,
+        # not here.
+        assert ws.subprotocol == OCPP_SUBPROTOCOL


### PR DESCRIPTION
## Summary

Follow-up to the test-suite audit triggered by #88 / #92 / #98. Closes 2 of the 3 gaps the audit flagged; the third was a false positive on the audit's part. Each new test was **demonstrated-failing on the broken state** before being shipped, the same close-the-loop discipline that landed in the Envoy fix.

### Gap 1 — Registry Lua compare-and-delete

\`test_registry.py\` mocks \`redis.eval()\`, so a Lua syntax error or KEYS/ARGV mismatch would still pass tests but silently break the multi-pod reconnect race guard. New file \`tests/unit/test_registry_lua.py\` runs the script against real Redis (compose default + skip pattern matching \`test_idempotency.py\`).

Verified-fails: replacing the Lua body with a plain \`redis.call('DEL', KEYS[1])\` makes the race-protection test fail. Restored before commit.

### Gap 2 — WS Basic Auth integration

\`test_basic_auth.py\` covers the parser and the verifier in isolation, but the wiring between \`serve_forever\`'s \`process_request\` callback and \`verify_basic_auth\` was never exercised. New file \`tests/unit/transport/test_ws_server_basic_auth.py\` boots the real \`serve_forever\` on an ephemeral port against an aiosqlite-backed session factory with one provisioned credential row, then opens real WebSocket connections from \`websockets.asyncio.client.connect\` and asserts strict-mode rejection paths.

Verified-fails: removing the \`process_request=_process_request\` parameter in \`ws_server.py\` makes both rejection tests fail. Restored before commit.

### Gap 3 — OpenAPI bypass with auth-required (audit was wrong)

The audit flagged this as missing. It's not — \`test_openapi_paths_bypass_auth_when_enabled\` already covers \`openapi_enabled=True + auth_required + non-empty allowlist\` (shipped in #89). I'm calling this out explicitly because flagging audit false-positives is part of the trust-restoration discipline I committed to.

## Out of scope

Audit findings 2 (webhook header shape), 6 (signature contract), 7 (bearer header) — lower severity, tracked for a follow-up PR.

## Test plan

- [x] \`make lint\` clean
- [x] \`make types\` clean
- [x] \`make test\` (656 passed at 84.4% coverage; +6 new tests)
- [x] Verify-fails dance for both new test files (described above)
- [ ] CI runs the full suite — Redis service is already declared in the \`unit\` job, so the new \`test_registry_lua.py\` tests will execute (not silently skip)

Closes #100