### PR TITLE
feature(security): SecurityEventNotification handler — TC_077, TC_078

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,7 @@ EVEYS_OCPP_KAFKA_TOPIC_CP_METER=cp.meter
 EVEYS_OCPP_KAFKA_TOPIC_CP_BOOT=cp.boot
 EVEYS_OCPP_KAFKA_TOPIC_CP_STATUS=cp.status
 EVEYS_OCPP_KAFKA_TOPIC_TX_STARTED=tx.started
+EVEYS_OCPP_KAFKA_TOPIC_CP_SECURITY_EVENT=cp.security_event
 
 # ---- Redis (online registry + pub/sub bus, ADR-0016) -------------
 

--- a/alembic/versions/2026_05_08_0007-0007_security_events.py
+++ b/alembic/versions/2026_05_08_0007-0007_security_events.py
@@ -1,0 +1,78 @@
+"""security_events table (Phase 5 / TC_077, TC_078).
+
+Revision ID: 0007
+Revises: 0006
+Create Date: 2026-05-08
+
+Per-charger security event log from OCPP 1.6 Security Whitepaper §4
+SecurityEventNotification. **Append-only log**, NOT latest-wins —
+events are audit-grade and we keep every one. The 18 spec-defined
+event types (FirmwareUpdated, InvalidFirmwareSignature,
+InvalidSecurityEventCertificate, ...) are stored as the charger-
+reported string; the column width allows for future spec additions
+or vendor extensions without a migration.
+
+`reported_at` is the charger's claimed timestamp; `received_at` is
+our server-receive time. The charger's clock is untrusted (AGENTS
+rule 7), so operator alerting / dedup MUST anchor on received_at.
+
+Index on (charge_point_id, received_at DESC) supports the natural
+operator query: "what security events did this charger emit, most
+recent first?".
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0007"
+down_revision: str | None = "0006"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "security_events",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, primary_key=True),
+        sa.Column(
+            "charge_point_id",
+            sa.BigInteger(),
+            sa.ForeignKey("charge_points.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        # OCPP 1.6 Security Whitepaper §4 enumerates 18 event-type
+        # names; longest is `InvalidSecurityEventCertificate` at 31
+        # chars. 64 leaves room for vendor extensions and future
+        # spec additions.
+        sa.Column("event_type", sa.String(length=64), nullable=False),
+        # Charger-claimed timestamp (untrusted; AGENTS rule 7).
+        sa.Column("reported_at", sa.DateTime(timezone=True), nullable=False),
+        # Server-receive time. The trustworthy ordering anchor.
+        sa.Column(
+            "received_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        # Optional vendor-specific context. The OCPP spec calls this
+        # `techInfo`; we keep snake_case. NULL distinct from empty
+        # string because the spec field is optional.
+        sa.Column("tech_info", sa.Text(), nullable=True),
+    )
+    # Ops query: "show me the last N events for charger X, newest
+    # first". Postgres can walk this index forward to satisfy the
+    # ORDER BY received_at DESC LIMIT N pattern.
+    op.create_index(
+        "ix_security_events_cp_received",
+        "security_events",
+        ["charge_point_id", sa.text("received_at DESC")],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_security_events_cp_received", table_name="security_events")
+    op.drop_table("security_events")

--- a/docs/08-ocpp-conformance.md
+++ b/docs/08-ocpp-conformance.md
@@ -84,7 +84,7 @@ A row moves from 🟡 to ✅ only when **all** of the following are true:
 | TC_075_1 | Install ManufacturerRootCertificate | ⏳ | Phase 5 | — | |
 | TC_075_2 | Install CentralSystemRootCertificate | ⏳ | Phase 5 | — | |
 | TC_076 | Delete a specific certificate | ⏳ | Phase 5 | — | |
-| TC_078 | Invalid CentralSystemCertificate Security Event | ⏳ | Phase 5 | — | |
+| TC_078 | Invalid CentralSystemCertificate Security Event | 🟡 | [`handlers/v16/security_event_notification.py`](../src/eveys_ocpp/handlers/v16/security_event_notification.py) | [test_security_event_notification.py](../tests/unit/handlers/v16/test_security_event_notification.py) | Charger-initiated SecurityEventNotification (OCPP 1.6 Security Whitepaper §4). Audit-grade row in `security_events` (append-only, FK to `charge_points`, migration `0007`); Kafka envelope `cp.security_event` for SIEM consumers. Handler covers all 18 spec event types — TC_077 (ChargePoint cert variant) shares the same row in the Advanced Security profile section below. |
 | TC_079 | Get Security Log | ⏳ | Phase 5 | — | |
 | TC_080 | Secure Firmware Update | ⏳ | Phase 5 | — | |
 | TC_081 | Secure Firmware Update — Invalid Signature | ⏳ | Phase 5 | — | |
@@ -129,7 +129,7 @@ These are charger-initiated actions the CSMS must respond to. Appendix C tests t
 | TC ID | Scenario | Status | Implementation |
 |---|---|---|---|
 | TC_074 | Update Charge Point Certificate by request of Central System | ⏳ Phase 5 | mTLS work (E5-5) |
-| TC_077 | Invalid ChargePointCertificate Security Event | ⏳ Phase 5 | |
+| TC_077 | Invalid ChargePointCertificate Security Event | 🟡 | [`handlers/v16/security_event_notification.py`](../src/eveys_ocpp/handlers/v16/security_event_notification.py); same handler as TC_078 — charger reports `type=InvalidSecurityEventCertificate` for either the CP or CSMS variant. Tests in [test_security_event_notification.py](../tests/unit/handlers/v16/test_security_event_notification.py). |
 | TC_087 | TLS — Client-side certificate — valid certificate | ⏳ Phase 5 | |
 
 ---

--- a/docs/11-configuration-reference.md
+++ b/docs/11-configuration-reference.md
@@ -82,6 +82,7 @@ sensitivity.
 | `EVEYS_OCPP_KAFKA_TOPIC_CP_BOOT` | `cp.boot` | string | structural | no | `BootNotification` events. | Renaming detaches every existing consumer. |
 | `EVEYS_OCPP_KAFKA_TOPIC_CP_STATUS` | `cp.status` | string | structural | no | `StatusNotification` events. | Renaming detaches every existing consumer. |
 | `EVEYS_OCPP_KAFKA_TOPIC_TX_STARTED` | `tx.started` | string | structural | no | `StartTransaction` events (financial path). | Renaming detaches every existing consumer. |
+| `EVEYS_OCPP_KAFKA_TOPIC_CP_SECURITY_EVENT` | `cp.security_event` | string | structural | no | `SecurityEventNotification` events from chargers (OCPP 1.6 Security Whitepaper §4). Audit-grade; downstream SIEM consumers tail this for alerting on invalid signatures, cert tampering, etc. | Renaming detaches every existing consumer. |
 
 ## Redis (online registry + pub/sub bus, ADR-0016)
 

--- a/proto/events/v1/events.proto
+++ b/proto/events/v1/events.proto
@@ -56,6 +56,7 @@ message EventEnvelope {
     CpStatus cp_status = 102;
     CpMeter cp_meter = 103;
     TxStarted tx_started = 104;
+    CpSecurityEvent cp_security_event = 105;
   }
 }
 
@@ -245,4 +246,30 @@ message TxStarted {
   int64 meter_start_wh = 4;
   // Charger-claimed timestamp. Server-receive time is in the envelope.
   string charger_reported_at = 5;
+}
+
+// -----------------------------------------------------------------------------
+// cp.security_event — SecurityEventNotification arrived (OCPP 1.6 Security
+// Whitepaper §4). Audit-grade event log; CSMS retains every event.
+// -----------------------------------------------------------------------------
+//
+// `type` is one of 18 spec-defined event names (FirmwareUpdated,
+// InvalidFirmwareSignature, InvalidSecurityEventCertificate, etc).
+// We persist whatever string the charger reports — same forward-compat
+// reasoning as `cp_status.error_code`. Operators classify CRITICAL vs
+// NON-CRITICAL downstream from the type field.
+
+message CpSecurityEvent {
+  // OCPP event type name. String, not enum, to allow vendor extensions
+  // and future spec additions without a proto bump.
+  string type = 1;
+  // Charger-claimed timestamp of when the event occurred. Server-
+  // receive time is in the envelope. The charger's clock is untrusted
+  // (AGENTS rule 7) — operators should anchor on `occurred_at` for
+  // ordering, not this field.
+  string charger_reported_at = 2;
+  // Optional vendor-specific detail. The OCPP spec calls this
+  // `techInfo`; we keep the snake_case name. Empty string when
+  // absent (proto3 default).
+  string tech_info = 3;
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,7 @@ module = [
     "eveys_ocpp.handlers.v16.boot_notification",
     "eveys_ocpp.handlers.v16.status_notification",
     "eveys_ocpp.handlers.v16.start_transaction",
+    "eveys_ocpp.handlers.v16.security_event_notification",
     # E2-14 ClickHouse ingestor — same generated `events_pb2` opaqueness.
     "eveys_ocpp.clickhouse.ingestor",
     # E3-9 webhook dispatcher — same generated `events_pb2` opaqueness.

--- a/src/eveys_ocpp/connection.py
+++ b/src/eveys_ocpp/connection.py
@@ -23,6 +23,7 @@ from eveys_ocpp.handlers.v16 import (
     firmware_status_notification,
     heartbeat,
     meter_values,
+    security_event_notification,
     start_transaction,
     status_notification,
     stop_transaction,
@@ -147,6 +148,12 @@ class EveysChargePoint(Cpv16):
         self, **kwargs: Any
     ) -> call_result.FirmwareStatusNotification:
         return await firmware_status_notification.handle(self, **kwargs)
+
+    @on(Action.security_event_notification)
+    async def on_security_event_notification(
+        self, **kwargs: Any
+    ) -> call_result.SecurityEventNotification:
+        return await security_event_notification.handle(self, **kwargs)
 
     # ---- Prometheus instrumentation hooks (E4-1) ----------------------------
     # Override the library's inbound and outbound dispatch points so we

--- a/src/eveys_ocpp/handlers/v16/security_event_notification.py
+++ b/src/eveys_ocpp/handlers/v16/security_event_notification.py
@@ -1,0 +1,143 @@
+"""SecurityEventNotification handler (charger-initiated).
+
+OCPP 1.6 reference: Security Whitepaper §4 (SecurityEventNotification.req
++ .conf). The charger emits this for any of the 18 spec-defined event
+types — some CRITICAL (e.g. `InvalidFirmwareSignature`,
+`InvalidSecurityEventCertificate`) which operator alerting must page
+on, others NON-CRITICAL (e.g. `FirmwareUpdated`) which are routine.
+The CSMS retains every event for audit (TC_077, TC_078).
+
+Behaviour:
+1. Insert a new row into `security_events` (append-only log; not
+   latest-wins). Foreign key requires the BootNotification handler
+   to have run first; an event before boot raises `ValueError` and
+   metrics it as a handler error so the on-call team notices.
+2. Publish a `cp.security_event` Kafka envelope so downstream SIEM
+   consumers can tail it. Best-effort: a publish failure is logged
+   and dropped, same as `meter_values` / `status_notification`.
+3. Increment the per-event-type counter so the fleet dashboard's
+   "security events by type" panel populates.
+4. Reply with the empty conf the spec mandates.
+
+The 18 spec-defined event types are stored as the charger-reported
+string; column width allows for vendor extensions and future spec
+additions without a migration. Operators classify CRITICAL vs
+NON-CRITICAL downstream from the type field — keeping that logic out
+of the gateway means a future spec amendment doesn't require a
+gateway code change.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from ocpp.v16 import call_result
+
+from eveys_ocpp._generated.events.v1 import events_pb2
+from eveys_ocpp.metrics import record_handler_error, time_handler
+from eveys_ocpp.metrics import registry as metrics_registry
+from eveys_ocpp.observability import bind_contextvars, get_logger
+from eveys_ocpp.persistence.db import session_scope
+from eveys_ocpp.persistence.repositories import record_security_event
+
+if TYPE_CHECKING:
+    from eveys_ocpp.connection import EveysChargePoint
+
+log = get_logger(__name__)
+
+
+def _build_envelope(
+    *,
+    cp_id: str,
+    payload: events_pb2.CpSecurityEvent,
+    occurred_at: datetime,
+) -> bytes:
+    envelope = events_pb2.EventEnvelope(
+        event_id=str(uuid.uuid4()),
+        occurred_at=occurred_at.isoformat(),
+        cp_id=cp_id,
+        schema_version="v1",
+        cp_security_event=payload,
+    )
+    return envelope.SerializeToString()
+
+
+def _parse_reported_at(timestamp: str) -> datetime:
+    """The OCPP spec's `timestamp` is ISO-8601. Pydantic-style parse;
+    fall back to "now" only if the charger sent something we can't
+    interpret — log loud so a misbehaving vendor is visible.
+
+    Charger clocks are untrusted (AGENTS rule 7), so a successful
+    parse here does not mean the value is *correct* — it just means
+    we have something to put in the column. Operators anchor on
+    `received_at` for ordering."""
+    try:
+        return datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        log.warning(
+            "security_event.unparseable_timestamp",
+            charger_reported=timestamp,
+        )
+        return datetime.now(UTC)
+
+
+async def handle(
+    cp: EveysChargePoint,
+    *,
+    type: str,
+    timestamp: str,
+    tech_info: str | None = None,
+    **_: object,
+) -> call_result.SecurityEventNotification:
+    bind_contextvars(cp_id=cp.id, action="SecurityEventNotification", direction="rx")
+
+    metrics_registry.SECURITY_EVENTS_TOTAL.labels(event_type=type).inc()
+    with time_handler("SecurityEventNotification"):
+        try:
+            received_at = datetime.now(UTC)
+            reported_at = _parse_reported_at(timestamp)
+
+            async with session_scope(cp.session_factory) as session:
+                await record_security_event(
+                    session,
+                    cp_id=cp.id,
+                    event_type=type,
+                    reported_at=reported_at,
+                    tech_info=tech_info,
+                )
+
+            log.info(
+                "security_event_notification",
+                event_type=type,
+                charger_reported_at=timestamp,
+                tech_info_present=tech_info is not None,
+            )
+
+            if cp.event_producer is not None:
+                payload = events_pb2.CpSecurityEvent(
+                    type=type,
+                    charger_reported_at=timestamp,
+                    tech_info=tech_info or "",
+                )
+                envelope_bytes = _build_envelope(
+                    cp_id=cp.id, payload=payload, occurred_at=received_at
+                )
+                # Best-effort: a Kafka publish failure must not crash
+                # the OCPP handler. Same rationale as status_notification
+                # / meter_values — the audit-grade row is already in
+                # Postgres above; Kafka is the SIEM-fanout path.
+                try:
+                    await cp.event_producer.publish(
+                        topic=cp.settings.kafka_topic_cp_security_event,
+                        key=cp.id,
+                        value=envelope_bytes,
+                    )
+                except Exception as exc:
+                    log.warning("security_event.publish_failed", error=str(exc))
+
+            return call_result.SecurityEventNotification()
+        except Exception as exc:
+            record_handler_error("SecurityEventNotification", exc)
+            raise

--- a/src/eveys_ocpp/metrics/registry.py
+++ b/src/eveys_ocpp/metrics/registry.py
@@ -269,6 +269,16 @@ DIAGNOSTICS_STATUS_TOTAL: Counter = Counter(
     "(Idle / Uploading / Uploaded / UploadFailed).",
     labelnames=("status",),
 )
+SECURITY_EVENTS_TOTAL: Counter = Counter(
+    "eveys_ocpp_security_events_total",
+    "SecurityEventNotification CALLs grouped by event type "
+    "(OCPP 1.6 Security Whitepaper §4: FirmwareUpdated, "
+    "InvalidFirmwareSignature, InvalidSecurityEventCertificate, "
+    "etc.). Operators use this for SIEM-style alerting; the "
+    "type label is bounded by the spec's 18-value enum + any "
+    "vendor extensions, so cardinality stays small.",
+    labelnames=("event_type",),
+)
 
 
 # ---- gRPC server ----------------------------------------------------------

--- a/src/eveys_ocpp/persistence/models.py
+++ b/src/eveys_ocpp/persistence/models.py
@@ -421,3 +421,32 @@ class ChargingSchedulePeriod(Base):
     start_period: Mapped[int] = mapped_column(nullable=False)
     limit: Mapped[Decimal] = mapped_column(Numeric(10, 2), nullable=False)
     number_phases: Mapped[int | None] = mapped_column()
+
+
+class SecurityEvent(Base):
+    """One row per `SecurityEventNotification` from a charger
+    (OCPP 1.6 Security Whitepaper §4, TC_077 / TC_078).
+
+    Audit-grade log, NOT latest-wins. Operator alerting / SIEM read
+    this table for security posture. The 18 spec-defined event types
+    are stored as the charger-reported string — same forward-compat
+    convention as `charge_points.last_status` / `error_code`.
+
+    `reported_at` is the charger's claimed timestamp (untrusted per
+    AGENTS rule 7); `received_at` is the trustworthy ordering anchor.
+    """
+
+    __tablename__ = "security_events"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    charge_point_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("charge_points.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    event_type: Mapped[str] = mapped_column(String(64), nullable=False)
+    reported_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    received_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    tech_info: Mapped[str | None] = mapped_column(Text)

--- a/src/eveys_ocpp/persistence/repositories.py
+++ b/src/eveys_ocpp/persistence/repositories.py
@@ -24,6 +24,7 @@ from .models import (
     LocalAuthList,
     LocalAuthListEntry,
     Reservation,
+    SecurityEvent,
     Transaction,
 )
 
@@ -95,6 +96,40 @@ async def update_firmware_status(session: AsyncSession, *, cp_id: str, status: s
     """Record the latest FirmwareStatusNotification (E2-1F)."""
     await session.execute(
         update(ChargePoint).where(ChargePoint.cp_id == cp_id).values(last_firmware_status=status)
+    )
+
+
+async def record_security_event(
+    session: AsyncSession,
+    *,
+    cp_id: str,
+    event_type: str,
+    reported_at: datetime,
+    tech_info: str | None,
+) -> None:
+    """Insert a row into `security_events` for an inbound
+    SecurityEventNotification (TC_077 / TC_078, OCPP 1.6 Security
+    Whitepaper §4).
+
+    Append-only — operators read the table via the audit query
+    surface; we never UPDATE or DELETE here. If the charger doesn't
+    yet have a row in `charge_points`, the FK fails — that's
+    intentional, callers should make sure the BootNotification
+    handler has run first.
+    """
+    cp_pk = await get_charge_point_pk(session, cp_id=cp_id)
+    if cp_pk is None:
+        # Defensive: a SecurityEventNotification before BootNotification
+        # would orphan the row. Fail loud — this is a charger
+        # protocol error, not a routine retry.
+        raise ValueError(f"unknown cp_id for security event: {cp_id!r}")
+    session.add(
+        SecurityEvent(
+            charge_point_id=cp_pk,
+            event_type=event_type,
+            reported_at=reported_at,
+            tech_info=tech_info,
+        )
     )
 
 

--- a/src/eveys_ocpp/settings.py
+++ b/src/eveys_ocpp/settings.py
@@ -380,6 +380,21 @@ class Settings(BaseSettings):
             "stability": "structural",
         },
     )
+    kafka_topic_cp_security_event: str = Field(
+        default="cp.security_event",
+        description=(
+            "`SecurityEventNotification` events from chargers "
+            "(OCPP 1.6 Security Whitepaper §4). Audit-grade; "
+            "downstream SIEM consumers tail this for alerting on "
+            "invalid signatures, cert tampering, etc."
+        ),
+        json_schema_extra={
+            "category": "kafka_topics",
+            "impact": "Renaming detaches every existing consumer.",
+            "secret": False,
+            "stability": "structural",
+        },
+    )
 
     # ---- Redis (online registry + pub/sub bus, ADR-0016) ----------------
     redis_url: str = Field(

--- a/tests/unit/handlers/v16/test_security_event_notification.py
+++ b/tests/unit/handlers/v16/test_security_event_notification.py
@@ -1,0 +1,201 @@
+"""Unit tests for the SecurityEventNotification handler (TC_077, TC_078).
+
+OCPP 1.6 Security Whitepaper §4. Audit-grade event log; one row per
+event in `security_events`. Operators tail the Kafka topic for
+SIEM-style alerting.
+
+Charger clocks are untrusted (AGENTS rule 7), so the handler:
+- persists the charger's claimed `timestamp` AS-IS in `reported_at`
+- stamps server-receive time in `received_at`
+- forwards both unchanged to the Kafka envelope's payload + envelope
+  outer fields respectively
+
+Tests below pin those contracts with verify-fails-without-fix
+checked before commit (commit message has the dance).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from ocpp.v16 import call_result
+
+from eveys_ocpp._generated.events.v1 import events_pb2
+from eveys_ocpp.handlers.v16 import security_event_notification
+
+
+@pytest.mark.asyncio
+async def test_records_event_and_returns_empty_conf(
+    fake_cp: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Happy path: handler invokes the repo function with the right
+    args and returns the empty conf the spec mandates."""
+    record = AsyncMock()
+    monkeypatch.setattr(security_event_notification, "record_security_event", record)
+
+    result = await security_event_notification.handle(
+        fake_cp,
+        type="FirmwareUpdated",
+        timestamp="2026-05-08T22:00:00+00:00",
+    )
+
+    assert isinstance(result, call_result.SecurityEventNotification)
+    record.assert_awaited_once()
+    kwargs = record.await_args.kwargs
+    assert kwargs["cp_id"] == "TEST_CP_001"
+    assert kwargs["event_type"] == "FirmwareUpdated"
+    assert kwargs["tech_info"] is None
+    # `reported_at` is parsed to a real datetime (not the raw string).
+    from datetime import datetime
+
+    assert isinstance(kwargs["reported_at"], datetime)
+    assert kwargs["reported_at"].tzinfo is not None
+
+
+@pytest.mark.asyncio
+async def test_persists_tech_info_when_provided(
+    fake_cp: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Vendor extensions arrive in `tech_info` (string). Empty/None
+    is the proto3 default; a real value must round-trip."""
+    record = AsyncMock()
+    monkeypatch.setattr(security_event_notification, "record_security_event", record)
+
+    await security_event_notification.handle(
+        fake_cp,
+        type="InvalidFirmwareSignature",
+        timestamp="2026-05-08T22:00:00+00:00",
+        tech_info="vendor:acme cert_serial=ABC123",
+    )
+
+    assert record.await_args.kwargs["tech_info"] == "vendor:acme cert_serial=ABC123"
+
+
+@pytest.mark.asyncio
+async def test_unparseable_timestamp_falls_back_to_now(
+    fake_cp: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A vendor that emits a non-ISO-8601 timestamp shouldn't crash
+    the handler — log loud, fall back to received-at-style 'now'.
+    Charger clocks are already untrusted, so the only correctness
+    guarantee is that we keep ingesting events."""
+    record = AsyncMock()
+    monkeypatch.setattr(security_event_notification, "record_security_event", record)
+
+    result = await security_event_notification.handle(
+        fake_cp,
+        type="FirmwareUpdated",
+        timestamp="not-a-real-timestamp",
+    )
+
+    assert isinstance(result, call_result.SecurityEventNotification)
+    # The repo is still called — we don't drop the event on bad
+    # timestamps. `reported_at` is a fallback datetime.
+    record.assert_awaited_once()
+    from datetime import datetime
+
+    assert isinstance(record.await_args.kwargs["reported_at"], datetime)
+
+
+# ---- Kafka emit -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_publishes_to_cp_security_event_topic_when_producer_attached(
+    fake_cp: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When event_producer is wired, the handler publishes a
+    `cp.security_event` envelope. SIEM consumers tail this for
+    alerting; the type, charger_reported_at, and tech_info round-trip
+    verbatim."""
+    monkeypatch.setattr(security_event_notification, "record_security_event", AsyncMock())
+    fake_producer = AsyncMock()
+    fake_cp.event_producer = fake_producer
+
+    await security_event_notification.handle(
+        fake_cp,
+        type="InvalidSecurityEventCertificate",
+        timestamp="2026-05-08T22:00:00+00:00",
+        tech_info="cert_subject=CN=evil",
+    )
+
+    fake_producer.publish.assert_awaited_once()
+    call_kwargs = fake_producer.publish.await_args.kwargs
+    assert call_kwargs["topic"] == fake_cp.settings.kafka_topic_cp_security_event
+    assert call_kwargs["key"] == "TEST_CP_001"
+
+    envelope = events_pb2.EventEnvelope()
+    envelope.ParseFromString(call_kwargs["value"])
+    assert envelope.cp_id == "TEST_CP_001"
+    assert envelope.HasField("cp_security_event")
+    assert envelope.cp_security_event.type == "InvalidSecurityEventCertificate"
+    assert envelope.cp_security_event.charger_reported_at == "2026-05-08T22:00:00+00:00"
+    assert envelope.cp_security_event.tech_info == "cert_subject=CN=evil"
+
+
+@pytest.mark.asyncio
+async def test_no_publish_when_producer_is_none(
+    fake_cp: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The Kafka path is best-effort — when no producer is wired the
+    handler still persists + returns the empty conf."""
+    monkeypatch.setattr(security_event_notification, "record_security_event", AsyncMock())
+    fake_cp.event_producer = None
+
+    result = await security_event_notification.handle(
+        fake_cp, type="FirmwareUpdated", timestamp="2026-05-08T22:00:00+00:00"
+    )
+
+    assert isinstance(result, call_result.SecurityEventNotification)
+
+
+@pytest.mark.asyncio
+async def test_handler_survives_kafka_publish_exception(
+    fake_cp: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Broker drop must not crash the OCPP handler. The audit row is
+    already in Postgres (above); Kafka is the SIEM-fanout path."""
+    monkeypatch.setattr(security_event_notification, "record_security_event", AsyncMock())
+    fake_producer = AsyncMock()
+    fake_producer.publish = AsyncMock(side_effect=RuntimeError("broker is down"))
+    fake_cp.event_producer = fake_producer
+
+    result = await security_event_notification.handle(
+        fake_cp, type="FirmwareUpdated", timestamp="2026-05-08T22:00:00+00:00"
+    )
+
+    assert isinstance(result, call_result.SecurityEventNotification)
+    fake_producer.publish.assert_awaited_once()
+
+
+# ---- Metric label ---------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_metric_label_carries_event_type(
+    fake_cp: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`SECURITY_EVENTS_TOTAL` is labelled by event_type; the fleet
+    dashboard's "security events by type" panel reads this. A future
+    regression that hardcoded the label would silently empty the
+    panel."""
+    from eveys_ocpp.metrics import registry as metrics_registry
+
+    monkeypatch.setattr(security_event_notification, "record_security_event", AsyncMock())
+
+    before = metrics_registry.SECURITY_EVENTS_TOTAL.labels(
+        event_type="InvalidFirmwareSignature"
+    )._value.get()
+
+    await security_event_notification.handle(
+        fake_cp,
+        type="InvalidFirmwareSignature",
+        timestamp="2026-05-08T22:00:00+00:00",
+    )
+
+    after = metrics_registry.SECURITY_EVENTS_TOTAL.labels(
+        event_type="InvalidFirmwareSignature"
+    )._value.get()
+    assert after == before + 1

--- a/tests/unit/metrics/test_registry.py
+++ b/tests/unit/metrics/test_registry.py
@@ -25,7 +25,8 @@ from eveys_ocpp.metrics import registry as m
 
 # Inventory total per E4-1 plan. Update both numbers if the inventory
 # grows in a future PR.
-EXPECTED_METRIC_COUNT = 55
+# 56: +1 SECURITY_EVENTS_TOTAL for SecurityEventNotification (TC_077/078)
+EXPECTED_METRIC_COUNT = 56
 
 
 def _gateway_metric_attrs() -> list[tuple[str, object]]:


### PR DESCRIPTION
## Summary

First slice of the OCPP 1.6 Security Whitepaper handlers. Charger-initiated SecurityEventNotification per §4 of the whitepaper — audit-grade event log; one row per event, NOT latest-wins. Operators tail the Kafka topic for SIEM-style alerting.

## What ships

- **Proto**: new \`CpSecurityEvent\` message in the \`EventEnvelope.payload\` oneof.
- **Migration 0007**: \`security_events\` table (append-only, FK to \`charge_points\`, indexed on \`(charge_point_id, received_at DESC)\`).
- **Model + repo**: \`SecurityEvent\`, \`record_security_event\` (fails loud on FK miss — protocol error if event arrives before BootNotification).
- **Handler**: \`handlers/v16/security_event_notification.py\`. Persist + best-effort Kafka publish + empty conf reply. Untrusted-clock handling: \`received_at\` is the ordering anchor; charger's claimed \`timestamp\` lands in \`reported_at\`. Unparseable timestamp → fallback to "now" with loud warning, not a crash (else we'd lose the audit row).
- **Settings**: \`kafka_topic_cp_security_event\` (default \`cp.security_event\`).
- **Wiring**: \`@on(Action.security_event_notification)\` in \`connection.py\`.
- **Metric**: \`eveys_ocpp_security_events_total{event_type}\`.

## Tests

7 new unit tests covering happy path, \`tech_info\` round-trip, unparseable timestamp, Kafka emit shape, no-producer path, broker-drop survival, per-event-type metric label.

**Verify-fails dance** for the two key invariants:

1. Skipped the \`record_security_event\` call → 3 tests failed (persistence assertion). Restored.
2. Clobbered \`payload.type\` to \`"UNKNOWN"\` → Kafka-emit test failed. Restored.

Full suite: 671 passed at 84.4% coverage.

## Matrix

- **TC_077** (Advanced Security profile, \`InvalidChargePointCertificate\` event variant) — ⏳ → 🟡
- **TC_078** (Core profile, \`InvalidCentralSystemCertificate\` event variant) — ⏳ → 🟡

Same handler covers both; the charger-reported \`type\` string differentiates which certificate variant.

## Out of scope (future slices)

- TC_074, TC_075, TC_076 — Install/Delete/CertificateSigned (real certificate state to persist)
- TC_079 — GetLog + LogStatusNotification (log-upload coordination)
- TC_080 / TC_081 — SignedUpdateFirmware (firmware signature verification)
- ClickHouse \`cp_security_events\` table + read-side endpoints

## Test plan

- [x] \`make lint\` clean
- [x] \`make types\` clean
- [x] \`make test\` (671 passed, 84.4% coverage; +7 new tests)
- [x] \`make config-export\` ran (new setting picked up in \`.env.example\` + \`docs/11-configuration-reference.md\`)
- [x] \`make protoc\` ran (events_pb2 stub regenerated; gitignored, CI rebuilds)
- [x] Verify-fails dance for both critical invariants

Closes #108