### PR TITLE
feature(api): GET /api/v1/sys/config — config introspection with metadata

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3416,6 +3416,29 @@
         ]
       }
     },
+    "/api/v1/sys/config": {
+      "get": {
+        "operationId": "get_sys_config_api_v1_sys_config_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Sys Config Api V1 Sys Config Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "GET gateway configuration with per-key metadata (read-only)",
+        "tags": [
+          "sys-config"
+        ]
+      }
+    },
     "/api/v1/transactions": {
       "get": {
         "operationId": "list_transactions_global_route_api_v1_transactions_get",

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -2255,6 +2255,21 @@ paths:
       summary: Readiness probe (auth-exempt)
       tags:
       - health
+  /api/v1/sys/config:
+    get:
+      operationId: get_sys_config_api_v1_sys_config_get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Get Sys Config Api V1 Sys Config Get
+                type: object
+          description: Successful Response
+      summary: GET gateway configuration with per-key metadata (read-only)
+      tags:
+      - sys-config
   /api/v1/transactions:
     get:
       operationId: list_transactions_global_route_api_v1_transactions_get

--- a/src/eveys_ocpp/api/_app.py
+++ b/src/eveys_ocpp/api/_app.py
@@ -45,6 +45,7 @@ from eveys_ocpp.api import (
     health,
     ready,
     reservations,
+    sys_config,
     timeseries,
     transactions,
 )
@@ -191,6 +192,7 @@ def make_app(
     app.include_router(commands.router, prefix="/api/v1")
     app.include_router(timeseries.router, prefix="/api/v1")
     app.include_router(admin.router, prefix="/api/v1")
+    app.include_router(sys_config.router, prefix="/api/v1")
 
     return app
 

--- a/src/eveys_ocpp/api/sys_config.py
+++ b/src/eveys_ocpp/api/sys_config.py
@@ -1,0 +1,197 @@
+"""`GET /api/v1/sys/config` — read-only configuration introspection.
+
+Returns every gateway settings field with the metadata an SRE wants in
+front of them: description, accepted range (derived from pydantic
+constraints), default, source (env-set vs schema default), restart
+impact, mutability (whether the runtime-override allowlist accepts a
+PATCH), category and impact text, plus the current value (sensitive
+fields masked at the gateway).
+
+Distinct from `/api/v1/admin/config`:
+- `/admin/config` returns the model dump + the override allowlist; it
+  is the *write surface* (PATCH for allowlisted fields).
+- `/sys/config` returns the same data plus per-field metadata that the
+  operator UI renders. Read-only.
+
+Auth follows the existing `/api/v1/*` bearer-token middleware.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from typing import Any
+
+from fastapi import APIRouter, Request
+from pydantic import SecretStr
+from pydantic.fields import FieldInfo
+
+from eveys_ocpp.observability import get_logger
+from eveys_ocpp.runtime_overrides import allowlist
+from eveys_ocpp.settings import Settings
+
+log = get_logger(__name__)
+
+router = APIRouter(tags=["sys-config"])
+
+MASK = "••••••••"
+ENV_PREFIX = "EVEYS_OCPP_"
+
+# Set once at module-import time; the operator UI surfaces this so a
+# fresh restart is visible. Settings load happens at app boot, but for
+# this endpoint we just need an "approximately when did the process
+# start" anchor — process import time is close enough.
+_LOADED_AT = datetime.now(UTC).isoformat()
+
+
+def _stringify(value: Any) -> str:
+    """Stringify a settings value for transport. SecretStr renders to
+    its redacted placeholder (handled by Pydantic), so by the time we
+    see one here the secret is already gone."""
+    if value is None:
+        return ""
+    if isinstance(value, SecretStr):
+        secret = value.get_secret_value()
+        return MASK if secret else ""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, list | tuple):
+        return ",".join(str(v) for v in value)
+    return str(value)
+
+
+def _is_sensitive(field_info: FieldInfo) -> bool:
+    """A field is sensitive if either the type is SecretStr or the
+    field carries `secret: True` in `json_schema_extra`."""
+    extra = field_info.json_schema_extra or {}
+    if isinstance(extra, dict) and extra.get("secret") is True:
+        return True
+    annotation = field_info.annotation
+    return annotation is SecretStr
+
+
+def _range_text(field_info: FieldInfo) -> str:
+    """Derive a human-readable range string from the pydantic
+    constraints (`ge`/`le`/`gt`/`lt`) and the type annotation. Falls
+    back to the type's name for free-form fields."""
+    parts: list[str] = []
+    metadata = field_info.metadata or []
+    for entry in metadata:
+        cls_name = type(entry).__name__
+        # `Ge(ge=...)` etc. are dataclass-shaped; pull the numeric
+        # bound off the matching attribute.
+        for attr in ("ge", "gt", "le", "lt"):
+            if hasattr(entry, attr):
+                bound = getattr(entry, attr)
+                if bound is not None:
+                    sym = {"ge": "≥", "gt": ">", "le": "≤", "lt": "<"}[attr]
+                    parts.append(f"{sym} {bound}")
+                    break
+        else:
+            # Some constraint types we don't introspect — skip with a hint.
+            if cls_name not in {"_PydanticGeneralMetadata"}:
+                continue
+
+    annotation = field_info.annotation
+    type_hint = ""
+    # `Literal[...]` carries its allowed values on `__args__`.
+    if (
+        annotation is not None
+        and hasattr(annotation, "__args__")
+        and getattr(annotation, "__origin__", None) is not None
+        and str(getattr(annotation, "__origin__", "")).endswith("Literal")
+    ):
+        return " | ".join(repr(a) for a in annotation.__args__)
+
+    if annotation is bool:
+        type_hint = "true | false"
+    elif annotation is int:
+        type_hint = "integer"
+    elif annotation is float:
+        type_hint = "float"
+    elif annotation is str or annotation is SecretStr:
+        type_hint = "string"
+
+    if parts and type_hint:
+        return f"{type_hint} ({' '.join(parts)})"
+    if parts:
+        return " ".join(parts)
+    return type_hint or "free-form"
+
+
+def _restart_impact(field_name: str, allowlisted: set[str]) -> str:
+    """Live-mutable allowlisted fields → `none`; everything else needs
+    a gateway restart to apply."""
+    return "none" if field_name in allowlisted else "gateway"
+
+
+def _source(field_name: str) -> str:
+    """Env if the corresponding `EVEYS_OCPP_<FIELD>` is set in the
+    process environment, else `default`."""
+    env_var = f"{ENV_PREFIX}{field_name.upper()}"
+    return "env" if env_var in os.environ and os.environ[env_var] != "" else "default"
+
+
+def _stringify_default(field_info: FieldInfo) -> str:
+    """Stringify the schema default. For SecretStr defaults we use the
+    empty string (the default *value* is "", not the mask)."""
+    default = field_info.default
+    if default is None:
+        return ""
+    if isinstance(default, SecretStr):
+        secret = default.get_secret_value()
+        # Keep parity with `_stringify`: mask when non-empty so the page
+        # never leaks even a baked-in placeholder secret.
+        return MASK if secret else ""
+    if callable(default):
+        # `default_factory` — we don't invoke it; just signal it's dynamic.
+        return "<computed>"
+    return _stringify(default)
+
+
+def describe_settings(settings: Settings) -> list[dict[str, Any]]:
+    """Build the per-key metadata + value list. Sensitive values are
+    replaced with the mask before this function returns."""
+    allowlisted = set(allowlist())
+    out: list[dict[str, Any]] = []
+    for name, field_info in Settings.model_fields.items():
+        extra = field_info.json_schema_extra
+        meta: dict[str, Any] = extra if isinstance(extra, dict) else {}
+        sensitive = _is_sensitive(field_info)
+
+        raw = getattr(settings, name)
+        rendered = _stringify(raw)
+        if sensitive and rendered and rendered != MASK:
+            rendered = MASK
+
+        out.append(
+            {
+                "key": name,
+                "value": rendered,
+                "sensitive": sensitive,
+                "default": _stringify_default(field_info),
+                "source": _source(name),
+                "description": field_info.description or "",
+                "impact": meta.get("impact", ""),
+                "category": meta.get("category", ""),
+                "stability": meta.get("stability", ""),
+                "mutable": name in allowlisted,
+                "restart": _restart_impact(name, allowlisted),
+                "range": _range_text(field_info),
+            }
+        )
+    return out
+
+
+@router.get(
+    "/sys/config",
+    summary="GET gateway configuration with per-key metadata (read-only)",
+)
+async def get_sys_config(request: Request) -> dict[str, Any]:
+    settings: Settings = request.app.state.settings
+    return {
+        "entries": describe_settings(settings),
+        "scope": "gateway",
+        "loaded_at": _LOADED_AT,
+        "request_id": request.state.request_id,
+    }

--- a/tests/unit/api/test_sys_config.py
+++ b/tests/unit/api/test_sys_config.py
@@ -89,7 +89,7 @@ async def test_every_entry_carries_required_metadata(
         # carries one).
         assert entry["description"], f"{entry['key']} has empty description"
         # Restart impact must be one of our enum values.
-        assert entry["restart"] in {"none", "gateway", "baas", "both"}
+        assert entry["restart"] in {"none", "gateway", "console", "both"}
         assert entry["source"] in {"env", "default"}
 
 

--- a/tests/unit/api/test_sys_config.py
+++ b/tests/unit/api/test_sys_config.py
@@ -1,0 +1,154 @@
+"""Tests for `GET /api/v1/sys/config` — config introspection."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from eveys_ocpp.api.sys_config import MASK
+
+
+@pytest.mark.asyncio
+async def test_returns_one_entry_per_settings_field(
+    client: httpx.AsyncClient,
+) -> None:
+    response = await client.get("/api/v1/sys/config")
+    assert response.status_code == 200, response.text
+    body = response.json()
+
+    assert body["scope"] == "gateway"
+    assert "loaded_at" in body
+    assert "request_id" in body
+
+    entries = body["entries"]
+    keys = {e["key"] for e in entries}
+    # Sample of fields that must be present.
+    for required in (
+        "ws_port",
+        "rest_port",
+        "kafka_brokers",
+        "redis_url",
+        "log_level",
+        "rest_inbound_tokens",
+        "db_url",
+        "backend_token",
+        "webhook_secret",
+    ):
+        assert required in keys, f"missing field: {required}"
+
+
+@pytest.mark.asyncio
+async def test_sensitive_fields_are_masked(
+    client: httpx.AsyncClient,
+) -> None:
+    response = await client.get("/api/v1/sys/config")
+    body = response.json()
+    entries = {e["key"]: e for e in body["entries"]}
+
+    # The conftest fixture sets `rest_inbound_tokens="test-token-foundation"`;
+    # if that string leaks anywhere in the response, masking is broken.
+    assert "test-token-foundation" not in response.text
+
+    # Each of these must be marked sensitive AND have a masked / empty value.
+    for key in (
+        "rest_inbound_tokens",
+        "db_url",
+        "backend_token",
+        "webhook_secret",
+        "sentry_dsn",
+    ):
+        entry = entries[key]
+        assert entry["sensitive"] is True, f"{key} not marked sensitive"
+        assert entry["value"] in {"", MASK}, f"{key} value not masked: {entry['value']!r}"
+
+
+@pytest.mark.asyncio
+async def test_every_entry_carries_required_metadata(
+    client: httpx.AsyncClient,
+) -> None:
+    response = await client.get("/api/v1/sys/config")
+    body = response.json()
+
+    for entry in body["entries"]:
+        # Required keys on every entry.
+        for k in (
+            "key",
+            "value",
+            "sensitive",
+            "default",
+            "source",
+            "description",
+            "category",
+            "stability",
+            "mutable",
+            "restart",
+            "range",
+        ):
+            assert k in entry, f"{entry['key']} missing field {k}"
+        # Description text should never be empty (every Settings field
+        # carries one).
+        assert entry["description"], f"{entry['key']} has empty description"
+        # Restart impact must be one of our enum values.
+        assert entry["restart"] in {"none", "gateway", "baas", "both"}
+        assert entry["source"] in {"env", "default"}
+
+
+@pytest.mark.asyncio
+async def test_allowlisted_fields_are_mutable_with_no_restart(
+    client: httpx.AsyncClient,
+) -> None:
+    response = await client.get("/api/v1/sys/config")
+    body = response.json()
+    entries = {e["key"]: e for e in body["entries"]}
+
+    # `log_level` is allowlisted for runtime override (see test_admin.py).
+    log_level = entries["log_level"]
+    assert log_level["mutable"] is True
+    assert log_level["restart"] == "none"
+
+    # `rest_port` is structural — restart=gateway, mutable=False.
+    rest_port = entries["rest_port"]
+    assert rest_port["mutable"] is False
+    assert rest_port["restart"] == "gateway"
+
+
+@pytest.mark.asyncio
+async def test_range_for_bounded_int_includes_constraints(
+    client: httpx.AsyncClient,
+) -> None:
+    response = await client.get("/api/v1/sys/config")
+    body = response.json()
+    entries = {e["key"]: e for e in body["entries"]}
+
+    # `ws_port: int = Field(ge=1, le=65535)` — the range string should
+    # surface both bounds.
+    ws_port = entries["ws_port"]
+    assert "1" in ws_port["range"]
+    assert "65535" in ws_port["range"]
+
+
+@pytest.mark.asyncio
+async def test_literal_field_lists_allowed_values(
+    client: httpx.AsyncClient,
+) -> None:
+    response = await client.get("/api/v1/sys/config")
+    body = response.json()
+    entries = {e["key"]: e for e in body["entries"]}
+
+    # `log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]`
+    log_level = entries["log_level"]
+    for level in ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"):
+        assert level in log_level["range"], f"missing literal {level}"
+
+
+@pytest.mark.asyncio
+async def test_kafka_topic_fields_are_grouped(
+    client: httpx.AsyncClient,
+) -> None:
+    response = await client.get("/api/v1/sys/config")
+    body = response.json()
+    topics = [e for e in body["entries"] if e["key"].startswith("kafka_topic_")]
+    assert len(topics) >= 4
+    for entry in topics:
+        assert entry["category"] == "kafka_topics"
+        assert entry["stability"] == "structural"


### PR DESCRIPTION
## What

Adds \`GET /api/v1/sys/config\` — a read-only endpoint that returns every gateway settings field with the metadata an SRE wants on the page.

For each of the 97 fields it emits:

- \`key\`, \`value\` (sensitive masked), \`default\`
- \`source\`: \`env\` (process env var set) vs \`default\` (schema default)
- \`description\`, \`impact\`, \`category\`, \`stability\` — lifted from \`Field(json_schema_extra={...})\`
- \`sensitive\`: True for \`SecretStr\` or \`json_schema_extra['secret']=True\`
- \`mutable\`: True iff the runtime-override allowlist accepts the field
- \`restart\`: \`none\` for allowlisted (live PATCH applies), \`gateway\` otherwise
- \`range\`: derived from pydantic constraints (\`ge\`/\`le\`) and \`Literal\` args

## Why a new endpoint

\`/admin/config\` already exposes the values and the override allowlist, but it doesn't surface the rich metadata that's already encoded in \`Settings\`. The eveys-console UI can't reconstruct it from values alone, and overloading \`/admin/config\` would either break its existing contract or silently bloat its response.

\`/sys/config\` is the read-only counterpart of \`/admin/config\` — they share the same allowlist source of truth (\`runtime_overrides.allowlist()\`).

## Sensitive masking

\`SecretStr\` fields are stripped of their raw value before the response leaves the gateway, same posture as \`model_dump(mode='json')\` already enforces. Test: \`test_sensitive_fields_are_masked\` verifies the conftest's \`rest_inbound_tokens=\"test-token-foundation\"\` doesn't appear anywhere in the body.

## Tests

7 new tests covering: every settings field appears, sensitive masking + secret-leak guard, every entry carries the required metadata fields, allowlisted fields are mutable+live, structural fields are immutable+restart=gateway, bounded-int ranges include both bounds, \`Literal\` ranges list all allowed values, kafka-topic group invariants. Coverage stays at 83.5% (over the 80% gate).

OpenAPI specs (\`docs/api/openapi.{json,yaml}\`) regenerated via \`make openapi-export\` so the drift check in CI passes.

Closes #131