### PR TITLE
docs(readme): drop docs/* pointer line and ADR-0023 cite under Architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,12 +135,8 @@ The gateway also calls the configured backend on the OCPP hot path —
                               └──────────────┘           │
                                                          │
         Hot path (Authorize / sessions/open / close) ────┘
-        via httpx, asymmetric envelope per ADR-0023
+        via httpx, asymmetric envelope
 ```
-
-Component narrative in [`docs/00-overview.md`](./docs/00-overview.md);
-decision rationale in [`docs/05-architecture-decisions.md`](./docs/05-architecture-decisions.md);
-backend contract in [`docs/integration/01-backend-rest-contract.md`](./docs/integration/01-backend-rest-contract.md).
 
 ---
 


### PR DESCRIPTION
## Summary

User-facing content should not cite `docs/*` or ADR-NNNN. Drops:

- The three-clause pointer line under the Architecture diagram (`docs/00-overview.md` / `docs/05-architecture-decisions.md` / `docs/integration/01-backend-rest-contract.md`).
- The trailing \`per ADR-0023\` inside the diagram caption.

The Documentation index further down the README is the one place that exists to point at docs; it stays.

Net: −5 / +1 lines.

Closes #127

## Test plan

- [ ] README renders cleanly on the PR page; the Architecture section ends at the closing fence.
- [ ] CI green.