### PR TITLE
fix(transport): basic-auth fails closed on DB error; compose-up runs migrations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ COMPOSE_GRAFANA := docker compose \
 
 .PHONY: help doctor install format lint types tests e2e smoke compose-smoke precommit clean distclean \
         compose-up compose-down compose-status compose-down-volumes compose-wait \
-        build-image protoc ch-migrate docs docs-clean config-export config-export-check config-schema \
+        build-image protoc migrate pg-migrate ch-migrate docs docs-clean config-export config-export-check config-schema \
         openapi-export openapi-export-check audit get-token grafana-up grafana-down
 
 # ---- meta -------------------------------------------------------------------
@@ -44,7 +44,8 @@ help:
 	@echo "  make precommit          run all pre-commit hooks against every file (no commit needed)"
 	@echo ""
 	@echo "Local stack (data plane):"
-	@echo "  make compose-up         start Postgres + Redis + Kafka + ClickHouse + service"
+	@echo "  make compose-up         start data plane + service AND apply migrations (one-step usable stack)"
+	@echo "  make migrate            apply Postgres + ClickHouse migrations against the running stack"
 	@echo "  make compose-wait       wait for all containers to report 'healthy'"
 	@echo "  make compose-down       stop containers, keep data volumes"
 	@echo "  make compose-down-volumes  stop AND wipe data (DESTRUCTIVE)"
@@ -156,8 +157,28 @@ build-image:
 
 compose-up:
 	$(COMPOSE) up -d
+	@$(MAKE) compose-wait
+	@echo ">> applying schema (Postgres + ClickHouse)..."
+	@$(MAKE) migrate
 	@echo ""
-	@echo "Stack starting. Use 'make compose-status' to watch health."
+	@echo "Stack ready. WS on :19000, REST on :8080, Swagger on /api/v1/docs."
+
+# Apply BOTH Postgres (alembic) and ClickHouse migrations against the
+# running compose stack. Run by `compose-up` automatically; also a
+# standalone target for re-running after a schema change without
+# bouncing the stack. Idempotent — alembic is no-op if at HEAD,
+# ch-migrate skips files already in `schema_migrations`.
+#
+# Forgetting this is the bug from issue #121 — a fresh `compose-up`
+# left Postgres empty, the WS Basic Auth check threw
+# `UndefinedTableError`, and chargers got 500 on reconnect. Baking
+# it into compose-up means an operator who only runs `make
+# compose-up` gets a usable stack, not a half-deployed one.
+migrate: pg-migrate ch-migrate
+
+pg-migrate: install
+	@echo ">> applying Postgres migrations (alembic)..."
+	@$(VENV)/bin/alembic upgrade head
 
 # Opt-in observability sidecar: Grafana + Prometheus joined to the
 # same compose network. The Grafana container pulls the ClickHouse
@@ -250,12 +271,8 @@ ch-migrate: install
 	    --db $${EVEYS_OCPP_CLICKHOUSE_DB:-eveys_ocpp}
 
 e2e: install
-	@echo ">> bringing up local data plane..."
+	@echo ">> bringing up local data plane (compose-up bakes in migrate)..."
 	@$(MAKE) compose-up
-	@$(MAKE) compose-wait
-	@echo ">> applying schema..."
-	@$(VENV)/bin/alembic upgrade head
-	@$(MAKE) ch-migrate
 	@echo ">> running e2e tests..."
 	@$(VENV)/bin/pytest tests/e2e -v --no-cov; \
 	rc=$$?; \

--- a/src/eveys_ocpp/metrics/registry.py
+++ b/src/eveys_ocpp/metrics/registry.py
@@ -243,9 +243,11 @@ WS_BASIC_AUTH_TOTAL: Counter = Counter(
     "eveys_ocpp_ws_basic_auth_total",
     "WS-edge Basic Auth verification outcomes (E5-6). `outcome` is a "
     "closed enum: ok, no_header, malformed, username_mismatch, "
-    "no_credential, bad_password. Sustained non-`ok` rate at a stable "
-    "cp_id (visible in the structured log line, not a label) is a "
-    "credential-rotation incident or an active probe.",
+    "no_credential, bad_password, db_error. Sustained non-`ok` rate "
+    "at a stable cp_id (visible in the structured log line, not a "
+    "label) is a credential-rotation incident or an active probe. "
+    "`db_error` specifically points at a deploy-time mistake "
+    "(missing migrations, Postgres outage) — page on it.",
     labelnames=("outcome",),
 )
 

--- a/src/eveys_ocpp/transport/_basic_auth.py
+++ b/src/eveys_ocpp/transport/_basic_auth.py
@@ -45,6 +45,12 @@ OUTCOME_MALFORMED = "malformed"
 OUTCOME_USERNAME_MISMATCH = "username_mismatch"
 OUTCOME_NO_CREDENTIAL = "no_credential"
 OUTCOME_BAD_PASSWORD = "bad_password"
+# DB lookup failed (table missing on a fresh stack, Postgres down,
+# etc.). Fail closed — return 401, log loud — rather than letting
+# the exception bubble up and become a 500 to the charger. From the
+# charger's perspective an auth-time DB outage IS a credential
+# failure: we can't prove the charger is who it says it is.
+OUTCOME_DB_ERROR = "db_error"
 
 
 @dataclass(frozen=True, slots=True)
@@ -76,6 +82,47 @@ def _parse_basic_header(header: str | None) -> tuple[str, str] | None:
         return None
     username, _, password = decoded.partition(":")
     return username, password
+
+
+# Sentinel returned by `_lookup_or_none` when the DB lookup itself
+# failed (vs. cleanly returning "no credential row"). Distinguishing
+# the two matters: missing row in permissive mode is "let them in",
+# whereas DB error must always reject.
+_DB_ERROR = object()
+
+
+async def _lookup_or_none(
+    session_factory: async_sessionmaker[AsyncSession],
+    *,
+    cp_id: str,
+) -> str | None | object:
+    """Look up the stored bcrypt hash for `cp_id`, returning:
+
+    - the hash string if a row exists
+    - ``None`` if no row exists (clean miss)
+    - ``_DB_ERROR`` sentinel on any DB exception (table missing,
+      Postgres unreachable, etc.)
+
+    Catching at this boundary is what stops a fresh-stack
+    `UndefinedTableError` from becoming a 500 to the charger. The
+    caller maps `_DB_ERROR` to `OUTCOME_DB_ERROR` + 401 — fail
+    closed; the charger reconnects with backoff like any other
+    auth failure.
+    """
+    try:
+        async with session_factory() as session:
+            return await get_credential_hash(session, cp_id=cp_id)
+    except Exception as exc:
+        # Loud structured log so an operator sees the deploy-time
+        # mistake. The cp_id is already in the WS upgrade path so
+        # it's not a secret leak.
+        log.warning(
+            "basic_auth.db_lookup_failed",
+            cp_id=cp_id,
+            error_type=type(exc).__name__,
+            error=str(exc),
+        )
+        return _DB_ERROR
 
 
 async def verify_basic_auth(
@@ -117,8 +164,9 @@ async def verify_basic_auth(
         outcome = OUTCOME_NO_HEADER if not auth_header else OUTCOME_MALFORMED
         if settings.ws_basic_auth_required:
             return AuthResult(accepted=False, outcome=outcome)
-        async with session_factory() as session:
-            stored_hash = await get_credential_hash(session, cp_id=cp_id)
+        stored_hash = await _lookup_or_none(session_factory, cp_id=cp_id)
+        if stored_hash is _DB_ERROR:
+            return AuthResult(accepted=False, outcome=OUTCOME_DB_ERROR)
         if stored_hash is None:
             return AuthResult(accepted=True, outcome=OUTCOME_OK)
         # Charger has a credential row but didn't present creds —
@@ -130,8 +178,9 @@ async def verify_basic_auth(
     if username != cp_id:
         return AuthResult(accepted=False, outcome=OUTCOME_USERNAME_MISMATCH)
 
-    async with session_factory() as session:
-        stored_hash = await get_credential_hash(session, cp_id=cp_id)
+    stored_hash = await _lookup_or_none(session_factory, cp_id=cp_id)
+    if stored_hash is _DB_ERROR:
+        return AuthResult(accepted=False, outcome=OUTCOME_DB_ERROR)
 
     if stored_hash is None:
         # No credential row. Permissive default lets unprovisioned
@@ -141,6 +190,9 @@ async def verify_basic_auth(
             return AuthResult(accepted=False, outcome=OUTCOME_NO_CREDENTIAL)
         return AuthResult(accepted=True, outcome=OUTCOME_OK)
 
+    # By here we've ruled out _DB_ERROR (returned above) and None
+    # (the no-row branch above). Narrow for the type checker.
+    assert isinstance(stored_hash, str)
     try:
         ok = bcrypt.checkpw(password.encode("utf-8"), stored_hash.encode("utf-8"))
     except ValueError:

--- a/tests/unit/transport/test_basic_auth.py
+++ b/tests/unit/transport/test_basic_auth.py
@@ -11,6 +11,7 @@ import pytest
 from eveys_ocpp.settings import Settings
 from eveys_ocpp.transport._basic_auth import (
     OUTCOME_BAD_PASSWORD,
+    OUTCOME_DB_ERROR,
     OUTCOME_MALFORMED,
     OUTCOME_NO_CREDENTIAL,
     OUTCOME_NO_HEADER,
@@ -321,3 +322,81 @@ def test_hash_password_round_trips() -> None:
     h = hash_password("hunter2")
     assert bcrypt.checkpw(b"hunter2", h.encode())
     assert not bcrypt.checkpw(b"wrong", h.encode())
+
+
+# -- DB-error fail-closed (regression: PR after #117) --------------------
+
+
+def _session_factory_raising(exc: Exception) -> Any:
+    """Build a session_factory whose `__aenter__` raises. Models the
+    real-world failure modes: `UndefinedTableError` (migrations
+    haven't run on a fresh stack), `ConnectionRefusedError`
+    (Postgres down), or any other exception that bubbles out of the
+    SQLAlchemy session context."""
+
+    factory = MagicMock()
+    session = MagicMock()
+    session.__aenter__ = AsyncMock(side_effect=exc)
+    session.__aexit__ = AsyncMock(return_value=None)
+    factory.return_value = session
+    return factory
+
+
+@pytest.mark.asyncio
+async def test_db_error_fails_closed_with_credentials_present(
+    settings_permissive: Settings,
+) -> None:
+    """A DB exception while looking up credentials must NOT bubble out
+    as a 500 to the charger. Fail closed — return 401 with
+    `db_error` outcome.
+
+    This is the regression that produced "Reconnect failed:
+    Unexpected server response: 500" against a fresh compose stack
+    where alembic hadn't run (`UndefinedTableError`)."""
+    factory = _session_factory_raising(
+        RuntimeError('relation "charge_point_credentials" does not exist')
+    )
+    result = await verify_basic_auth(
+        cp_id="CP_001",
+        auth_header=_basic("CP_001", "anything"),
+        session_factory=factory,
+        settings=settings_permissive,
+    )
+    assert result == AuthResult(accepted=False, outcome=OUTCOME_DB_ERROR)
+
+
+@pytest.mark.asyncio
+async def test_db_error_fails_closed_in_no_header_permissive_path(
+    settings_permissive: Settings,
+) -> None:
+    """The "no header + permissive mode + check whether a credential
+    row exists" branch also touches the DB. A failure there must
+    fail closed identically — otherwise an unprovisioned charger
+    that should have been silently accepted hits a 500 on the WS
+    upgrade just because Postgres blipped."""
+    factory = _session_factory_raising(RuntimeError("connection refused"))
+    result = await verify_basic_auth(
+        cp_id="CP_001",
+        auth_header=None,  # no header, falls to the permissive-lookup branch
+        session_factory=factory,
+        settings=settings_permissive,
+    )
+    assert result == AuthResult(accepted=False, outcome=OUTCOME_DB_ERROR)
+
+
+@pytest.mark.asyncio
+async def test_db_error_fails_closed_in_strict_mode(
+    settings_strict: Settings,
+) -> None:
+    """Strict mode: a DB error doesn't change the rejection decision
+    (we'd reject anyway because we can't verify the credential).
+    Outcome label distinguishes "rejected because no creds" from
+    "rejected because DB blew up" — operator alerting cares."""
+    factory = _session_factory_raising(RuntimeError("postgres down"))
+    result = await verify_basic_auth(
+        cp_id="CP_001",
+        auth_header=_basic("CP_001", "anything"),
+        session_factory=factory,
+        settings=settings_strict,
+    )
+    assert result == AuthResult(accepted=False, outcome=OUTCOME_DB_ERROR)


### PR DESCRIPTION
## Summary

Reproduces / fixes "Reconnect failed: Unexpected server response: 500" reported against a fresh \`make compose-up\` stack.

| Bug | Fix |
|---|---|
| \`verify_basic_auth\` lets DB exceptions bubble out → 500 to the charger | Catch at \`_lookup_or_none\` boundary, return new \`OUTCOME_DB_ERROR\`, log loud. Charger gets 401 + closed-enum reason; operator gets a structured log line pointing at the deploy-time mistake. |
| \`make compose-up\` brings Postgres up but doesn't migrate | Bake \`make migrate\` (= \`pg-migrate ch-migrate\`) into \`compose-up\`. New standalone targets for re-running on demand. |

## Verify-fails dance (Bug 1)

Removed the \`try/except\` in \`_lookup_or_none\`. All 3 new tests failed with \`RuntimeError\` bubbling out, exactly the regression they catch. Restored.

## Manual verification (Bug 2)

\`\`\`
make compose-down-volumes   # wipe data
make compose-up             # full fresh boot
\`\`\`

Output ends with:

\`\`\`
>> applying Postgres migrations (alembic)...
INFO  [alembic.runtime.migration] Running upgrade  -> 0001 ...
... 9 migrations ...
>> applying ClickHouse migrations...
applied 5 migration(s): [1, 2, 3, 4, 5]

Stack ready. WS on :19000, REST on :8080, Swagger on /api/v1/docs.
\`\`\`

\`docker exec ... psql -c \\dt\` shows 11 tables (vs 0 before this PR). Health check returns 200.

## Test plan

- [x] \`make lint\` clean
- [x] \`make types\` clean
- [x] \`make test\` (729 passed at 84% coverage; +3 fail-closed tests)
- [x] Verify-fails dance for Bug 1 documented above
- [x] Manual verification for Bug 2 documented above
- [ ] CI watch — I'll \`gh pr checks --watch\` before any merge per the new discipline

Closes #121