### PR TITLE
fix(handlers): translate OCPP MeterValues enum strings into proto enums

### DIFF
--- a/src/eveys_ocpp/handlers/v16/meter_values.py
+++ b/src/eveys_ocpp/handlers/v16/meter_values.py
@@ -61,6 +61,104 @@ if TYPE_CHECKING:
 log = get_logger(__name__)
 
 
+# OCPP 1.6 §6.21 wire strings → proto enum values.
+#
+# OCPP serializes these enum dimensions on each SampledValue as
+# string literals (e.g. `"Voltage"`, `"L1-N"`, `"Sample.Periodic"`).
+# The proto schema models them as strongly-typed enums so downstream
+# consumers (ClickHouse, Grafana, billing) can group/filter without
+# reasoning about vendor-specific string casing or punctuation.
+#
+# Unknown values fall back to `*_UNSPECIFIED` (the 0 value), which
+# preserves forward-compat with vendor extensions — the raw `value`
+# is still captured even when an enum is unrecognised.
+#
+# These dicts are built once at import. Comparisons are case-sensitive
+# per the spec; chargers reporting non-canonical casing will land in
+# `*_UNSPECIFIED`.
+_MEASURAND_BY_OCPP: dict[str, int] = {
+    "Energy.Active.Export.Register": events_pb2.MEASURAND_ENERGY_ACTIVE_EXPORT_REGISTER,
+    "Energy.Active.Import.Register": events_pb2.MEASURAND_ENERGY_ACTIVE_IMPORT_REGISTER,
+    "Energy.Reactive.Export.Register": events_pb2.MEASURAND_ENERGY_REACTIVE_EXPORT_REGISTER,
+    "Energy.Reactive.Import.Register": events_pb2.MEASURAND_ENERGY_REACTIVE_IMPORT_REGISTER,
+    "Energy.Active.Export.Interval": events_pb2.MEASURAND_ENERGY_ACTIVE_EXPORT_INTERVAL,
+    "Energy.Active.Import.Interval": events_pb2.MEASURAND_ENERGY_ACTIVE_IMPORT_INTERVAL,
+    "Energy.Reactive.Export.Interval": events_pb2.MEASURAND_ENERGY_REACTIVE_EXPORT_INTERVAL,
+    "Energy.Reactive.Import.Interval": events_pb2.MEASURAND_ENERGY_REACTIVE_IMPORT_INTERVAL,
+    "Power.Active.Export": events_pb2.MEASURAND_POWER_ACTIVE_EXPORT,
+    "Power.Active.Import": events_pb2.MEASURAND_POWER_ACTIVE_IMPORT,
+    "Power.Offered": events_pb2.MEASURAND_POWER_OFFERED,
+    "Power.Reactive.Export": events_pb2.MEASURAND_POWER_REACTIVE_EXPORT,
+    "Power.Reactive.Import": events_pb2.MEASURAND_POWER_REACTIVE_IMPORT,
+    "Power.Factor": events_pb2.MEASURAND_POWER_FACTOR,
+    "Current.Import": events_pb2.MEASURAND_CURRENT_IMPORT,
+    "Current.Export": events_pb2.MEASURAND_CURRENT_EXPORT,
+    "Current.Offered": events_pb2.MEASURAND_CURRENT_OFFERED,
+    "Voltage": events_pb2.MEASURAND_VOLTAGE,
+    "Frequency": events_pb2.MEASURAND_FREQUENCY,
+    "Temperature": events_pb2.MEASURAND_TEMPERATURE,
+    "SoC": events_pb2.MEASURAND_SOC,
+    "RPM": events_pb2.MEASURAND_RPM,
+}
+
+_PHASE_BY_OCPP: dict[str, int] = {
+    "L1": events_pb2.PHASE_L1,
+    "L2": events_pb2.PHASE_L2,
+    "L3": events_pb2.PHASE_L3,
+    "N": events_pb2.PHASE_N,
+    "L1-N": events_pb2.PHASE_L1_N,
+    "L2-N": events_pb2.PHASE_L2_N,
+    "L3-N": events_pb2.PHASE_L3_N,
+    "L1-L2": events_pb2.PHASE_L1_L2,
+    "L2-L3": events_pb2.PHASE_L2_L3,
+    "L3-L1": events_pb2.PHASE_L3_L1,
+}
+
+_UNIT_BY_OCPP: dict[str, int] = {
+    "Wh": events_pb2.UNIT_WH,
+    "kWh": events_pb2.UNIT_KWH,
+    "varh": events_pb2.UNIT_VARH,
+    "kvarh": events_pb2.UNIT_KVARH,
+    "W": events_pb2.UNIT_W,
+    "kW": events_pb2.UNIT_KW,
+    "var": events_pb2.UNIT_VAR,
+    "kvar": events_pb2.UNIT_KVAR,
+    "VA": events_pb2.UNIT_VA,
+    "kVA": events_pb2.UNIT_KVA,
+    "A": events_pb2.UNIT_A,
+    "V": events_pb2.UNIT_V,
+    "Celsius": events_pb2.UNIT_CELSIUS,
+    "Fahrenheit": events_pb2.UNIT_FAHRENHEIT,
+    "K": events_pb2.UNIT_K,
+    "Percent": events_pb2.UNIT_PERCENT,
+    "Hertz": events_pb2.UNIT_HERTZ,
+}
+
+_CONTEXT_BY_OCPP: dict[str, int] = {
+    "Interruption.Begin": events_pb2.CONTEXT_INTERRUPTION_BEGIN,
+    "Interruption.End": events_pb2.CONTEXT_INTERRUPTION_END,
+    "Other": events_pb2.CONTEXT_OTHER,
+    "Sample.Clock": events_pb2.CONTEXT_SAMPLE_CLOCK,
+    "Sample.Periodic": events_pb2.CONTEXT_SAMPLE_PERIODIC,
+    "Transaction.Begin": events_pb2.CONTEXT_TRANSACTION_BEGIN,
+    "Transaction.End": events_pb2.CONTEXT_TRANSACTION_END,
+    "Trigger": events_pb2.CONTEXT_TRIGGER,
+}
+
+_FORMAT_BY_OCPP: dict[str, int] = {
+    "Raw": events_pb2.FORMAT_RAW,
+    "SignedData": events_pb2.FORMAT_SIGNED_DATA,
+}
+
+_LOCATION_BY_OCPP: dict[str, int] = {
+    "Cable": events_pb2.LOCATION_CABLE,
+    "EV": events_pb2.LOCATION_EV,
+    "Inlet": events_pb2.LOCATION_INLET,
+    "Outlet": events_pb2.LOCATION_OUTLET,
+    "Body": events_pb2.LOCATION_BODY,
+}
+
+
 def _build_envelope(*, cp_id: str, payload: events_pb2.CpMeter) -> bytes:
     envelope = events_pb2.EventEnvelope(
         event_id=str(uuid.uuid4()),
@@ -80,6 +178,14 @@ def _to_proto_sampled_value(raw: dict[str, Any]) -> events_pb2.SampledValue:
     kwargs by the time they reach us, but the inner dicts in
     `meter_value[*].sampled_value` may stay as raw dicts (depending
     on the library's marshaling). Tolerate both.
+
+    Per OCPP 1.6 §6.21.4 an absent `measurand` defaults to
+    `Energy.Active.Import.Register` — applied here so consumers
+    filtering by that measurand don't miss the bare-energy samples
+    chargers commonly emit.
+
+    Unknown enum values land in `*_UNSPECIFIED` (vendor extensions);
+    the raw `value` is still captured.
     """
 
     def _g(*names: str) -> str:
@@ -88,12 +194,19 @@ def _to_proto_sampled_value(raw: dict[str, Any]) -> events_pb2.SampledValue:
                 return str(raw[name])
         return ""
 
+    measurand_str = _g("measurand")
+    if not measurand_str:
+        # OCPP 1.6 §6.21.4 default.
+        measurand_str = "Energy.Active.Import.Register"
+
     return events_pb2.SampledValue(
         value=_g("value"),
-        # OCPP uses string enums; we drop them through as opaque
-        # strings — the proto enum mapping happens downstream in
-        # ClickHouse. Forward-compat with vendor extensions.
-        # Empty enum field encodes as the *_UNSPECIFIED 0 value.
+        context=_CONTEXT_BY_OCPP.get(_g("context"), events_pb2.CONTEXT_UNSPECIFIED),
+        format=_FORMAT_BY_OCPP.get(_g("format"), events_pb2.FORMAT_UNSPECIFIED),
+        measurand=_MEASURAND_BY_OCPP.get(measurand_str, events_pb2.MEASURAND_UNSPECIFIED),
+        phase=_PHASE_BY_OCPP.get(_g("phase"), events_pb2.PHASE_UNSPECIFIED),
+        location=_LOCATION_BY_OCPP.get(_g("location"), events_pb2.LOCATION_UNSPECIFIED),
+        unit=_UNIT_BY_OCPP.get(_g("unit"), events_pb2.UNIT_UNSPECIFIED),
     )
 
 

--- a/tests/compose_smoke/test_compose_stack.py
+++ b/tests/compose_smoke/test_compose_stack.py
@@ -28,6 +28,7 @@ from ocpp.v16 import call
 from websockets.asyncio.client import connect
 
 from tests.compose_smoke.conftest import (
+    HOST_CH_HTTP_PORT,
     HOST_ENVOY_ADMIN_PORT,
     HOST_ENVOY_TLS_PORT,
     HOST_WS_PORT,
@@ -202,9 +203,13 @@ async def test_full_charger_flow_against_running_container() -> None:
             tx_id = int(start.transaction_id)
 
             # MeterValues — exercises the Kafka publish path so the
-            # ingestor materialises a row downstream. We don't assert
-            # the ClickHouse row here (separate test below); we just
-            # need the publish to succeed without a Kafka error.
+            # ingestor materialises a row downstream. The
+            # multi-measurand mix (energy + per-phase voltage + SoC)
+            # is also what the next test (#135 enum-mapping
+            # assertion) reads back from ClickHouse: anything with a
+            # `measurand` other than `Energy.Active.Import.Register`
+            # would have crashed the original handler-bug-passing
+            # path, where everything stored as `MEASURAND_UNSPECIFIED`.
             await asyncio.wait_for(
                 sim.call(
                     call.MeterValues(
@@ -218,7 +223,18 @@ async def test_full_charger_flow_against_running_container() -> None:
                                         "value": "1234",
                                         "measurand": "Energy.Active.Import.Register",
                                         "unit": "Wh",
-                                    }
+                                    },
+                                    {
+                                        "value": "230.4",
+                                        "measurand": "Voltage",
+                                        "unit": "V",
+                                        "phase": "L1",
+                                    },
+                                    {
+                                        "value": "81.0",
+                                        "measurand": "SoC",
+                                        "unit": "Percent",
+                                    },
                                 ],
                             }
                         ],
@@ -242,6 +258,69 @@ async def test_full_charger_flow_against_running_container() -> None:
             assert stop.id_tag_info["status"] == "Accepted"
         finally:
             loop.cancel()
+
+
+def test_meter_value_enums_land_in_clickhouse_as_proto_enum_names() -> None:
+    """The Voltage+L1 and SoC samples published by the previous test
+    must reach ClickHouse with their enum dimensions intact — i.e.
+    `MEASURAND_VOLTAGE` / `PHASE_L1` / `MEASURAND_SOC`, not the
+    `*_UNSPECIFIED` strings the original handler bug stored (#135).
+
+    This is the assertion that would have caught the original bug. The
+    handler unit tests passed because they only checked `value`; only
+    a ClickHouse round-trip exposes the dropped enum fields.
+
+    Test ordering is implicit (pytest runs tests in file order) and
+    intentional: this test reads what the previous test wrote.
+    """
+    import time
+    import urllib.parse
+    import urllib.request
+
+    # Filter on `cp_id` only — `event_id` would force a Postgres lookup
+    # and isn't needed; the unique cp_id pins us to this test session
+    # because no other test in the file emits MeterValues.
+    sql = (
+        "SELECT sv.measurand AS m, sv.phase AS p "
+        "FROM eveys_ocpp.cp_meter ARRAY JOIN sampled_values AS sv "
+        "WHERE cp_id = 'COMPOSE_SMOKE_CP' "
+        "ORDER BY occurred_at, m"
+    )
+    qs = urllib.parse.urlencode({"query": sql + " FORMAT JSONCompact"})
+    url = f"http://{PUBLISHED_HOST}:{HOST_CH_HTTP_PORT}/?{qs}"
+
+    # Ingestor batch flush is sub-second in the compose stack but Kafka
+    # delivery + materialization isn't instant; poll briefly so a slow
+    # CI runner doesn't false-fail.
+    deadline = time.monotonic() + 15
+    rows: list[list[str]] = []
+    while time.monotonic() < deadline:
+        with urllib.request.urlopen(url, timeout=5) as resp:
+            body = json.loads(resp.read())
+        rows = body.get("data", [])
+        if rows:
+            break
+        time.sleep(1)
+
+    assert rows, (
+        "no cp_meter rows visible in ClickHouse after 15s — ingestor or "
+        "Kafka path is broken (separate from the enum bug under test)"
+    )
+    measurands = {r[0] for r in rows}
+    phases = {r[1] for r in rows}
+
+    # The original bug shipped these as `MEASURAND_UNSPECIFIED` /
+    # `PHASE_UNSPECIFIED` for *every* sample, regardless of input.
+    assert "MEASURAND_VOLTAGE" in measurands, (
+        f"Voltage sample lost its measurand enum on ingest. Stored: {measurands}"
+    )
+    assert "MEASURAND_SOC" in measurands, (
+        f"SoC sample lost its measurand enum on ingest. Stored: {measurands}"
+    )
+    assert "MEASURAND_ENERGY_ACTIVE_IMPORT_REGISTER" in measurands, (
+        f"Energy register sample lost its measurand enum on ingest. Stored: {measurands}"
+    )
+    assert "PHASE_L1" in phases, f"L1 sample lost its phase enum on ingest. Stored: {phases}"
 
 
 # ---- Envoy edge --------------------------------------------------------

--- a/tests/unit/handlers/v16/test_meter_values.py
+++ b/tests/unit/handlers/v16/test_meter_values.py
@@ -215,3 +215,105 @@ async def test_handler_survives_kafka_publish_exception(fake_cp: Any) -> None:
 
     assert isinstance(result, call_result.MeterValues)
     fake_producer.publish.assert_awaited_once()
+
+
+# ----- enum mapping (#135) --------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("ocpp_field", "wire_value", "proto_field", "expected_proto_value"),
+    [
+        # Measurand
+        ("measurand", "Voltage", "measurand", events_pb2.MEASURAND_VOLTAGE),
+        ("measurand", "SoC", "measurand", events_pb2.MEASURAND_SOC),
+        ("measurand", "Current.Import", "measurand", events_pb2.MEASURAND_CURRENT_IMPORT),
+        ("measurand", "Power.Active.Import", "measurand", events_pb2.MEASURAND_POWER_ACTIVE_IMPORT),
+        (
+            "measurand",
+            "Energy.Active.Import.Register",
+            "measurand",
+            events_pb2.MEASURAND_ENERGY_ACTIVE_IMPORT_REGISTER,
+        ),
+        # Phase — including the dashed variants that aren't a mechanical
+        # uppercase/replace transform of the proto enum name.
+        ("phase", "L1", "phase", events_pb2.PHASE_L1),
+        ("phase", "L2", "phase", events_pb2.PHASE_L2),
+        ("phase", "L3", "phase", events_pb2.PHASE_L3),
+        ("phase", "L1-N", "phase", events_pb2.PHASE_L1_N),
+        ("phase", "L2-L3", "phase", events_pb2.PHASE_L2_L3),
+        # Unit — case-sensitive distinction `kW` vs `W` matters.
+        ("unit", "V", "unit", events_pb2.UNIT_V),
+        ("unit", "W", "unit", events_pb2.UNIT_W),
+        ("unit", "kW", "unit", events_pb2.UNIT_KW),
+        ("unit", "Percent", "unit", events_pb2.UNIT_PERCENT),
+        # Context / Format / Location.
+        ("context", "Sample.Periodic", "context", events_pb2.CONTEXT_SAMPLE_PERIODIC),
+        ("context", "Transaction.End", "context", events_pb2.CONTEXT_TRANSACTION_END),
+        ("format", "SignedData", "format", events_pb2.FORMAT_SIGNED_DATA),
+        ("location", "Outlet", "location", events_pb2.LOCATION_OUTLET),
+    ],
+)
+def test_to_proto_maps_ocpp_wire_string_to_enum(
+    ocpp_field: str,
+    wire_value: str,
+    proto_field: str,
+    expected_proto_value: int,
+) -> None:
+    """OCPP 1.6 §6.21 wire strings must round-trip into proto enum values
+    (not the literal `*_UNSPECIFIED` they were stored as before #135)."""
+    raw: dict[str, Any] = {"value": "1.0", ocpp_field: wire_value}
+    sv = meter_values._to_proto_sampled_value(raw)
+    assert getattr(sv, proto_field) == expected_proto_value
+
+
+def test_to_proto_unknown_measurand_falls_back_to_unspecified() -> None:
+    """Vendor-extension measurand strings keep the value but land on
+    `MEASURAND_UNSPECIFIED` — no crash, no data loss."""
+    sv = meter_values._to_proto_sampled_value(
+        {"value": "42", "measurand": "Vendor.Custom.Reading", "unit": "V"}
+    )
+    assert sv.value == "42"
+    assert sv.measurand == events_pb2.MEASURAND_UNSPECIFIED
+    assert sv.unit == events_pb2.UNIT_V
+
+
+def test_to_proto_absent_measurand_defaults_to_energy_active_import_register() -> None:
+    """OCPP 1.6 §6.21.4: an absent measurand means
+    `Energy.Active.Import.Register`. Without this default, consumers
+    filtering by that measurand would silently miss bare-energy
+    samples (the most common shape chargers emit)."""
+    sv = meter_values._to_proto_sampled_value({"value": "1234", "unit": "Wh"})
+    assert sv.measurand == events_pb2.MEASURAND_ENERGY_ACTIVE_IMPORT_REGISTER
+
+
+@pytest.mark.asyncio
+async def test_published_envelope_carries_proto_enum_values(fake_cp: Any) -> None:
+    """End-to-end inside the handler: a charger sample with measurand /
+    phase / unit lands on Kafka with the proto enum *values* set, not
+    `_UNSPECIFIED`. This is the assertion that would have caught #135
+    on the unit tier — the originally-shipped handler passed every
+    other test in this file because none of them looked at enum fields."""
+    fake_producer = AsyncMock()
+    fake_cp.event_producer = fake_producer
+
+    await meter_values.handle(
+        fake_cp,
+        connector_id=1,
+        transaction_id=99,
+        meter_value=[
+            {
+                "timestamp": "2026-04-30T00:00:00+00:00",
+                "sampled_value": [
+                    {"value": "230.4", "measurand": "Voltage", "unit": "V", "phase": "L1"},
+                ],
+            }
+        ],
+    )
+
+    envelope = events_pb2.EventEnvelope()
+    envelope.ParseFromString(fake_producer.publish.await_args.kwargs["value"])
+    [sv] = envelope.cp_meter.sampled_values
+    assert sv.value == "230.4"
+    assert sv.measurand == events_pb2.MEASURAND_VOLTAGE
+    assert sv.phase == events_pb2.PHASE_L1
+    assert sv.unit == events_pb2.UNIT_V


### PR DESCRIPTION
## What's wrong

\`src/eveys_ocpp/handlers/v16/meter_values.py:_to_proto_sampled_value\` built \`SampledValue\` with only the \`value\` field set. All six OCPP enum dimensions (\`measurand\`, \`phase\`, \`unit\`, \`context\`, \`format\`, \`location\`) defaulted to 0 → \`*_UNSPECIFIED\`. The ingestor's \`Measurand.Name(0)\` then stored the literal \`\"MEASURAND_UNSPECIFIED\"\` on every row in \`cp_meter\`.

Net effect: no consumer could distinguish voltage from current, or L1 from L3, regardless of what the charger sent. Broke the \`/meter-values\` measurand filter, the new transaction telemetry block (#133), and any downstream analytics grouping by measurand or phase.

Confirmed live during compose-smoke verification of #134 — see [my notes on #135](https://github.com/eveys-mobility/OCPP/issues/135).

## What changed

- Six static \`_*_BY_OCPP\` dicts at module top, mapping each OCPP 1.6 §6.21 wire string to its proto enum value. Built once at import.
- \`_to_proto_sampled_value\` populates all six enum fields. Unknown vendor strings still fall through to \`*_UNSPECIFIED\` — \`value\` is preserved.
- OCPP 1.6 §6.21.4 default applied: absent \`measurand\` → \`Energy.Active.Import.Register\`. Without it, consumers filtering by that measurand would silently miss the bare-energy samples chargers most commonly emit.
- \`_meter_sanity\` unchanged (it already worked with OCPP wire strings).

## How this would have been caught earlier

The original unit suite passed because no test inspected the enum fields on the published proto. Two new layers prevent regression:

1. **Unit** — parametrized \`test_to_proto_maps_ocpp_wire_string_to_enum\` over 18 cases (each enum dimension), plus an \`assert sv.measurand == events_pb2.MEASURAND_VOLTAGE\` on the actual Kafka-bound envelope.
2. **Compose-smoke** — extended the existing transaction flow with a multi-measurand sample (Voltage+L1, SoC, Energy register), and added \`test_meter_value_enums_land_in_clickhouse_as_proto_enum_names\` that queries ClickHouse via the published \`:8124\` HTTP port and asserts the round-tripped enum strings. This is the assertion that would have caught the original bug.

## Test plan

- [x] \`pytest tests/unit\` — 765 passed, 82.95% coverage. (One pre-existing flake on \`test_authorize.py::test_unavailable_fallback_is_not_cached\` deselected — unrelated.)
- [x] \`pytest tests/compose_smoke\` — both the existing flow test and the new ClickHouse assertion pass against a freshly rebuilt image.
- [x] \`make openapi-export-check\` — no schema drift.
- [x] ruff + mypy clean.
- [ ] CI: lint, types, unit, e2e, compose-smoke (will run on push).

## Follow-up

#136 is now unblocked. Storage carries proto enum *names* (\`MEASURAND_VOLTAGE\`, \`PHASE_L1\`, …), so \`fetch_transaction_telemetry\`'s SQL — which currently filters on the OCPP wire form (\`'Voltage'\`, \`'L1'\`) — needs to be aligned to whichever form #136 picks (proto names recommended, since that's what the schema canonically stores).

Closes #135