### PR TITLE
docs(readme): drop restating-the-obvious prose under Architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,16 +138,9 @@ The gateway also calls the configured backend on the OCPP hot path —
         via httpx, asymmetric envelope per ADR-0023
 ```
 
-Two boundary rules:
-
-- Chargers connect only to the gateway. No other service holds an
-  OCPP socket.
-- The gateway owns no user, billing, or session state. All of those
-  decisions are deferred to the configured backend over REST per
-  [`docs/integration/01-backend-rest-contract.md`](./docs/integration/01-backend-rest-contract.md).
-
-Component-level narrative: [`docs/00-overview.md`](./docs/00-overview.md).
-Decision rationale: [`docs/05-architecture-decisions.md`](./docs/05-architecture-decisions.md).
+Component narrative in [`docs/00-overview.md`](./docs/00-overview.md);
+decision rationale in [`docs/05-architecture-decisions.md`](./docs/05-architecture-decisions.md);
+backend contract in [`docs/integration/01-backend-rest-contract.md`](./docs/integration/01-backend-rest-contract.md).
 
 ---
 


### PR DESCRIPTION
## Summary

Drops the two-bullet \"boundary rules\" block under the Architecture diagram (\"chargers connect only to the gateway\", \"the gateway owns no user / billing / session state\") plus the two trailing pointer lines, replacing them with one combined pointer line to the deeper docs. The bullets restated what the diagram already shows and what the word \"gateway\" already implies.

Net: −7 lines.

Closes #125

## Test plan

- [ ] README renders on the PR page; the Architecture section reads tightly without losing the doc pointers.
- [ ] CI green.