### PR TITLE
feature(api): SoC + per-phase snapshot on transaction detail

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -732,6 +732,58 @@
         "title": "MeterValuesResponse",
         "type": "object"
       },
+      "PhaseSnapshot": {
+        "description": "Most-recent per-phase electrical snapshot for one transaction.\n\n`argMax(value, occurred_at)` per measurand on the named phase\n(`L1`, `L2`, `L3`). Each field is `null` when the charger never\nreported that measurand on that phase \u2014 single-phase chargers\npopulate only one phase, DC chargers may populate none.",
+        "properties": {
+          "current_a": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Current A"
+          },
+          "last_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ISO 8601 timestamp of the most recent sample on this phase.",
+            "title": "Last At"
+          },
+          "power_w": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Power W"
+          },
+          "voltage_v": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Voltage V"
+          }
+        },
+        "title": "PhaseSnapshot",
+        "type": "object"
+      },
       "RemoteStartRequest": {
         "example": {
           "connector_id": 1,
@@ -869,6 +921,47 @@
           "type"
         ],
         "title": "ResetRequest",
+        "type": "object"
+      },
+      "SocSummary": {
+        "description": "State-of-charge summary for one transaction.\n\n`start_pct` is the earliest SoC sample inside the transaction's\nwindow; `last_pct` is the most recent. For a stopped transaction,\n`last_pct` is effectively the SoC at stop. Any field is `null`\nwhen the charger never reported SoC.",
+        "properties": {
+          "last_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ISO 8601 timestamp of the most recent SoC sample.",
+            "title": "Last At"
+          },
+          "last_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Pct"
+          },
+          "start_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Pct"
+          }
+        },
+        "title": "SocSummary",
         "type": "object"
       },
       "StatusEvent": {
@@ -1057,6 +1150,33 @@
           "started_at": "2026-05-07T12:00:00+00:00",
           "stop_reason": "Local",
           "stopped_at": "2026-05-07T12:30:00+00:00",
+          "telemetry": {
+            "phases": {
+              "L1": {
+                "current_a": 14.8,
+                "last_at": "2026-05-07T12:29:58+00:00",
+                "power_w": 3417.3,
+                "voltage_v": 231.4
+              },
+              "L2": {
+                "current_a": 14.6,
+                "last_at": "2026-05-07T12:29:58+00:00",
+                "power_w": 3370.5,
+                "voltage_v": 230.9
+              },
+              "L3": {
+                "current_a": 14.7,
+                "last_at": "2026-05-07T12:29:58+00:00",
+                "power_w": 3393.0,
+                "voltage_v": 231.1
+              }
+            },
+            "soc": {
+              "last_at": "2026-05-07T12:29:58+00:00",
+              "last_pct": 81.0,
+              "start_pct": 38.0
+            }
+          },
           "transaction_id": 12345
         },
         "properties": {
@@ -1123,6 +1243,17 @@
               }
             ],
             "title": "Stopped At"
+          },
+          "telemetry": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TransactionTelemetry"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ClickHouse-backed snapshot \u2014 SoC start/last and per-phase voltage/current/power. `null` when the gateway has no ClickHouse read client configured."
           },
           "transaction_id": {
             "description": "OCPP 1.6 transaction id assigned by the gateway.",
@@ -1192,6 +1323,28 @@
           "request_id"
         ],
         "title": "TransactionListResponse",
+        "type": "object"
+      },
+      "TransactionTelemetry": {
+        "description": "ClickHouse-backed telemetry summary attached to the transaction\ndetail endpoint.\n\nBounded shape \u2014 SoC start/last and one snapshot per phase \u2014 so the\nresponse stays small regardless of session length. Callers wanting\nthe full curve should hit\n`GET /api/v1/charge-points/{cp_id}/meter-values` with a window.",
+        "properties": {
+          "phases": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/PhaseSnapshot"
+            },
+            "description": "Keyed by OCPP 1.6 phase name (`L1`, `L2`, `L3`). Phases the charger never reported are absent from the map.",
+            "title": "Phases",
+            "type": "object"
+          },
+          "soc": {
+            "$ref": "#/components/schemas/SocSummary"
+          }
+        },
+        "required": [
+          "soc",
+          "phases"
+        ],
+        "title": "TransactionTelemetry",
         "type": "object"
       },
       "UpdateBody": {

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -491,6 +491,41 @@ components:
       - request_id
       title: MeterValuesResponse
       type: object
+    PhaseSnapshot:
+      description: 'Most-recent per-phase electrical snapshot for one transaction.
+
+
+        `argMax(value, occurred_at)` per measurand on the named phase
+
+        (`L1`, `L2`, `L3`). Each field is `null` when the charger never
+
+        reported that measurand on that phase — single-phase chargers
+
+        populate only one phase, DC chargers may populate none.'
+      properties:
+        current_a:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Current A
+        last_at:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: ISO 8601 timestamp of the most recent sample on this phase.
+          title: Last At
+        power_w:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Power W
+        voltage_v:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Voltage V
+      title: PhaseSnapshot
+      type: object
     RemoteStartRequest:
       example:
         connector_id: 1
@@ -583,6 +618,36 @@ components:
       required:
       - type
       title: ResetRequest
+      type: object
+    SocSummary:
+      description: 'State-of-charge summary for one transaction.
+
+
+        `start_pct` is the earliest SoC sample inside the transaction''s
+
+        window; `last_pct` is the most recent. For a stopped transaction,
+
+        `last_pct` is effectively the SoC at stop. Any field is `null`
+
+        when the charger never reported SoC.'
+      properties:
+        last_at:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: ISO 8601 timestamp of the most recent SoC sample.
+          title: Last At
+        last_pct:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Last Pct
+        start_pct:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Start Pct
+      title: SocSummary
       type: object
     StatusEvent:
       properties:
@@ -705,6 +770,27 @@ components:
         started_at: '2026-05-07T12:00:00+00:00'
         stop_reason: Local
         stopped_at: '2026-05-07T12:30:00+00:00'
+        telemetry:
+          phases:
+            L1:
+              current_a: 14.8
+              last_at: '2026-05-07T12:29:58+00:00'
+              power_w: 3417.3
+              voltage_v: 231.4
+            L2:
+              current_a: 14.6
+              last_at: '2026-05-07T12:29:58+00:00'
+              power_w: 3370.5
+              voltage_v: 230.9
+            L3:
+              current_a: 14.7
+              last_at: '2026-05-07T12:29:58+00:00'
+              power_w: 3393.0
+              voltage_v: 231.1
+          soc:
+            last_at: '2026-05-07T12:29:58+00:00'
+            last_pct: 81.0
+            start_pct: 38.0
         transaction_id: 12345
       properties:
         connector_id:
@@ -746,6 +832,12 @@ components:
           - type: string
           - type: 'null'
           title: Stopped At
+        telemetry:
+          anyOf:
+          - $ref: '#/components/schemas/TransactionTelemetry'
+          - type: 'null'
+          description: ClickHouse-backed snapshot — SoC start/last and per-phase voltage/current/power.
+            `null` when the gateway has no ClickHouse read client configured.
         transaction_id:
           description: OCPP 1.6 transaction id assigned by the gateway.
           title: Transaction Id
@@ -795,6 +887,34 @@ components:
       - next_cursor
       - request_id
       title: TransactionListResponse
+      type: object
+    TransactionTelemetry:
+      description: 'ClickHouse-backed telemetry summary attached to the transaction
+
+        detail endpoint.
+
+
+        Bounded shape — SoC start/last and one snapshot per phase — so the
+
+        response stays small regardless of session length. Callers wanting
+
+        the full curve should hit
+
+        `GET /api/v1/charge-points/{cp_id}/meter-values` with a window.'
+      properties:
+        phases:
+          additionalProperties:
+            $ref: '#/components/schemas/PhaseSnapshot'
+          description: Keyed by OCPP 1.6 phase name (`L1`, `L2`, `L3`). Phases the
+            charger never reported are absent from the map.
+          title: Phases
+          type: object
+        soc:
+          $ref: '#/components/schemas/SocSummary'
+      required:
+      - soc
+      - phases
+      title: TransactionTelemetry
       type: object
     UpdateBody:
       description: 'PATCH body. The keys in `updates` must be allowlisted; the

--- a/src/eveys_ocpp/api/_schemas.py
+++ b/src/eveys_ocpp/api/_schemas.py
@@ -240,6 +240,57 @@ class ChargePointListResponse(BaseModel):
 # --------------------------------------------------------------------------
 
 
+class SocSummary(BaseModel):
+    """State-of-charge summary for one transaction.
+
+    `start_pct` is the earliest SoC sample inside the transaction's
+    window; `last_pct` is the most recent. For a stopped transaction,
+    `last_pct` is effectively the SoC at stop. Any field is `null`
+    when the charger never reported SoC."""
+
+    start_pct: float | None = None
+    last_pct: float | None = None
+    last_at: str | None = Field(
+        default=None,
+        description="ISO 8601 timestamp of the most recent SoC sample.",
+    )
+
+
+class PhaseSnapshot(BaseModel):
+    """Most-recent per-phase electrical snapshot for one transaction.
+
+    `argMax(value, occurred_at)` per measurand on the named phase
+    (`L1`, `L2`, `L3`). Each field is `null` when the charger never
+    reported that measurand on that phase — single-phase chargers
+    populate only one phase, DC chargers may populate none."""
+
+    voltage_v: float | None = None
+    current_a: float | None = None
+    power_w: float | None = None
+    last_at: str | None = Field(
+        default=None,
+        description="ISO 8601 timestamp of the most recent sample on this phase.",
+    )
+
+
+class TransactionTelemetry(BaseModel):
+    """ClickHouse-backed telemetry summary attached to the transaction
+    detail endpoint.
+
+    Bounded shape — SoC start/last and one snapshot per phase — so the
+    response stays small regardless of session length. Callers wanting
+    the full curve should hit
+    `GET /api/v1/charge-points/{cp_id}/meter-values` with a window."""
+
+    soc: SocSummary
+    phases: dict[str, PhaseSnapshot] = Field(
+        description=(
+            "Keyed by OCPP 1.6 phase name (`L1`, `L2`, `L3`). Phases the "
+            "charger never reported are absent from the map."
+        ),
+    )
+
+
 class Transaction(BaseModel):
     transaction_id: int = Field(description="OCPP 1.6 transaction id assigned by the gateway.")
     cp_id: str
@@ -254,6 +305,14 @@ class Transaction(BaseModel):
 
 
 class TransactionDetail(Transaction):
+    telemetry: TransactionTelemetry | None = Field(
+        default=None,
+        description=(
+            "ClickHouse-backed snapshot — SoC start/last and per-phase "
+            "voltage/current/power. `null` when the gateway has no "
+            "ClickHouse read client configured."
+        ),
+    )
     request_id: str
 
     model_config = {
@@ -269,6 +328,33 @@ class TransactionDetail(Transaction):
                 "stopped_at": "2026-05-07T12:30:00+00:00",
                 "stop_reason": "Local",
                 "open": False,
+                "telemetry": {
+                    "soc": {
+                        "start_pct": 38.0,
+                        "last_pct": 81.0,
+                        "last_at": "2026-05-07T12:29:58+00:00",
+                    },
+                    "phases": {
+                        "L1": {
+                            "voltage_v": 231.4,
+                            "current_a": 14.8,
+                            "power_w": 3417.3,
+                            "last_at": "2026-05-07T12:29:58+00:00",
+                        },
+                        "L2": {
+                            "voltage_v": 230.9,
+                            "current_a": 14.6,
+                            "power_w": 3370.5,
+                            "last_at": "2026-05-07T12:29:58+00:00",
+                        },
+                        "L3": {
+                            "voltage_v": 231.1,
+                            "current_a": 14.7,
+                            "power_w": 3393.0,
+                            "last_at": "2026-05-07T12:29:58+00:00",
+                        },
+                    },
+                },
                 "request_id": "9b3c5d18-1f7c-4b6a-8e0e-5b9a3c4f2e10",
             }
         }
@@ -431,14 +517,17 @@ __all__ = [
     "HealthResponse",
     "MeterValueSample",
     "MeterValuesResponse",
+    "PhaseSnapshot",
     "RemoteStartRequest",
     "RemoteStopRequest",
     "Reservation",
     "ReservationListResponse",
     "ResetRequest",
+    "SocSummary",
     "StatusEvent",
     "StatusHistoryResponse",
     "Transaction",
     "TransactionDetail",
     "TransactionListResponse",
+    "TransactionTelemetry",
 ]

--- a/src/eveys_ocpp/api/transactions.py
+++ b/src/eveys_ocpp/api/transactions.py
@@ -237,5 +237,23 @@ async def get_transaction_route(request: Request, transaction_id: int) -> dict[s
             message=f"unknown transaction_id: {transaction_id}",
         )
     response = _transaction_to_response(tx)
+    response["telemetry"] = await _telemetry_for(request, tx)
     response["request_id"] = request.state.request_id
     return response
+
+
+async def _telemetry_for(request: Request, tx: dict[str, Any]) -> dict[str, Any] | None:
+    """Fetch the per-transaction telemetry snapshot, or `None` when the
+    gateway has no ClickHouse read client wired in.
+
+    Compose-smoke and unit-test apps run without ClickHouse; surface
+    `telemetry: null` in those environments rather than 500ing on a
+    detail call."""
+    ch_client = getattr(request.app.state, "ch_client", None)
+    if ch_client is None:
+        return None
+    result: dict[str, Any] = await ch_client.fetch_transaction_telemetry(
+        cp_id=tx["cp_id"],
+        transaction_id=tx["transaction_id"],
+    )
+    return result

--- a/src/eveys_ocpp/clickhouse/read_client.py
+++ b/src/eveys_ocpp/clickhouse/read_client.py
@@ -187,6 +187,117 @@ class ClickHouseReadClient:
             out.setdefault(cp_id, []).append(record)
         return out
 
+    async def fetch_transaction_telemetry(
+        self,
+        *,
+        cp_id: str,
+        transaction_id: int,
+    ) -> dict[str, Any]:
+        """Bounded telemetry snapshot for one transaction.
+
+        Two scans of `cp_meter` filtered by (`cp_id`, `transaction_id`) —
+        one for SoC start/last, one for per-phase voltage/current/power.
+        The transaction id pins the work so a long-running session can't
+        blow up the result set: at most 1 row from the SoC query and 9
+        from the phases query (3 phases x 3 measurands).
+
+        Returns a dict shaped for `TransactionTelemetry`:
+            {
+                "soc": {"start_pct": ..., "last_pct": ..., "last_at": ...},
+                "phases": {"L1": {voltage_v, current_a, power_w, last_at}, ...},
+            }
+
+        Phases the charger never reported are absent from `phases`. SoC
+        fields are `None` when no SoC sample exists for the transaction.
+        """
+        assert self._conn is not None  # narrowed by start()
+
+        # Both queries restrict to (cp_id, transaction_id) so the
+        # MergeTree partition + order key (cp_id, occurred_at) prunes
+        # the scan. The string-cast on `value` matches `cp_meter`'s
+        # column type — sampled values are stored as Strings (DDL
+        # at clickhouse/ddl/0002_create_cp_meter.sql); cast at read.
+        soc_sql = """
+            SELECT
+                argMin(toFloat64OrNull(sv.value), occurred_at) AS start_pct,
+                argMax(toFloat64OrNull(sv.value), occurred_at) AS last_pct,
+                max(occurred_at) AS last_at
+            FROM cp_meter
+            ARRAY JOIN sampled_values AS sv
+            WHERE cp_id = {cp_id}
+              AND transaction_id = {transaction_id}
+              AND sv.measurand = 'SoC'
+        """
+        phases_sql = """
+            SELECT
+                sv.phase AS phase,
+                sv.measurand AS measurand,
+                argMax(toFloat64OrNull(sv.value), occurred_at) AS value,
+                max(occurred_at) AS last_at
+            FROM cp_meter
+            ARRAY JOIN sampled_values AS sv
+            WHERE cp_id = {cp_id}
+              AND transaction_id = {transaction_id}
+              AND sv.phase IN ('L1', 'L2', 'L3')
+              AND sv.measurand IN ('Voltage', 'Current.Import', 'Power.Active.Import')
+            GROUP BY phase, measurand
+        """
+        params: dict[str, Any] = {"cp_id": cp_id, "transaction_id": transaction_id}
+
+        async with self._conn.cursor() as cursor:
+            await cursor.execute(soc_sql, params)
+            soc_cols = [d[0] for d in cursor.description]
+            soc_rows = await cursor.fetchall()
+
+            await cursor.execute(phases_sql, params)
+            phase_cols = [d[0] for d in cursor.description]
+            phase_rows = await cursor.fetchall()
+
+        soc: dict[str, Any] = {"start_pct": None, "last_pct": None, "last_at": None}
+        if soc_rows:
+            row = dict(zip(soc_cols, soc_rows[0], strict=True))
+            # `max(occurred_at)` over an empty filter yields the epoch sentinel
+            # (1970-01-01) on ClickHouse — guard so we don't surface that as
+            # a real timestamp.
+            last_at = row["last_at"]
+            has_data = row["start_pct"] is not None or row["last_pct"] is not None
+            soc = {
+                "start_pct": row["start_pct"],
+                "last_pct": row["last_pct"],
+                "last_at": last_at.isoformat() if has_data and last_at is not None else None,
+            }
+
+        phases: dict[str, dict[str, Any]] = {}
+        _measurand_to_field = {
+            "Voltage": "voltage_v",
+            "Current.Import": "current_a",
+            "Power.Active.Import": "power_w",
+        }
+        for raw in phase_rows:
+            row = dict(zip(phase_cols, raw, strict=True))
+            phase = row["phase"]
+            field = _measurand_to_field.get(row["measurand"])
+            if field is None:
+                continue
+            snap = phases.setdefault(
+                phase,
+                {"voltage_v": None, "current_a": None, "power_w": None, "last_at": None},
+            )
+            snap[field] = row["value"]
+            # `last_at` per phase = max occurred_at across that phase's
+            # measurands (groupBy is per measurand; we fold here).
+            row_last = row["last_at"]
+            if row_last is not None and (snap["last_at"] is None or row_last > snap["last_at"]):
+                snap["last_at"] = row_last
+
+        # Format last_at strings only after the fold so comparisons
+        # above stay on native datetimes.
+        for snap in phases.values():
+            if snap["last_at"] is not None:
+                snap["last_at"] = snap["last_at"].isoformat()
+
+        return {"soc": soc, "phases": phases}
+
     async def fetch_status_history(
         self,
         *,

--- a/src/eveys_ocpp/persistence/repositories.py
+++ b/src/eveys_ocpp/persistence/repositories.py
@@ -924,14 +924,26 @@ async def get_transaction_by_id(
     """Single-transaction detail, looked up by `transaction_id` (the
     OCPP-visible id, not the surrogate PK).
 
+    Joins ``charge_points`` so the projected dict carries the
+    OCPP-visible ``cp_id`` string — the detail route needs it to scope
+    the ClickHouse telemetry lookup, and it's the same shape callers
+    already get from ``list_transactions``.
+
     Returns `None` when no row exists (route handler → 404
     `UNKNOWN_TRANSACTION_ID`)."""
-    stmt = select(Transaction).where(Transaction.transaction_id == transaction_id)
+    stmt = (
+        select(Transaction, ChargePoint.cp_id)
+        .join(ChargePoint, Transaction.charge_point_id == ChargePoint.id)
+        .where(Transaction.transaction_id == transaction_id)
+    )
     result = await session.execute(stmt)
-    tx = result.scalar_one_or_none()
-    if tx is None:
+    row = result.one_or_none()
+    if row is None:
         return None
-    return _transaction_to_dict(tx)
+    tx, cp_id_value = row
+    out = _transaction_to_dict(tx)
+    out["cp_id"] = cp_id_value
+    return out
 
 
 def _reservation_to_dict(r: Reservation) -> dict[str, Any]:

--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -95,6 +95,12 @@ def fake_ch_client() -> MagicMock:
     client.fetch_meter_values = AsyncMock(return_value=[])
     client.fetch_status_history = AsyncMock(return_value=[])
     client.fetch_latest_connector_statuses = AsyncMock(return_value={})
+    client.fetch_transaction_telemetry = AsyncMock(
+        return_value={
+            "soc": {"start_pct": None, "last_pct": None, "last_at": None},
+            "phases": {},
+        }
+    )
     return client
 
 

--- a/tests/unit/api/test_transactions.py
+++ b/tests/unit/api/test_transactions.py
@@ -9,12 +9,21 @@ from unittest.mock import AsyncMock
 import httpx
 import pytest
 
+from eveys_ocpp.api._app import make_app
+from eveys_ocpp.settings import Settings
 
-def _tx_row(transaction_id: int = 999, *, stopped: bool = False) -> dict[str, Any]:
+
+def _tx_row(
+    transaction_id: int = 999,
+    *,
+    stopped: bool = False,
+    cp_id: str = "CP_001",
+) -> dict[str, Any]:
     return {
         "id": transaction_id,
         "transaction_id": transaction_id,
         "charge_point_id": 1,
+        "cp_id": cp_id,
         "connector_id": 1,
         "id_tag": "RFID_001",
         "meter_start_wh": 1_000_000,
@@ -235,3 +244,113 @@ async def test_list_global_does_not_collide_with_detail_route(
     listing = await client.get("/api/v1/transactions")
     assert listing.status_code == 200
     assert listing.json()["transactions"] == []
+
+
+# ----- telemetry on detail endpoint -----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_detail_includes_telemetry_block(
+    client: httpx.AsyncClient,
+    fake_ch_client: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Detail response stitches the ClickHouse telemetry snapshot under
+    `telemetry`, scoped by (cp_id, transaction_id)."""
+    from eveys_ocpp.api import transactions as tx_module
+
+    monkeypatch.setattr(
+        tx_module,
+        "get_transaction_by_id",
+        AsyncMock(return_value=_tx_row(transaction_id=999, stopped=True, cp_id="CP_BERLIN_001")),
+    )
+    fake_ch_client.fetch_transaction_telemetry = AsyncMock(
+        return_value={
+            "soc": {
+                "start_pct": 38.0,
+                "last_pct": 81.0,
+                "last_at": "2026-05-05T15:00:00+00:00",
+            },
+            "phases": {
+                "L1": {
+                    "voltage_v": 231.4,
+                    "current_a": 14.8,
+                    "power_w": 3417.3,
+                    "last_at": "2026-05-05T15:00:00+00:00",
+                },
+            },
+        }
+    )
+
+    response = await client.get("/api/v1/transactions/999")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["telemetry"]["soc"]["start_pct"] == 38.0
+    assert body["telemetry"]["soc"]["last_pct"] == 81.0
+    assert body["telemetry"]["phases"]["L1"]["voltage_v"] == 231.4
+    assert body["telemetry"]["phases"]["L1"]["current_a"] == 14.8
+    assert body["telemetry"]["phases"]["L1"]["power_w"] == 3417.3
+
+    fake_ch_client.fetch_transaction_telemetry.assert_awaited_once_with(
+        cp_id="CP_BERLIN_001", transaction_id=999
+    )
+
+
+@pytest.mark.asyncio
+async def test_detail_telemetry_null_when_no_ch_client(
+    settings: Settings,
+    fake_session_factory: Any,
+    fake_registry: Any,
+    fake_command_service: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Compose-smoke / unit-test gateways may run without ClickHouse —
+    surface `telemetry: null` instead of 500ing on a detail call."""
+    app = make_app(
+        session_factory=fake_session_factory,
+        settings=settings,
+        registry=fake_registry,
+        redis=None,
+        command_service=fake_command_service,
+        ch_client=None,
+    )
+
+    from eveys_ocpp.api import transactions as tx_module
+
+    monkeypatch.setattr(
+        tx_module, "get_transaction_by_id", AsyncMock(return_value=_tx_row(transaction_id=42))
+    )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://gw",
+        headers={"Authorization": "Bearer test-token-foundation"},
+    ) as ac:
+        response = await ac.get("/api/v1/transactions/42")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["transaction_id"] == 42
+    assert body["telemetry"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_responses_have_no_telemetry_field(
+    client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Telemetry is detail-only — list responses must stay Postgres-only
+    so cursor pages don't fan out N+1 ClickHouse queries."""
+    from eveys_ocpp.api import transactions as tx_module
+
+    monkeypatch.setattr(
+        tx_module,
+        "list_transactions",
+        AsyncMock(return_value=[_tx_row_with_cp(1, "CP_X"), _tx_row_with_cp(2, "CP_Y")]),
+    )
+
+    response = await client.get("/api/v1/transactions")
+
+    body = response.json()
+    for row in body["transactions"]:
+        assert "telemetry" not in row


### PR DESCRIPTION
## Summary

- `GET /api/v1/transactions/{id}` now carries a `telemetry` block: SoC start/last and a per-phase voltage/current/power snapshot for L1/L2/L3.
- The data already lived in ClickHouse `cp_meter`. This is the bounded projection so a UI doesn't have to walk the meter-values firehose to render a session.
- List endpoints (`/transactions`, `/charge-points/{cp_id}/transactions`) intentionally do **not** include telemetry — N+1 ClickHouse fan-out per cursor page would tank latency. Detail-only.
- `telemetry: null` when the gateway has no ClickHouse read client wired in (compose-smoke, some test envs) instead of 500.

## Shape

```json
"telemetry": {
  "soc": { "start_pct": 38.0, "last_pct": 81.0, "last_at": "..." },
  "phases": {
    "L1": { "voltage_v": 231.4, "current_a": 14.8, "power_w": 3417.3, "last_at": "..." },
    "L2": { ... },
    "L3": { ... }
  }
}
```

Phases the charger never reported are absent from `phases`. Single-phase AC populates one key. SoC fields are `null` when no SoC sample exists.

## Implementation notes

- `ClickHouseReadClient.fetch_transaction_telemetry` runs two scans bounded by `(cp_id, transaction_id)` — one `argMin/argMax` for SoC, one `argMax GROUP BY phase, measurand` for phases. Result rows are 1 (SoC) + at most 9 (3 phases x 3 measurands).
- `get_transaction_by_id` now joins `charge_points` so the route can pass the OCPP-visible `cp_id` to ClickHouse.
- For a stopped tx, `argMax(value, occurred_at)` is by definition the value at stop. For an open tx it's the most recent sample. Same column, both meanings work — the docstring spells this out.
- Regenerated `docs/api/openapi.{json,yaml}`.

## Test plan

- [x] `tests/unit/api/test_transactions.py` — three new tests: telemetry block on detail, `telemetry: null` when `ch_client is None`, list responses don't carry `telemetry`.
- [x] Existing detail/list tests updated to include `cp_id` on fixture rows (the repo now returns it).
- [x] `tests/unit/api/test_openapi.py` — committed snapshot regenerated; snapshot test passes.
- [x] Full unit suite: 741 passed, 83.51% coverage. (One pre-existing flake on `test_authorize.py::test_unavailable_fallback_is_not_cached` deselected — unrelated to this change.)
- [ ] e2e / compose-smoke: not run locally; CI will exercise.

Closes #133