### PR TITLE
feature(api): GET /api/v1/transactions — global list

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3416,6 +3416,166 @@
         ]
       }
     },
+    "/api/v1/transactions": {
+      "get": {
+        "operationId": "list_transactions_global_route_api_v1_transactions_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maximum": 10000,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Limit"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cp_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cp Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "id_tag",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Id Tag"
+            }
+          },
+          {
+            "in": "query",
+            "name": "active",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Active"
+            }
+          },
+          {
+            "in": "query",
+            "name": "from",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "From"
+            }
+          },
+          {
+            "in": "query",
+            "name": "to",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "To"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransactionListResponse",
+                  "additionalProperties": true,
+                  "title": "Response List Transactions Global Route Api V1 Transactions Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Bad cursor or unparseable from/to timestamp."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List transactions (cursor-paginated, global)",
+        "tags": [
+          "transactions"
+        ]
+      }
+    },
     "/api/v1/transactions/{transaction_id}": {
       "get": {
         "operationId": "get_transaction_route_api_v1_transactions__transaction_id__get",

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -2255,6 +2255,94 @@ paths:
       summary: Readiness probe (auth-exempt)
       tags:
       - health
+  /api/v1/transactions:
+    get:
+      operationId: list_transactions_global_route_api_v1_transactions_get
+      parameters:
+      - in: query
+        name: cursor
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Cursor
+      - in: query
+        name: limit
+        required: false
+        schema:
+          anyOf:
+          - maximum: 10000
+            minimum: 1
+            type: integer
+          - type: 'null'
+          title: Limit
+      - in: query
+        name: cp_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Cp Id
+      - in: query
+        name: id_tag
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Id Tag
+      - in: query
+        name: active
+        required: false
+        schema:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Active
+      - in: query
+        name: from
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: From
+      - in: query
+        name: to
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: To
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransactionListResponse'
+                additionalProperties: true
+                title: Response List Transactions Global Route Api V1 Transactions
+                  Get
+                type: object
+          description: Successful Response
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+          description: Bad cursor or unparseable from/to timestamp.
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: List transactions (cursor-paginated, global)
+      tags:
+      - transactions
   /api/v1/transactions/{transaction_id}:
     get:
       operationId: get_transaction_route_api_v1_transactions__transaction_id__get

--- a/docs/integration/02-gateway-rest-api.md
+++ b/docs/integration/02-gateway-rest-api.md
@@ -278,6 +278,32 @@ Transactions for a charger. **Postgres-backed**.
 
 ---
 
+### `GET /api/v1/transactions`
+
+Global cursor-paginated list of transactions across all chargers. Same row
+shape as the per-cp variant; each row already includes `cp_id` so the
+caller doesn't need a second lookup.
+
+**Query parameters**:
+
+| Param | Type | Notes |
+|---|---|---|
+| `cursor` | string | Opaque cursor from a prior response. Omit on first page. |
+| `limit` | int | 1–10000. Default from `Settings.rest_default_page_size`. |
+| `cp_id` | string | Exact match. Omit for "all chargers". |
+| `id_tag` | string | Exact match. |
+| `active` | bool | `true` keeps txns with no stop event yet; `false` keeps only stopped txns; omitted returns both. |
+| `from` | ISO 8601 | Lower bound on `started_reported_at`. |
+| `to` | ISO 8601 | Upper bound on `started_reported_at`. |
+
+Use this endpoint for "what's charging across the fleet right now?"
+(`active=true`) without N+1 fan-out across the per-cp endpoint.
+
+`400` with `error_code: BAD_REQUEST` for malformed cursor or
+unparseable `from`/`to`.
+
+---
+
 ### `GET /api/v1/transactions/{transaction_id}`
 
 Single transaction. Same shape as the array element above.

--- a/src/eveys_ocpp/api/transactions.py
+++ b/src/eveys_ocpp/api/transactions.py
@@ -34,6 +34,7 @@ from eveys_ocpp.api._schemas import (
 from eveys_ocpp.persistence.db import session_scope
 from eveys_ocpp.persistence.repositories import (
     get_transaction_by_id,
+    list_transactions,
     list_transactions_by_cp,
 )
 
@@ -145,6 +146,74 @@ async def list_transactions_route(
 
     return {
         "transactions": [{**_transaction_to_response(tx), "cp_id": cp_id} for tx in page],
+        "next_cursor": next_cursor,
+        "request_id": request.state.request_id,
+    }
+
+
+@router.get(
+    "/transactions",
+    summary="List transactions (cursor-paginated, global)",
+    responses={
+        200: {"model": TransactionListResponse},
+        400: {
+            "model": ErrorEnvelope,
+            "description": "Bad cursor or unparseable from/to timestamp.",
+        },
+    },
+)
+async def list_transactions_global_route(
+    request: Request,
+    cursor: str | None = Query(default=None),
+    limit: int | None = Query(default=None, ge=1, le=10_000),
+    cp_id: str | None = Query(default=None),
+    id_tag: str | None = Query(default=None),
+    active: bool | None = Query(default=None),
+    from_: str | None = Query(default=None, alias="from"),
+    to: str | None = Query(default=None),
+) -> dict[str, Any]:
+    settings = request.app.state.settings
+    page_size = clamp_limit(
+        limit,
+        default=settings.rest_default_page_size,
+        maximum=settings.rest_max_page_size,
+    )
+
+    cursor_payload = decode_cursor(cursor)
+    after_id: int | None = None
+    if cursor_payload is not None:
+        raw_id = cursor_payload.get("id")
+        if not isinstance(raw_id, int):
+            raise ApiError(
+                status_code=400,
+                error_code=ERR_BAD_REQUEST,
+                message="malformed cursor: missing 'id'",
+            )
+        after_id = raw_id
+
+    started_from = _parse_iso8601(from_, field_name="from")
+    started_to = _parse_iso8601(to, field_name="to")
+
+    async with session_scope(request.app.state.session_factory) as session:
+        rows = await list_transactions(
+            session,
+            after_id=after_id,
+            limit=page_size,
+            cp_id=cp_id,
+            id_tag=id_tag,
+            active=active,
+            started_from=started_from,
+            started_to=started_to,
+        )
+
+    has_more = len(rows) > page_size
+    page = rows[:page_size]
+    next_cursor: str | None = None
+    if has_more and page:
+        next_cursor = encode_cursor({"id": page[-1]["id"]})
+
+    return {
+        "transactions": [_transaction_to_response(tx) for tx in page],
         "next_cursor": next_cursor,
         "request_id": request.state.request_id,
     }

--- a/src/eveys_ocpp/persistence/repositories.py
+++ b/src/eveys_ocpp/persistence/repositories.py
@@ -864,6 +864,60 @@ async def list_transactions_by_cp(
     return [_transaction_to_dict(tx) for tx in result.scalars().all()]
 
 
+async def list_transactions(
+    session: AsyncSession,
+    *,
+    after_id: int | None,
+    limit: int,
+    cp_id: str | None = None,
+    id_tag: str | None = None,
+    active: bool | None = None,
+    started_from: datetime | None = None,
+    started_to: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """Global cursor-paginated transactions list.
+
+    Same filter shape as ``list_transactions_by_cp`` plus an optional
+    ``cp_id`` filter (exact match). Unlike the per-cp variant this
+    function does not return ``None`` for unknown chargers — an unknown
+    or omitted ``cp_id`` simply yields the unfiltered (or empty) result.
+
+    Joins ``charge_points`` so each row's projected dict includes the
+    charger's OCPP-visible ``cp_id`` string; the BaaS / operator
+    console can render rows without a second lookup. Returns up to
+    ``limit + 1`` rows for next-page detection.
+    """
+    stmt = select(Transaction, ChargePoint.cp_id).join(
+        ChargePoint, Transaction.charge_point_id == ChargePoint.id
+    )
+    conditions = []
+    if cp_id is not None:
+        conditions.append(ChargePoint.cp_id == cp_id)
+    if id_tag is not None:
+        conditions.append(Transaction.id_tag == id_tag)
+    if active is True:
+        conditions.append(Transaction.stopped_reported_at.is_(None))
+    elif active is False:
+        conditions.append(Transaction.stopped_reported_at.is_not(None))
+    if started_from is not None:
+        conditions.append(Transaction.started_reported_at >= started_from)
+    if started_to is not None:
+        conditions.append(Transaction.started_reported_at <= started_to)
+    if after_id is not None:
+        conditions.append(Transaction.id > after_id)
+    if conditions:
+        stmt = stmt.where(and_(*conditions))
+    stmt = stmt.order_by(Transaction.id).limit(limit + 1)
+
+    result = await session.execute(stmt)
+    rows: list[dict[str, Any]] = []
+    for tx, cp_id_value in result.all():
+        row = _transaction_to_dict(tx)
+        row["cp_id"] = cp_id_value
+        rows.append(row)
+    return rows
+
+
 async def get_transaction_by_id(
     session: AsyncSession, *, transaction_id: int
 ) -> dict[str, Any] | None:

--- a/tests/unit/api/test_transactions.py
+++ b/tests/unit/api/test_transactions.py
@@ -124,3 +124,114 @@ async def test_list_by_cp_rejects_unparseable_time(client: httpx.AsyncClient) ->
 
     assert response.status_code == 400
     assert response.json()["error_code"] == "BAD_REQUEST"
+
+
+# ----- GET /api/v1/transactions (global list) -------------------------------
+
+
+def _tx_row_with_cp(transaction_id: int, cp_id: str, *, stopped: bool = False) -> dict[str, Any]:
+    row = _tx_row(transaction_id, stopped=stopped)
+    row["cp_id"] = cp_id
+    return row
+
+
+@pytest.mark.asyncio
+async def test_list_global_empty_returns_empty_array(
+    client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from eveys_ocpp.api import transactions as tx_module
+
+    monkeypatch.setattr(tx_module, "list_transactions", AsyncMock(return_value=[]))
+
+    response = await client.get("/api/v1/transactions")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["transactions"] == []
+    assert body["next_cursor"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_global_returns_cp_id_per_row(
+    client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from eveys_ocpp.api import transactions as tx_module
+
+    rows = [
+        _tx_row_with_cp(1, "CP_BERLIN_001"),
+        _tx_row_with_cp(2, "CP_BERLIN_002"),
+    ]
+    monkeypatch.setattr(tx_module, "list_transactions", AsyncMock(return_value=rows))
+
+    response = await client.get("/api/v1/transactions")
+
+    body = response.json()
+    assert [t["cp_id"] for t in body["transactions"]] == ["CP_BERLIN_001", "CP_BERLIN_002"]
+
+
+@pytest.mark.asyncio
+async def test_list_global_paginates_and_emits_cursor(
+    client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from eveys_ocpp.api import transactions as tx_module
+
+    rows = [_tx_row_with_cp(i, "CP_X") for i in range(1, 4)]  # 3 rows
+    monkeypatch.setattr(tx_module, "list_transactions", AsyncMock(return_value=rows))
+
+    response = await client.get("/api/v1/transactions?limit=2")
+
+    body = response.json()
+    assert len(body["transactions"]) == 2
+    assert body["next_cursor"]
+
+
+@pytest.mark.asyncio
+async def test_list_global_passes_filters_through(
+    client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from eveys_ocpp.api import transactions as tx_module
+
+    spy = AsyncMock(return_value=[])
+    monkeypatch.setattr(tx_module, "list_transactions", spy)
+
+    response = await client.get(
+        "/api/v1/transactions"
+        "?cp_id=CP_X&id_tag=RFID_X&active=true"
+        "&from=2026-05-01T00:00:00%2B00:00&to=2026-05-31T00:00:00%2B00:00"
+    )
+
+    assert response.status_code == 200
+    kwargs = spy.await_args.kwargs
+    assert kwargs["cp_id"] == "CP_X"
+    assert kwargs["id_tag"] == "RFID_X"
+    assert kwargs["active"] is True
+    assert kwargs["started_from"] is not None
+    assert kwargs["started_to"] is not None
+
+
+@pytest.mark.asyncio
+async def test_list_global_rejects_unparseable_time(client: httpx.AsyncClient) -> None:
+    response = await client.get("/api/v1/transactions?from=not-iso-8601")
+
+    assert response.status_code == 400
+    assert response.json()["error_code"] == "BAD_REQUEST"
+
+
+@pytest.mark.asyncio
+async def test_list_global_does_not_collide_with_detail_route(
+    client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Sanity: /transactions and /transactions/{id} are distinct routes."""
+    from eveys_ocpp.api import transactions as tx_module
+
+    monkeypatch.setattr(
+        tx_module, "get_transaction_by_id", AsyncMock(return_value=_tx_row(transaction_id=42))
+    )
+    detail = await client.get("/api/v1/transactions/42")
+    assert detail.status_code == 200
+    assert detail.json()["transaction_id"] == 42
+
+    monkeypatch.setattr(tx_module, "list_transactions", AsyncMock(return_value=[]))
+    listing = await client.get("/api/v1/transactions")
+    assert listing.status_code == 200
+    assert listing.json()["transactions"] == []


### PR DESCRIPTION
## Summary

Adds a global REST endpoint for listing transactions across all chargers, so consumers don't need to fan out N+1 calls across the per-cp endpoint.

- \`GET /api/v1/transactions\` with cursor pagination and filters \`cp_id\`, \`id_tag\`, \`active\`, \`from\`, \`to\`.
- Each row pre-projects \`cp_id\` (joined from \`charge_points\`) so the caller doesn't need a second lookup.
- \`active=true\` keeps txns with no stop event yet — exactly what an operator console needs for the "currently charging" view.
- 6 new tests; OpenAPI snapshot regenerated; integration spec updated.

Driven by the operator console at \`eveys-mobility/eveys-console\` whose Transactions page hit a 404 because no such endpoint existed.

Closes #129

## Test plan

- [ ] CI green (lint, types, unit, e2e, compose-smoke, security).
- [ ] Manual: \`curl -H 'Authorization: Bearer ...' 'http://localhost:8080/api/v1/transactions?active=true'\` returns a paginated list with \`cp_id\` on every row.
- [ ] Re-running \`make openapi-export-check\` after merge produces no diff.