### PR TITLE
fix(ci): generate dev certs in compose-smoke before stack startup

### DIFF
--- a/.github/workflows/compose-smoke.yml
+++ b/.github/workflows/compose-smoke.yml
@@ -50,6 +50,18 @@ jobs:
           docker --version
           docker compose version
 
+      # `deploy/envoy/certs/` is gitignored (committing dev certs would
+      # defeat the secret=True discipline). Envoy in the compose stack
+      # mounts that path read-only and crashes on boot if the keys are
+      # missing — which kills the compose-smoke job since #99 wired
+      # Envoy into `_EXPECTED_CONTAINERS`. Same step the envoy-validate
+      # job in quality.yml runs. Short cert lifetime — these only have
+      # to outlive the job.
+      - name: Generate dev certs for Envoy
+        run: |
+          bash scripts/gen-dev-certs.sh 30
+          chmod a+r deploy/envoy/certs/server.crt deploy/envoy/certs/server.key
+
       - name: Build compose images
         # Split from `make compose-smoke` so a build failure is a distinct,
         # faster signal than a stack-startup failure.


### PR DESCRIPTION
## Summary

\`compose-smoke\` has been red on every PR / push to main since #99 wired Envoy into \`_EXPECTED_CONTAINERS\`. Root cause: \`deploy/envoy/certs/\` is gitignored, the compose Envoy mounts that path and needs valid keys to boot, and the \`compose-smoke.yml\` workflow never ran the cert-gen step that already exists in \`quality.yml\`.

Adds the same \`bash scripts/gen-dev-certs.sh 30\` step before \`make compose-smoke\`. 30-day cert lifetime — only has to outlive the job.

## Why this slipped past me on PRs #99 - #115

\`gh pr merge --auto\` doesn't wait for "all checks pass" — it waits for branch-protection rules to be satisfied. This repo's branch protection has no required status checks, so \`--auto\` fired on every PR even when compose-smoke was red. I called those PRs "all green" without explicitly checking compose-smoke. Documented in #116; the fix here is for the specific compose-smoke regression.

## Test plan

- [x] Verified \`scripts/gen-dev-certs.sh\` produces a parseable RSA key + cert locally.
- [ ] **CI to verify**: compose-smoke goes green on this PR; unit / lint / types stay green.

I'll watch CI explicitly via \`gh pr checks --watch\` before proposing merge — leaving merge to you given the trust I've burned.

Closes #118