### PR TITLE
fix(deps): re-add aiosqlite to dev deps; CI was red since #113

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
     "grpcio-tools>=1.66",          # protoc + grpc_tools.protoc for codegen (dev only)
     "pyyaml>=6.0",                 # parse `deploy/prometheus/rules.yml` in the SLO sanity test (E4-8). Transitively present today via pre-commit, but declared here so the test stays green if pre-commit drops the dep.
     "pip-audit>=2.7",              # E5-8: scan resolved deps against the PyPI advisory DB. Local-runnable via `make audit`; CI runs on PR + daily schedule.
+    "aiosqlite>=0.20",             # In-memory async SQLite for unit tests that need real ORM behaviour (FK cascades, IntegrityError, BigInteger PK quirks). Used by `tests/unit/transport/test_ws_server_basic_auth.py` and `tests/unit/transport/test_grpc_server.py` cert-mgmt + signed-firmware tests. Production runs on Postgres.
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary

\`aiosqlite\` was missing from \`pyproject.toml\` dev deps. The cert-mgmt tests in #113 and the signed-firmware tests in #115 both relied on it, both passed locally (cached from a rolled-back branch), and **both merged with \`unit\` FAILING in CI** because branch protection on \`main\` doesn't require any status check.

This PR re-adds the dep with a comment explaining what it's for and which tests need it.

## Why this slipped through

- Local venv had aiosqlite cached → \`make test\` green for me.
- CI failed with 12 \`ModuleNotFoundError\` errors → \`unit\` job FAILURE.
- \`gh pr merge --auto\` fires when branch-protection rules are met. The repo's protection rules don't list any required status check, so \`--auto\` accepted both PRs despite the failures.

This is the same class of "test was green for the wrong reason" gap the audit work in #100 / #102 was supposed to catch — but inverted: the **dep declaration** was wrong rather than the **test wiring**. The verify-fails discipline I've been using locally doesn't catch this; only CI does.

## What I'm changing

Operationally, going forward I'll:

1. Always run \`gh pr checks <num> --watch\` before \`gh pr merge\`, regardless of \`--auto\` behaviour.
2. Refuse to call merges "successful" until the \`unit\` check is green on the merge commit.
3. Flag dep-graph changes (\`pyproject.toml\` edits) explicitly in PR descriptions.

The branch-protection config gap is the user's call (issue #116 spells out the recommended required-checks list).

## Test plan

- [x] \`make lint\` clean
- [x] \`make types\` clean
- [x] \`make test\` (726 passed at 84% coverage)
- [x] Verify-fails: with the dep removed, 12 unit tests error with \`ModuleNotFoundError\`. Restored.

Closes #116