### PR TITLE
ci(compose-smoke): drop path filter so it can be a required check

### DIFF
--- a/.github/workflows/compose-smoke.yml
+++ b/.github/workflows/compose-smoke.yml
@@ -6,19 +6,17 @@
 # catches deploy-time wiring bugs (env vars, Kafka listener layout,
 # ENTRYPOINT/CMD shape, healthchecks).
 #
-# Path-filtered to the surfaces it can actually catch — running this on
-# every PR would burn ~5 minutes for changes that can't break it.
+# Runs on every PR so it can be a required status check on `main`.
+# Required-but-skipped reads as a blocked merge under GitHub branch
+# protection; the path filter that used to live here was the right call
+# when compose-smoke was advisory, but conflicts with required status.
+# ~1m45s per run on GitHub-hosted runners is the cost of admission. If
+# this gets too slow later, the answer is to speed up the build, not
+# to filter — required and skipped don't compose.
 name: compose-smoke
 
 on:
   pull_request:
-    paths:
-      - "deploy/**"
-      - "tests/compose_smoke/**"
-      - "pyproject.toml"
-      - "src/eveys_ocpp/__main__.py"
-      - "src/eveys_ocpp/clickhouse/ingestor.py"
-      - ".github/workflows/compose-smoke.yml"
   push:
     branches: [main]
 


### PR DESCRIPTION
## Summary

Required status checks under GitHub branch protection have a sharp edge: **required-but-skipped reads as a blocked merge**. The path filter on \`compose-smoke\` was the right call while the job was advisory, but conflicts with making it required.

Drops the filter. \`compose-smoke\` now runs on every PR (~1m45s on GitHub-hosted runners, measured on #119).

## Why now

You asked to make \`e2e\` + \`compose-smoke\` required. \`e2e\` already has no path filter — safe to require directly. \`compose-smoke\` does, so it needs this change first or docs-only PRs get permanently blocked.

## Order of operations

1. Merge this PR — \`compose-smoke\` becomes always-runs.
2. Update branch protection to add \`unit, types, lint, pip-audit, proto-breaking, helm-lint, envoy-validate, config-reference-fresh\` (already there) PLUS \`e2e\`, \`compose-smoke\`, \`mock-backend-smoke\` (the latter is also already always-runs; can promote at the same time).

If steps reorder, the next docs-only PR is unmergeable until the path filter goes away.

## Test plan

- [x] \`make lint\` n/a (workflow yaml only)
- [ ] CI run on this PR — verifies the job now runs unconditionally

Refs #118