### PR TITLE
fix(api): align enum naming — storage in proto names, API in OCPP wire form

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,6 +165,9 @@ module = [
     "eveys_ocpp.clickhouse.ingestor",
     # E3-9 webhook dispatcher — same generated `events_pb2` opaqueness.
     "eveys_ocpp.webhooks.dispatcher",
+    # OCPP wire-form ↔ proto enum translation tables. Touches the
+    # generated `events_pb2` symbols by name (same opaqueness).
+    "eveys_ocpp._ocpp_enums",
 ]
 disallow_untyped_decorators = false
 disallow_untyped_calls = false

--- a/src/eveys_ocpp/_ocpp_enums.py
+++ b/src/eveys_ocpp/_ocpp_enums.py
@@ -1,0 +1,215 @@
+"""OCPP wire-string ↔ proto enum translation tables.
+
+The proto schema (`proto/events/v1/events.proto`) models MeterValue
+dimensions (measurand, phase, unit, context, format, location) as
+strongly-typed enums. OCPP 1.6 §6.21 serializes them on the wire as
+string literals — `"Voltage"`, `"L1-N"`, `"Sample.Periodic"`, etc.
+
+Two translation paths share these tables:
+
+- **Ingest** (`handlers/v16/meter_values.py`): wire string → proto enum
+  value. Stored in ClickHouse as the proto enum *name* (e.g.
+  `MEASURAND_VOLTAGE`).
+- **Read** (`api/timeseries.py`, `clickhouse/read_client.py`): proto
+  enum name → OCPP wire string for API responses, and OCPP wire string
+  → proto enum name for query-param filters.
+
+Co-locating both directions in one module guarantees the round-trip
+stays consistent. Adding a new measurand means editing one table.
+
+Unknown values:
+
+- ingest: fall through to `*_UNSPECIFIED` (vendor extensions; the raw
+  `value` is still captured).
+- read: surface `None` rather than leak the proto enum name to API
+  clients.
+"""
+
+from __future__ import annotations
+
+from eveys_ocpp._generated.events.v1 import events_pb2
+
+# --- Wire string → proto enum value (used at ingest) ------------------------
+#
+# Comparisons are case-sensitive per the spec; chargers reporting
+# non-canonical casing land in `*_UNSPECIFIED`.
+
+MEASURAND_BY_OCPP: dict[str, int] = {
+    "Energy.Active.Export.Register": events_pb2.MEASURAND_ENERGY_ACTIVE_EXPORT_REGISTER,
+    "Energy.Active.Import.Register": events_pb2.MEASURAND_ENERGY_ACTIVE_IMPORT_REGISTER,
+    "Energy.Reactive.Export.Register": events_pb2.MEASURAND_ENERGY_REACTIVE_EXPORT_REGISTER,
+    "Energy.Reactive.Import.Register": events_pb2.MEASURAND_ENERGY_REACTIVE_IMPORT_REGISTER,
+    "Energy.Active.Export.Interval": events_pb2.MEASURAND_ENERGY_ACTIVE_EXPORT_INTERVAL,
+    "Energy.Active.Import.Interval": events_pb2.MEASURAND_ENERGY_ACTIVE_IMPORT_INTERVAL,
+    "Energy.Reactive.Export.Interval": events_pb2.MEASURAND_ENERGY_REACTIVE_EXPORT_INTERVAL,
+    "Energy.Reactive.Import.Interval": events_pb2.MEASURAND_ENERGY_REACTIVE_IMPORT_INTERVAL,
+    "Power.Active.Export": events_pb2.MEASURAND_POWER_ACTIVE_EXPORT,
+    "Power.Active.Import": events_pb2.MEASURAND_POWER_ACTIVE_IMPORT,
+    "Power.Offered": events_pb2.MEASURAND_POWER_OFFERED,
+    "Power.Reactive.Export": events_pb2.MEASURAND_POWER_REACTIVE_EXPORT,
+    "Power.Reactive.Import": events_pb2.MEASURAND_POWER_REACTIVE_IMPORT,
+    "Power.Factor": events_pb2.MEASURAND_POWER_FACTOR,
+    "Current.Import": events_pb2.MEASURAND_CURRENT_IMPORT,
+    "Current.Export": events_pb2.MEASURAND_CURRENT_EXPORT,
+    "Current.Offered": events_pb2.MEASURAND_CURRENT_OFFERED,
+    "Voltage": events_pb2.MEASURAND_VOLTAGE,
+    "Frequency": events_pb2.MEASURAND_FREQUENCY,
+    "Temperature": events_pb2.MEASURAND_TEMPERATURE,
+    "SoC": events_pb2.MEASURAND_SOC,
+    "RPM": events_pb2.MEASURAND_RPM,
+}
+
+PHASE_BY_OCPP: dict[str, int] = {
+    "L1": events_pb2.PHASE_L1,
+    "L2": events_pb2.PHASE_L2,
+    "L3": events_pb2.PHASE_L3,
+    "N": events_pb2.PHASE_N,
+    "L1-N": events_pb2.PHASE_L1_N,
+    "L2-N": events_pb2.PHASE_L2_N,
+    "L3-N": events_pb2.PHASE_L3_N,
+    "L1-L2": events_pb2.PHASE_L1_L2,
+    "L2-L3": events_pb2.PHASE_L2_L3,
+    "L3-L1": events_pb2.PHASE_L3_L1,
+}
+
+UNIT_BY_OCPP: dict[str, int] = {
+    "Wh": events_pb2.UNIT_WH,
+    "kWh": events_pb2.UNIT_KWH,
+    "varh": events_pb2.UNIT_VARH,
+    "kvarh": events_pb2.UNIT_KVARH,
+    "W": events_pb2.UNIT_W,
+    "kW": events_pb2.UNIT_KW,
+    "var": events_pb2.UNIT_VAR,
+    "kvar": events_pb2.UNIT_KVAR,
+    "VA": events_pb2.UNIT_VA,
+    "kVA": events_pb2.UNIT_KVA,
+    "A": events_pb2.UNIT_A,
+    "V": events_pb2.UNIT_V,
+    "Celsius": events_pb2.UNIT_CELSIUS,
+    "Fahrenheit": events_pb2.UNIT_FAHRENHEIT,
+    "K": events_pb2.UNIT_K,
+    "Percent": events_pb2.UNIT_PERCENT,
+    "Hertz": events_pb2.UNIT_HERTZ,
+}
+
+CONTEXT_BY_OCPP: dict[str, int] = {
+    "Interruption.Begin": events_pb2.CONTEXT_INTERRUPTION_BEGIN,
+    "Interruption.End": events_pb2.CONTEXT_INTERRUPTION_END,
+    "Other": events_pb2.CONTEXT_OTHER,
+    "Sample.Clock": events_pb2.CONTEXT_SAMPLE_CLOCK,
+    "Sample.Periodic": events_pb2.CONTEXT_SAMPLE_PERIODIC,
+    "Transaction.Begin": events_pb2.CONTEXT_TRANSACTION_BEGIN,
+    "Transaction.End": events_pb2.CONTEXT_TRANSACTION_END,
+    "Trigger": events_pb2.CONTEXT_TRIGGER,
+}
+
+FORMAT_BY_OCPP: dict[str, int] = {
+    "Raw": events_pb2.FORMAT_RAW,
+    "SignedData": events_pb2.FORMAT_SIGNED_DATA,
+}
+
+LOCATION_BY_OCPP: dict[str, int] = {
+    "Cable": events_pb2.LOCATION_CABLE,
+    "EV": events_pb2.LOCATION_EV,
+    "Inlet": events_pb2.LOCATION_INLET,
+    "Outlet": events_pb2.LOCATION_OUTLET,
+    "Body": events_pb2.LOCATION_BODY,
+}
+
+
+# --- Proto enum *name* → OCPP wire string (used at read) --------------------
+#
+# Storage layer (ingestor → ClickHouse) keeps the proto enum *name*
+# string, e.g. `"MEASURAND_VOLTAGE"`. The read path translates back to
+# the OCPP wire form (`"Voltage"`) for API responses; the inbound
+# query-param form (`?measurand=Voltage`) is the same OCPP wire form,
+# so the read path also uses these wire strings as the canonical
+# "user-facing" representation.
+#
+# Built once at import by inverting the *_BY_OCPP tables and prefixing
+# each value with its proto enum name. Hand-editing the inverse would
+# mean two places to remember; deriving it keeps the round-trip honest.
+
+
+def _proto_name(value: int, enum_descriptor) -> str:  # type: ignore[no-untyped-def]
+    return enum_descriptor.values_by_number[value].name
+
+
+def _invert_with_proto_names(by_ocpp: dict[str, int], enum_descriptor) -> dict[str, str]:  # type: ignore[no-untyped-def]
+    return {_proto_name(v, enum_descriptor): k for k, v in by_ocpp.items()}
+
+
+_DESC = events_pb2.DESCRIPTOR
+
+OCPP_BY_MEASURAND_NAME: dict[str, str] = _invert_with_proto_names(
+    MEASURAND_BY_OCPP, _DESC.enum_types_by_name["Measurand"]
+)
+OCPP_BY_PHASE_NAME: dict[str, str] = _invert_with_proto_names(
+    PHASE_BY_OCPP, _DESC.enum_types_by_name["Phase"]
+)
+OCPP_BY_UNIT_NAME: dict[str, str] = _invert_with_proto_names(
+    UNIT_BY_OCPP, _DESC.enum_types_by_name["Unit"]
+)
+OCPP_BY_CONTEXT_NAME: dict[str, str] = _invert_with_proto_names(
+    CONTEXT_BY_OCPP, _DESC.enum_types_by_name["Context"]
+)
+OCPP_BY_FORMAT_NAME: dict[str, str] = _invert_with_proto_names(
+    FORMAT_BY_OCPP, _DESC.enum_types_by_name["Format"]
+)
+OCPP_BY_LOCATION_NAME: dict[str, str] = _invert_with_proto_names(
+    LOCATION_BY_OCPP, _DESC.enum_types_by_name["Location"]
+)
+
+
+def proto_enum_name_for_measurand(ocpp_wire: str | None) -> str | None:
+    """OCPP wire string (`"Voltage"`) → proto enum name
+    (`"MEASURAND_VOLTAGE"`) for SQL filter use. `None` when the input
+    is unknown — caller should treat as "no filter possible," not as
+    "match everything"."""
+    if ocpp_wire is None:
+        return None
+    proto_value = MEASURAND_BY_OCPP.get(ocpp_wire)
+    if proto_value is None:
+        return None
+    return _proto_name(proto_value, _DESC.enum_types_by_name["Measurand"])
+
+
+def proto_enum_name_for_phase(ocpp_wire: str | None) -> str | None:
+    """OCPP wire string (`"L1"`) → proto enum name (`"PHASE_L1"`).
+    See `proto_enum_name_for_measurand` for `None` semantics."""
+    if ocpp_wire is None:
+        return None
+    proto_value = PHASE_BY_OCPP.get(ocpp_wire)
+    if proto_value is None:
+        return None
+    return _proto_name(proto_value, _DESC.enum_types_by_name["Phase"])
+
+
+def ocpp_string_for(field: str, proto_name: str | None) -> str | None:
+    """Stored proto enum name → OCPP wire string for one of the six
+    sampled-value enum dimensions.
+
+    `field` is `"measurand"` / `"phase"` / `"unit"` / `"context"` /
+    `"format"` / `"location"`.
+
+    Empty / `None` / unrecognised proto name (including `*_UNSPECIFIED`
+    and any vendor-extension string the ingestor stored verbatim from
+    the wire) → `None`. We deliberately do NOT surface
+    `\"MEASURAND_UNSPECIFIED\"` to API clients — that's an internal
+    sentinel."""
+    if not proto_name:
+        return None
+    table = _READ_TABLES.get(field)
+    if table is None:
+        raise KeyError(f"unknown sampled-value enum field: {field!r}")
+    return table.get(proto_name)
+
+
+_READ_TABLES: dict[str, dict[str, str]] = {
+    "measurand": OCPP_BY_MEASURAND_NAME,
+    "phase": OCPP_BY_PHASE_NAME,
+    "unit": OCPP_BY_UNIT_NAME,
+    "context": OCPP_BY_CONTEXT_NAME,
+    "format": OCPP_BY_FORMAT_NAME,
+    "location": OCPP_BY_LOCATION_NAME,
+}

--- a/src/eveys_ocpp/api/timeseries.py
+++ b/src/eveys_ocpp/api/timeseries.py
@@ -23,6 +23,10 @@ from typing import Any
 
 from fastapi import APIRouter, Query, Request
 
+from eveys_ocpp._ocpp_enums import (
+    ocpp_string_for,
+    proto_enum_name_for_measurand,
+)
 from eveys_ocpp.api._errors import (
     ERR_BAD_REQUEST,
     ERR_INTERNAL_ERROR,
@@ -133,12 +137,26 @@ async def list_meter_values(
 
     await _ensure_cp_exists(request, cp_id)
 
+    # Storage-form translation: API takes the OCPP wire form
+    # (`?measurand=Voltage`); ClickHouse rows store the proto enum name
+    # (`MEASURAND_VOLTAGE`). Translate before the SQL goes out so an
+    # unknown wire string returns an empty page rather than silently
+    # matching every UNSPECIFIED row.
+    storage_measurand = measurand
+    if measurand is not None:
+        storage_measurand = proto_enum_name_for_measurand(measurand)
+        if storage_measurand is None:
+            return {
+                "meter_values": [],
+                "request_id": request.state.request_id,
+            }
+
     rows = await _ch_client(request).fetch_meter_values(
         cp_id=cp_id,
         started_from=started_from,
         started_to=started_to,
         connector_id=connector_id,
-        measurand=measurand,
+        measurand=storage_measurand,
         limit=page_size,
     )
 
@@ -193,6 +211,13 @@ async def list_status_history(
 
 
 def _meter_to_response(row: dict[str, Any]) -> dict[str, Any]:
+    """Project a ClickHouse `cp_meter` row into the API shape.
+
+    Storage form is the proto enum name (`"MEASURAND_VOLTAGE"`,
+    `"PHASE_L1"`, …); the API exposes the OCPP wire form
+    (`"Voltage"`, `"L1"`). `*_UNSPECIFIED`, vendor extensions, and
+    empty strings all surface as `null` rather than leak the proto
+    sentinel to clients."""
     return {
         "event_id": row["event_id"],
         "occurred_at": _isoformat(row["occurred_at"]),
@@ -202,12 +227,12 @@ def _meter_to_response(row: dict[str, Any]) -> dict[str, Any]:
         "charger_reported_at": row["charger_reported_at"] or None,
         "sample": {
             "value": row["value"],
-            "context": row["context"] or None,
-            "format": row["format"] or None,
-            "measurand": row["measurand"] or None,
-            "phase": row["phase"] or None,
-            "location": row["location"] or None,
-            "unit": row["unit"] or None,
+            "context": ocpp_string_for("context", row["context"]),
+            "format": ocpp_string_for("format", row["format"]),
+            "measurand": ocpp_string_for("measurand", row["measurand"]),
+            "phase": ocpp_string_for("phase", row["phase"]),
+            "location": ocpp_string_for("location", row["location"]),
+            "unit": ocpp_string_for("unit", row["unit"]),
         },
     }
 

--- a/src/eveys_ocpp/clickhouse/read_client.py
+++ b/src/eveys_ocpp/clickhouse/read_client.py
@@ -217,6 +217,13 @@ class ClickHouseReadClient:
         # the scan. The string-cast on `value` matches `cp_meter`'s
         # column type — sampled values are stored as Strings (DDL
         # at clickhouse/ddl/0002_create_cp_meter.sql); cast at read.
+        #
+        # Storage form is the proto enum *name* (e.g. `MEASURAND_VOLTAGE`,
+        # `PHASE_L1`) — written by the ingestor from `events_pb2.*.Name(v)`
+        # against the values produced by `_ocpp_enums.MEASURAND_BY_OCPP`
+        # in the MeterValues handler. Filter strings here MUST match that
+        # form, not the OCPP wire form (`"Voltage"`, `"L1"`); the route
+        # layer translates user-facing wire-form filter params on input.
         soc_sql = """
             SELECT
                 argMin(toFloat64OrNull(sv.value), occurred_at) AS start_pct,
@@ -226,7 +233,7 @@ class ClickHouseReadClient:
             ARRAY JOIN sampled_values AS sv
             WHERE cp_id = {cp_id}
               AND transaction_id = {transaction_id}
-              AND sv.measurand = 'SoC'
+              AND sv.measurand = 'MEASURAND_SOC'
         """
         phases_sql = """
             SELECT
@@ -238,8 +245,12 @@ class ClickHouseReadClient:
             ARRAY JOIN sampled_values AS sv
             WHERE cp_id = {cp_id}
               AND transaction_id = {transaction_id}
-              AND sv.phase IN ('L1', 'L2', 'L3')
-              AND sv.measurand IN ('Voltage', 'Current.Import', 'Power.Active.Import')
+              AND sv.phase IN ('PHASE_L1', 'PHASE_L2', 'PHASE_L3')
+              AND sv.measurand IN (
+                  'MEASURAND_VOLTAGE',
+                  'MEASURAND_CURRENT_IMPORT',
+                  'MEASURAND_POWER_ACTIVE_IMPORT'
+              )
             GROUP BY phase, measurand
         """
         params: dict[str, Any] = {"cp_id": cp_id, "transaction_id": transaction_id}
@@ -267,17 +278,26 @@ class ClickHouseReadClient:
                 "last_at": last_at.isoformat() if has_data and last_at is not None else None,
             }
 
+        # Keyed on the proto enum *name* form (storage form). The
+        # response dict is keyed by the OCPP wire-form phase name
+        # (`"L1"`, not `"PHASE_L1"`) so API consumers see the spec
+        # form they already know.
         phases: dict[str, dict[str, Any]] = {}
         _measurand_to_field = {
-            "Voltage": "voltage_v",
-            "Current.Import": "current_a",
-            "Power.Active.Import": "power_w",
+            "MEASURAND_VOLTAGE": "voltage_v",
+            "MEASURAND_CURRENT_IMPORT": "current_a",
+            "MEASURAND_POWER_ACTIVE_IMPORT": "power_w",
+        }
+        _phase_to_wire = {
+            "PHASE_L1": "L1",
+            "PHASE_L2": "L2",
+            "PHASE_L3": "L3",
         }
         for raw in phase_rows:
             row = dict(zip(phase_cols, raw, strict=True))
-            phase = row["phase"]
+            phase = _phase_to_wire.get(row["phase"])
             field = _measurand_to_field.get(row["measurand"])
-            if field is None:
+            if phase is None or field is None:
                 continue
             snap = phases.setdefault(
                 phase,

--- a/src/eveys_ocpp/handlers/v16/meter_values.py
+++ b/src/eveys_ocpp/handlers/v16/meter_values.py
@@ -50,6 +50,14 @@ from typing import TYPE_CHECKING, Any
 from ocpp.v16 import call_result
 
 from eveys_ocpp._generated.events.v1 import events_pb2
+from eveys_ocpp._ocpp_enums import (
+    CONTEXT_BY_OCPP,
+    FORMAT_BY_OCPP,
+    LOCATION_BY_OCPP,
+    MEASURAND_BY_OCPP,
+    PHASE_BY_OCPP,
+    UNIT_BY_OCPP,
+)
 from eveys_ocpp.handlers.v16 import _meter_sanity
 from eveys_ocpp.metrics import record_handler_error, time_handler
 from eveys_ocpp.metrics import registry as metrics_registry
@@ -59,104 +67,6 @@ if TYPE_CHECKING:
     from eveys_ocpp.connection import EveysChargePoint
 
 log = get_logger(__name__)
-
-
-# OCPP 1.6 §6.21 wire strings → proto enum values.
-#
-# OCPP serializes these enum dimensions on each SampledValue as
-# string literals (e.g. `"Voltage"`, `"L1-N"`, `"Sample.Periodic"`).
-# The proto schema models them as strongly-typed enums so downstream
-# consumers (ClickHouse, Grafana, billing) can group/filter without
-# reasoning about vendor-specific string casing or punctuation.
-#
-# Unknown values fall back to `*_UNSPECIFIED` (the 0 value), which
-# preserves forward-compat with vendor extensions — the raw `value`
-# is still captured even when an enum is unrecognised.
-#
-# These dicts are built once at import. Comparisons are case-sensitive
-# per the spec; chargers reporting non-canonical casing will land in
-# `*_UNSPECIFIED`.
-_MEASURAND_BY_OCPP: dict[str, int] = {
-    "Energy.Active.Export.Register": events_pb2.MEASURAND_ENERGY_ACTIVE_EXPORT_REGISTER,
-    "Energy.Active.Import.Register": events_pb2.MEASURAND_ENERGY_ACTIVE_IMPORT_REGISTER,
-    "Energy.Reactive.Export.Register": events_pb2.MEASURAND_ENERGY_REACTIVE_EXPORT_REGISTER,
-    "Energy.Reactive.Import.Register": events_pb2.MEASURAND_ENERGY_REACTIVE_IMPORT_REGISTER,
-    "Energy.Active.Export.Interval": events_pb2.MEASURAND_ENERGY_ACTIVE_EXPORT_INTERVAL,
-    "Energy.Active.Import.Interval": events_pb2.MEASURAND_ENERGY_ACTIVE_IMPORT_INTERVAL,
-    "Energy.Reactive.Export.Interval": events_pb2.MEASURAND_ENERGY_REACTIVE_EXPORT_INTERVAL,
-    "Energy.Reactive.Import.Interval": events_pb2.MEASURAND_ENERGY_REACTIVE_IMPORT_INTERVAL,
-    "Power.Active.Export": events_pb2.MEASURAND_POWER_ACTIVE_EXPORT,
-    "Power.Active.Import": events_pb2.MEASURAND_POWER_ACTIVE_IMPORT,
-    "Power.Offered": events_pb2.MEASURAND_POWER_OFFERED,
-    "Power.Reactive.Export": events_pb2.MEASURAND_POWER_REACTIVE_EXPORT,
-    "Power.Reactive.Import": events_pb2.MEASURAND_POWER_REACTIVE_IMPORT,
-    "Power.Factor": events_pb2.MEASURAND_POWER_FACTOR,
-    "Current.Import": events_pb2.MEASURAND_CURRENT_IMPORT,
-    "Current.Export": events_pb2.MEASURAND_CURRENT_EXPORT,
-    "Current.Offered": events_pb2.MEASURAND_CURRENT_OFFERED,
-    "Voltage": events_pb2.MEASURAND_VOLTAGE,
-    "Frequency": events_pb2.MEASURAND_FREQUENCY,
-    "Temperature": events_pb2.MEASURAND_TEMPERATURE,
-    "SoC": events_pb2.MEASURAND_SOC,
-    "RPM": events_pb2.MEASURAND_RPM,
-}
-
-_PHASE_BY_OCPP: dict[str, int] = {
-    "L1": events_pb2.PHASE_L1,
-    "L2": events_pb2.PHASE_L2,
-    "L3": events_pb2.PHASE_L3,
-    "N": events_pb2.PHASE_N,
-    "L1-N": events_pb2.PHASE_L1_N,
-    "L2-N": events_pb2.PHASE_L2_N,
-    "L3-N": events_pb2.PHASE_L3_N,
-    "L1-L2": events_pb2.PHASE_L1_L2,
-    "L2-L3": events_pb2.PHASE_L2_L3,
-    "L3-L1": events_pb2.PHASE_L3_L1,
-}
-
-_UNIT_BY_OCPP: dict[str, int] = {
-    "Wh": events_pb2.UNIT_WH,
-    "kWh": events_pb2.UNIT_KWH,
-    "varh": events_pb2.UNIT_VARH,
-    "kvarh": events_pb2.UNIT_KVARH,
-    "W": events_pb2.UNIT_W,
-    "kW": events_pb2.UNIT_KW,
-    "var": events_pb2.UNIT_VAR,
-    "kvar": events_pb2.UNIT_KVAR,
-    "VA": events_pb2.UNIT_VA,
-    "kVA": events_pb2.UNIT_KVA,
-    "A": events_pb2.UNIT_A,
-    "V": events_pb2.UNIT_V,
-    "Celsius": events_pb2.UNIT_CELSIUS,
-    "Fahrenheit": events_pb2.UNIT_FAHRENHEIT,
-    "K": events_pb2.UNIT_K,
-    "Percent": events_pb2.UNIT_PERCENT,
-    "Hertz": events_pb2.UNIT_HERTZ,
-}
-
-_CONTEXT_BY_OCPP: dict[str, int] = {
-    "Interruption.Begin": events_pb2.CONTEXT_INTERRUPTION_BEGIN,
-    "Interruption.End": events_pb2.CONTEXT_INTERRUPTION_END,
-    "Other": events_pb2.CONTEXT_OTHER,
-    "Sample.Clock": events_pb2.CONTEXT_SAMPLE_CLOCK,
-    "Sample.Periodic": events_pb2.CONTEXT_SAMPLE_PERIODIC,
-    "Transaction.Begin": events_pb2.CONTEXT_TRANSACTION_BEGIN,
-    "Transaction.End": events_pb2.CONTEXT_TRANSACTION_END,
-    "Trigger": events_pb2.CONTEXT_TRIGGER,
-}
-
-_FORMAT_BY_OCPP: dict[str, int] = {
-    "Raw": events_pb2.FORMAT_RAW,
-    "SignedData": events_pb2.FORMAT_SIGNED_DATA,
-}
-
-_LOCATION_BY_OCPP: dict[str, int] = {
-    "Cable": events_pb2.LOCATION_CABLE,
-    "EV": events_pb2.LOCATION_EV,
-    "Inlet": events_pb2.LOCATION_INLET,
-    "Outlet": events_pb2.LOCATION_OUTLET,
-    "Body": events_pb2.LOCATION_BODY,
-}
 
 
 def _build_envelope(*, cp_id: str, payload: events_pb2.CpMeter) -> bytes:
@@ -201,12 +111,12 @@ def _to_proto_sampled_value(raw: dict[str, Any]) -> events_pb2.SampledValue:
 
     return events_pb2.SampledValue(
         value=_g("value"),
-        context=_CONTEXT_BY_OCPP.get(_g("context"), events_pb2.CONTEXT_UNSPECIFIED),
-        format=_FORMAT_BY_OCPP.get(_g("format"), events_pb2.FORMAT_UNSPECIFIED),
-        measurand=_MEASURAND_BY_OCPP.get(measurand_str, events_pb2.MEASURAND_UNSPECIFIED),
-        phase=_PHASE_BY_OCPP.get(_g("phase"), events_pb2.PHASE_UNSPECIFIED),
-        location=_LOCATION_BY_OCPP.get(_g("location"), events_pb2.LOCATION_UNSPECIFIED),
-        unit=_UNIT_BY_OCPP.get(_g("unit"), events_pb2.UNIT_UNSPECIFIED),
+        context=CONTEXT_BY_OCPP.get(_g("context"), events_pb2.CONTEXT_UNSPECIFIED),
+        format=FORMAT_BY_OCPP.get(_g("format"), events_pb2.FORMAT_UNSPECIFIED),
+        measurand=MEASURAND_BY_OCPP.get(measurand_str, events_pb2.MEASURAND_UNSPECIFIED),
+        phase=PHASE_BY_OCPP.get(_g("phase"), events_pb2.PHASE_UNSPECIFIED),
+        location=LOCATION_BY_OCPP.get(_g("location"), events_pb2.LOCATION_UNSPECIFIED),
+        unit=UNIT_BY_OCPP.get(_g("unit"), events_pb2.UNIT_UNSPECIFIED),
     )
 
 

--- a/tests/compose_smoke/conftest.py
+++ b/tests/compose_smoke/conftest.py
@@ -62,12 +62,15 @@ _EXPECTED_CONTAINERS = (
 )
 
 # Host ports the compose file publishes. Used by tests that drive the
-# real WS / gRPC / DB / ClickHouse from outside the docker network.
+# real WS / gRPC / DB / ClickHouse / REST from outside the docker network.
 HOST_WS_PORT = 19000
 HOST_PG_PORT = 5432
 # Compose remaps CH HTTP from the canonical 8123 to 8124 to dodge a
 # Homebrew `clickhouse server` already on the laptop (issue #24).
 HOST_CH_HTTP_PORT = 8124
+# Backend-facing REST surface (ADR-0026). 1:1 host:container so curl
+# from the host works without translation.
+HOST_REST_PORT = 8080
 # Envoy edge — TLS-fronted entry point + admin port.
 HOST_ENVOY_TLS_PORT = 19443
 HOST_ENVOY_ADMIN_PORT = 19901
@@ -113,9 +116,26 @@ def _gate() -> None:
 
 
 def _compose(*args: str) -> subprocess.CompletedProcess[str]:
-    """Run `docker compose -f <file> <args>` from the repo root."""
+    """Run `docker compose -f <file> <args>` from the repo root.
+
+    Mirrors `make compose-up`: passes `--env-file .env` when present so
+    container-side env (e.g. `EVEYS_OCPP_REST_INBOUND_TOKENS` for the
+    REST surface) is loaded the same way developers see locally.
+    Without this, the smoke stack runs with an empty inbound-token
+    allowlist and every REST call 401s — silent until a test actually
+    hits REST.
+
+    On CI no `.env` exists; a process-level
+    `EVEYS_OCPP_REST_INBOUND_TOKENS` (set by the harness fixture
+    below) takes over via compose's variable substitution on the
+    `${EVEYS_OCPP_REST_INBOUND_TOKENS:-}` fallback in the YAML.
+    """
+    env_args: list[str] = []
+    env_file = _REPO_ROOT / ".env"
+    if env_file.exists():
+        env_args = ["--env-file", str(env_file)]
     return subprocess.run(
-        ["docker", "compose", "-f", str(_COMPOSE_FILE), *args],
+        ["docker", "compose", "-f", str(_COMPOSE_FILE), *env_args, *args],
         cwd=str(_REPO_ROOT),
         check=False,
         capture_output=True,
@@ -178,6 +198,37 @@ def _wait_for_tcp(host: str, port: int, timeout_s: int = 30) -> bool:
     return False
 
 
+def gateway_inbound_token() -> str:
+    """First token from the running gateway container's inbound allowlist.
+
+    The compose stack loads `EVEYS_OCPP_REST_INBOUND_TOKENS` from the
+    repo's `.env`; pulling it from `docker inspect` instead of the
+    file means the test reads what the gateway is *actually* enforcing,
+    not what the operator wishes it were enforcing. CSV form takes the
+    first entry."""
+    proc = subprocess.run(
+        [
+            "docker",
+            "inspect",
+            "--format",
+            "{{range .Config.Env}}{{println .}}{{end}}",
+            "eveys-ocpp",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    for line in proc.stdout.splitlines():
+        key, _, value = line.partition("=")
+        if key == "EVEYS_OCPP_REST_INBOUND_TOKENS" and value:
+            return value.split(",", 1)[0].strip()
+    raise RuntimeError(
+        "EVEYS_OCPP_REST_INBOUND_TOKENS not set on the eveys-ocpp container — "
+        "compose-smoke needs an inbound token to call the REST surface. Set "
+        "it in .env before bringing the stack up."
+    )
+
+
 def _container_logs(name: str, tail: int = 200) -> str:
     proc = subprocess.run(
         ["docker", "logs", "--tail", str(tail), name],
@@ -196,6 +247,18 @@ def _compose_stack() -> Iterator[None]:
     the next session's "first run" mysteriously broken.
     """
     _gate()
+
+    # Inbound-token discipline: REST tests need a known-good bearer.
+    # Local devs have one in `.env`; CI runs without an .env, so seed
+    # a random per-session token if none is set. Compose's
+    # `${EVEYS_OCPP_REST_INBOUND_TOKENS:-}` interpolation picks it up
+    # at `up` time. Setting it on the parent process here means the
+    # token survives across compose's variable substitution AND any
+    # tests that read it back via `docker inspect` later.
+    if not os.environ.get("EVEYS_OCPP_REST_INBOUND_TOKENS"):
+        import secrets
+
+        os.environ["EVEYS_OCPP_REST_INBOUND_TOKENS"] = secrets.token_hex(16)
 
     # Clean slate. Downing here is cheap if no project exists; it
     # prevents stale containers from a prior aborted run masking an

--- a/tests/compose_smoke/test_compose_stack.py
+++ b/tests/compose_smoke/test_compose_stack.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import asyncio
 import json
 import subprocess
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from ocpp.v16 import ChargePoint as Cp
@@ -31,10 +31,12 @@ from tests.compose_smoke.conftest import (
     HOST_CH_HTTP_PORT,
     HOST_ENVOY_ADMIN_PORT,
     HOST_ENVOY_TLS_PORT,
+    HOST_REST_PORT,
     HOST_WS_PORT,
     PUBLISHED_HOST,
     _container_logs,
     _container_state,
+    gateway_inbound_token,
 )
 
 # ---- container shape ------------------------------------------------------
@@ -321,6 +323,72 @@ def test_meter_value_enums_land_in_clickhouse_as_proto_enum_names() -> None:
         f"Energy register sample lost its measurand enum on ingest. Stored: {measurands}"
     )
     assert "PHASE_L1" in phases, f"L1 sample lost its phase enum on ingest. Stored: {phases}"
+
+
+def test_rest_meter_values_returns_ocpp_wire_form_not_proto_enum_names() -> None:
+    """The `/api/v1/charge-points/{cp_id}/meter-values` response must
+    show OCPP 1.6 wire-form strings (`"Voltage"`, `"L1"`, `"V"`), not
+    the proto enum names that ClickHouse stores (`"MEASURAND_VOLTAGE"`,
+    `"PHASE_L1"`, `"UNIT_V"`).
+
+    This is the #136 contract: the storage layer canonical form is the
+    proto enum name, but the public REST surface speaks the OCPP wire
+    form. Without translation at the boundary, every API consumer
+    would have to know two naming systems for the same enum and there
+    would be no path to a stable contract.
+
+    Reads back the same Voltage+L1 / SoC samples the previous tests
+    already published. Auth: pulled live from the running container
+    so the test enforces what the gateway is actually accepting.
+    """
+    import urllib.parse
+    import urllib.request
+
+    cp_id = "COMPOSE_SMOKE_CP"
+    # The /meter-values route caps query windows at 7 days
+    # (`WINDOW_TOO_LARGE`); the previous tests' samples were emitted
+    # seconds ago, so a window straddling "now" by a day on each side
+    # comfortably contains them while staying under the cap.
+    now = datetime.now(UTC)
+    window_from = (now - timedelta(days=1)).isoformat()
+    window_to = (now + timedelta(days=1)).isoformat()
+    qs = urllib.parse.urlencode(
+        {
+            "from": window_from,
+            "to": window_to,
+            "measurand": "Voltage",
+            "limit": 10,
+        }
+    )
+    url = f"http://{PUBLISHED_HOST}:{HOST_REST_PORT}/api/v1/charge-points/{cp_id}/meter-values?{qs}"
+    token = gateway_inbound_token()
+    req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        body = json.loads(resp.read())
+
+    samples = body.get("meter_values", [])
+    assert samples, (
+        f"expected at least one Voltage sample; got empty page. body={body}. "
+        "If this fails, the OCPP-wire → proto-enum-name translation on the "
+        "?measurand= filter is broken (an unknown wire string returns []), "
+        "OR the Voltage sample never reached ClickHouse (separate from #136)."
+    )
+
+    # All samples MUST be in OCPP wire form. Even one `MEASURAND_*`
+    # leaking through means the boundary translation is incomplete.
+    for s in samples:
+        sample = s["sample"]
+        assert sample["measurand"] == "Voltage", (
+            f"measurand leaked storage form: {sample['measurand']!r} "
+            f"(should be the OCPP wire string 'Voltage')"
+        )
+        # Phase: only the L1 sample we sent has a phase; later vendor
+        # extensions might be `null` — accept either, but never the
+        # proto enum form.
+        assert sample["phase"] in {"L1", "L2", "L3", "L1-N", "L2-N", "L3-N", None}, (
+            f"phase leaked storage form: {sample['phase']!r}"
+        )
+        assert sample["unit"] in {"V", None}, f"unit leaked storage form: {sample['unit']!r}"
 
 
 # ---- Envoy edge --------------------------------------------------------

--- a/tests/unit/api/test_timeseries.py
+++ b/tests/unit/api/test_timeseries.py
@@ -11,6 +11,9 @@ import pytest
 
 
 def _meter_row(connector_id: int = 1) -> dict[str, Any]:
+    """Mock the *storage* shape — proto enum names (`MEASURAND_*`,
+    `PHASE_*`, …) — not the OCPP wire form. The route layer (#136)
+    translates these to the wire form on the way out."""
     return {
         "event_id": "evt-0001",
         "occurred_at": datetime(2026, 5, 6, 14, 0, tzinfo=UTC),
@@ -19,12 +22,12 @@ def _meter_row(connector_id: int = 1) -> dict[str, Any]:
         "transaction_id": 12345,
         "charger_reported_at": "2026-05-06T13:59:59Z",
         "value": "1500",
-        "context": "Sample.Periodic",
-        "format": "Raw",
-        "measurand": "Energy.Active.Import.Register",
+        "context": "CONTEXT_SAMPLE_PERIODIC",
+        "format": "FORMAT_RAW",
+        "measurand": "MEASURAND_ENERGY_ACTIVE_IMPORT_REGISTER",
         "phase": "",
-        "location": "Outlet",
-        "unit": "Wh",
+        "location": "LOCATION_OUTLET",
+        "unit": "UNIT_WH",
     }
 
 
@@ -110,8 +113,111 @@ async def test_meter_values_passes_filters_through(
     assert response.status_code == 200
     kwargs = spy.await_args.kwargs
     assert kwargs["connector_id"] == 2
-    assert kwargs["measurand"] == "Energy.Active.Import.Register"
+    # Route translates the OCPP wire form on input → proto enum name
+    # (storage form) before issuing the SQL.
+    assert kwargs["measurand"] == "MEASURAND_ENERGY_ACTIVE_IMPORT_REGISTER"
     assert kwargs["limit"] == 50
+
+
+@pytest.mark.asyncio
+async def test_meter_values_response_translates_proto_enum_names_to_ocpp_wire_form(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    fake_ch_client: MagicMock,
+) -> None:
+    """Storage layer returns proto enum names (`MEASURAND_*`, `PHASE_*`,
+    `UNIT_*`); the API surfaces the OCPP wire form (`Voltage`, `L1`,
+    `V`). Without this, every API consumer would have to learn two
+    naming systems for the same enum dimension."""
+    from eveys_ocpp.api import timeseries as ts_module
+
+    monkeypatch.setattr(ts_module, "get_charge_point_pk", AsyncMock(return_value=1))
+    row = _meter_row()
+    row.update(
+        {
+            "measurand": "MEASURAND_VOLTAGE",
+            "phase": "PHASE_L1",
+            "unit": "UNIT_V",
+            "context": "CONTEXT_SAMPLE_PERIODIC",
+            "format": "FORMAT_RAW",
+            "location": "LOCATION_OUTLET",
+        }
+    )
+    fake_ch_client.fetch_meter_values = AsyncMock(return_value=[row])
+
+    response = await client.get(
+        "/api/v1/charge-points/CP_001/meter-values"
+        "?from=2026-05-06T00:00:00%2B00:00&to=2026-05-06T23:59:59%2B00:00"
+    )
+
+    sample = response.json()["meter_values"][0]["sample"]
+    assert sample["measurand"] == "Voltage"
+    assert sample["phase"] == "L1"
+    assert sample["unit"] == "V"
+    assert sample["context"] == "Sample.Periodic"
+    assert sample["format"] == "Raw"
+    assert sample["location"] == "Outlet"
+
+
+@pytest.mark.asyncio
+async def test_meter_values_response_normalises_unspecified_to_null(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    fake_ch_client: MagicMock,
+) -> None:
+    """`*_UNSPECIFIED` is an internal sentinel — it MUST NOT leak to
+    API clients. Same goes for vendor-extension strings the ingestor
+    stored verbatim from the wire (no proto mapping). Both surface as
+    `null` so consumers can safely treat absent / unknown identically."""
+    from eveys_ocpp.api import timeseries as ts_module
+
+    monkeypatch.setattr(ts_module, "get_charge_point_pk", AsyncMock(return_value=1))
+    row = _meter_row()
+    row.update(
+        {
+            "measurand": "MEASURAND_UNSPECIFIED",  # internal sentinel
+            "phase": "Vendor.Custom.Phase",  # vendor extension
+            "unit": "",  # absent
+        }
+    )
+    fake_ch_client.fetch_meter_values = AsyncMock(return_value=[row])
+
+    response = await client.get(
+        "/api/v1/charge-points/CP_001/meter-values"
+        "?from=2026-05-06T00:00:00%2B00:00&to=2026-05-06T23:59:59%2B00:00"
+    )
+
+    sample = response.json()["meter_values"][0]["sample"]
+    assert sample["measurand"] is None
+    assert sample["phase"] is None
+    assert sample["unit"] is None
+
+
+@pytest.mark.asyncio
+async def test_meter_values_unknown_filter_short_circuits_to_empty(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    fake_ch_client: MagicMock,
+) -> None:
+    """`?measurand=Vendor.Custom` (unknown) returns an empty page WITHOUT
+    issuing a CH query. The alternative — passing the unknown string
+    through to SQL — would silently match every `_UNSPECIFIED` row and
+    mislead the caller into thinking those rows match their filter."""
+    from eveys_ocpp.api import timeseries as ts_module
+
+    monkeypatch.setattr(ts_module, "get_charge_point_pk", AsyncMock(return_value=1))
+    spy = AsyncMock(return_value=[_meter_row()])
+    fake_ch_client.fetch_meter_values = spy
+
+    response = await client.get(
+        "/api/v1/charge-points/CP_001/meter-values"
+        "?from=2026-05-06T00:00:00%2B00:00&to=2026-05-06T23:59:59%2B00:00"
+        "&measurand=Vendor.Custom.Reading"
+    )
+
+    assert response.status_code == 200
+    assert response.json()["meter_values"] == []
+    spy.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_ocpp_enums.py
+++ b/tests/unit/test_ocpp_enums.py
@@ -1,0 +1,106 @@
+"""Round-trip + unknown-value behaviour for the OCPP enum translation
+tables (#136).
+
+The maps are derived: `OCPP_BY_*_NAME` is built by inverting
+`*_BY_OCPP` at import. A typo in one would silently desync from the
+other; these tests prove the round-trip holds for every entry."""
+
+from __future__ import annotations
+
+import pytest
+
+from eveys_ocpp._generated.events.v1 import events_pb2
+from eveys_ocpp._ocpp_enums import (
+    MEASURAND_BY_OCPP,
+    OCPP_BY_MEASURAND_NAME,
+    OCPP_BY_PHASE_NAME,
+    OCPP_BY_UNIT_NAME,
+    PHASE_BY_OCPP,
+    UNIT_BY_OCPP,
+    ocpp_string_for,
+    proto_enum_name_for_measurand,
+    proto_enum_name_for_phase,
+)
+
+
+@pytest.mark.parametrize(
+    ("by_ocpp", "by_proto_name", "enum_descriptor_name"),
+    [
+        (MEASURAND_BY_OCPP, OCPP_BY_MEASURAND_NAME, "Measurand"),
+        (PHASE_BY_OCPP, OCPP_BY_PHASE_NAME, "Phase"),
+        (UNIT_BY_OCPP, OCPP_BY_UNIT_NAME, "Unit"),
+    ],
+)
+def test_round_trip_holds_for_every_mapped_value(
+    by_ocpp: dict[str, int],
+    by_proto_name: dict[str, str],
+    enum_descriptor_name: str,
+) -> None:
+    """For each OCPP wire string, mapping wire→proto→name→wire must
+    return the original. A typo in one direction would desync silently
+    without this guard."""
+    desc = events_pb2.DESCRIPTOR.enum_types_by_name[enum_descriptor_name]
+    for wire, proto_value in by_ocpp.items():
+        proto_name = desc.values_by_number[proto_value].name
+        assert by_proto_name[proto_name] == wire, (
+            f"{enum_descriptor_name}: {wire!r} → proto value {proto_value} "
+            f"→ name {proto_name!r} → wire {by_proto_name.get(proto_name)!r}"
+            f" (expected {wire!r})"
+        )
+
+
+def test_proto_enum_name_for_measurand_handles_known_unknown_and_none() -> None:
+    """API filter helper: known wire string → proto name; unknown
+    wire string → None (caller short-circuits the page); None → None."""
+    assert proto_enum_name_for_measurand("Voltage") == "MEASURAND_VOLTAGE"
+    assert proto_enum_name_for_measurand("SoC") == "MEASURAND_SOC"
+    assert proto_enum_name_for_measurand("Vendor.Custom.Reading") is None
+    assert proto_enum_name_for_measurand(None) is None
+
+
+def test_proto_enum_name_for_phase_handles_dashed_form() -> None:
+    """Phase has dash-form variants (`L1-N`) that aren't a mechanical
+    underscore-replace of the proto enum name (`PHASE_L1_N`)."""
+    assert proto_enum_name_for_phase("L1") == "PHASE_L1"
+    assert proto_enum_name_for_phase("L1-N") == "PHASE_L1_N"
+    assert proto_enum_name_for_phase("L2-L3") == "PHASE_L2_L3"
+    assert proto_enum_name_for_phase("Vendor.Phase") is None
+
+
+def test_ocpp_string_for_unspecified_returns_none() -> None:
+    """The internal `*_UNSPECIFIED` sentinel must NOT leak to API
+    clients — it's how the storage layer encodes "the charger sent
+    something we don't recognise." Surface as `null` so consumers
+    treat it the same as an absent dimension."""
+    assert ocpp_string_for("measurand", "MEASURAND_UNSPECIFIED") is None
+    assert ocpp_string_for("phase", "PHASE_UNSPECIFIED") is None
+    assert ocpp_string_for("unit", "UNIT_UNSPECIFIED") is None
+
+
+def test_ocpp_string_for_empty_or_none_returns_none() -> None:
+    """Storage-side empty strings (column never written) and None
+    (missing key) both surface as `null`, identical to UNSPECIFIED."""
+    assert ocpp_string_for("measurand", "") is None
+    assert ocpp_string_for("measurand", None) is None
+
+
+def test_ocpp_string_for_unknown_proto_name_returns_none() -> None:
+    """A vendor-extension string the ingestor stored verbatim (no
+    proto mapping) won't appear in the inverse table — surface as
+    `null` rather than leak the raw string we can't promise to be
+    OCPP-spec-compliant."""
+    assert ocpp_string_for("measurand", "Vendor.Custom.Reading") is None
+
+
+def test_ocpp_string_for_round_trips_known_proto_names() -> None:
+    assert ocpp_string_for("measurand", "MEASURAND_VOLTAGE") == "Voltage"
+    assert ocpp_string_for("phase", "PHASE_L1") == "L1"
+    assert ocpp_string_for("phase", "PHASE_L1_N") == "L1-N"
+    assert ocpp_string_for("unit", "UNIT_V") == "V"
+    assert ocpp_string_for("context", "CONTEXT_SAMPLE_PERIODIC") == "Sample.Periodic"
+    assert ocpp_string_for("location", "LOCATION_OUTLET") == "Outlet"
+
+
+def test_ocpp_string_for_unknown_field_raises() -> None:
+    with pytest.raises(KeyError):
+        ocpp_string_for("not_a_real_field", "MEASURAND_VOLTAGE")


### PR DESCRIPTION
## What's wrong

After #135 fixed the handler to store proto enum *names* in ClickHouse (\`MEASURAND_VOLTAGE\`, \`PHASE_L1\`, …), two read paths still spoke the old OCPP wire form:

- \`fetch_transaction_telemetry\` filtered \`WHERE sv.measurand = 'Voltage' AND sv.phase IN ('L1', 'L2', 'L3')\` — these strings never match storage. \`GET /api/v1/transactions/{id}\` returned \`telemetry.phases: {}\` against real charging sessions.
- \`/api/v1/charge-points/{cp_id}/meter-values\` returned \`{\"measurand\": \"MEASURAND_VOLTAGE\", \"phase\": \"PHASE_L1\", ...}\` to API consumers — leaking the proto enum naming, which a reasonable consumer would not expect (the schema description and OCPP spec both speak the wire form).

## Decision (Option A from the issue)

**Storage stays canonical to the proto schema; the API speaks the OCPP 1.6 wire form; translation happens at the route boundary.**

- Spec-aligned for external callers (any OCPP-aware tool already knows \`\"Voltage\"\`/\`\"L1\"\`, not the proto names).
- Machine-friendly for internal ad-hoc CH queries (proto enum names are stable, machine-grep-friendly, future-compat).
- Single translation table to maintain (one module, both directions).

## What changed

- **New \`src/eveys_ocpp/_ocpp_enums.py\`** owns translation. \`*_BY_OCPP\` (wire → proto value, used at ingest) is unchanged from #135. The new \`OCPP_BY_*_NAME\` (proto name → wire, used at read) is **derived by inversion at import** — a typo in one direction can't desync because the inverse is generated from the canonical map.
- \`handlers/v16/meter_values.py\` imports the shared maps instead of duplicating them (lifted out of the file by this PR).
- \`fetch_transaction_telemetry\` SQL filters now on \`MEASURAND_VOLTAGE\` / \`PHASE_L1\` etc. The Python-side phase-key fold translates back to the wire form (\`'L1'\`) for the response.
- \`list_meter_values\` route translates the inbound \`?measurand=\` from wire → proto name before SQL. **Unknown wire string short-circuits to an empty page** (the alternative — passing through — would silently match every \`_UNSPECIFIED\` row and mislead the caller).
- \`_meter_to_response\` translates each enum field from stored proto name → wire form. \`*_UNSPECIFIED\` and vendor-extension strings surface as \`null\` — internal sentinels MUST NOT leak to API clients.

## Tests

- **New \`tests/unit/test_ocpp_enums.py\`**: parametrized round-trip across every wire string in every dimension, plus unknown-vendor / \`*_UNSPECIFIED\` / \`None\` / empty-string handling on the read helper.
- **\`tests/unit/api/test_timeseries.py\`** (updated): \`_meter_row\` now mocks the *storage* shape (proto names); new tests assert proto→wire translation on the response, the unknown-filter short-circuit, and the \`UNSPECIFIED\` → \`null\` contract.
- **\`tests/compose_smoke/test_compose_stack.py\`** (new test): queries \`/api/v1/charge-points/{cp_id}/meter-values?measurand=Voltage\` against the running stack and asserts every sample's \`measurand\`/\`phase\`/\`unit\` is in OCPP wire form. This is the assertion that closes the original #135 → #136 chain end-to-end.
- **\`tests/compose_smoke/conftest.py\`**: \`_compose()\` now passes \`--env-file .env\` like \`make compose-up\` does. CI doesn't have a \`.env\`, so the harness seeds a random \`EVEYS_OCPP_REST_INBOUND_TOKENS\` per session — local dev keeps using the \`.env\` token, CI gets a fresh one with no secret needed. New \`gateway_inbound_token()\` reads what the running container is *actually* enforcing via \`docker inspect\` (vs. trusting the operator's \`.env\` snapshot).

## End-to-end proof

Verified live against a fresh compose stack — \`GET /api/v1/transactions/{id}\` returns:

\`\`\`json
\"telemetry\": {
  \"soc\": { \"start_pct\": 38.0, \"last_pct\": 81.0, \"last_at\": \"...\" },
  \"phases\": {
    \"L1\": { \"voltage_v\": 231.4, \"current_a\": 14.8, \"power_w\": 3424.7, \"last_at\": \"...\" },
    \"L2\": { \"voltage_v\": 231.8, \"current_a\": 14.9, \"power_w\": 3454.7, \"last_at\": \"...\" },
    \"L3\": { \"voltage_v\": 232.2, \"current_a\": 15.0, \"power_w\": 3484.7, \"last_at\": \"...\" }
  }
}
\`\`\`

## Test plan

- [x] Unit: 778 passed (was 765 — 13 new for #136), 83.07% coverage.
- [x] Compose-smoke: all 12 tests pass against fresh stack, including the new REST translation assertion.
- [x] Telemetry script (\`/tmp/drive_telemetry.py\`-style) confirms the full chain.
- [x] ruff + mypy + \`make openapi-export-check\` clean.
- [ ] CI (will run on push).

## Compatibility note

Anyone who started reading \`MEASURAND_*\` / \`PHASE_*\` strings off \`/meter-values\` between #135 (merged ~30 min ago) and this PR will see the response shape revert to OCPP wire form. Given the gap and that the OCPP wire form is what the schema documentation already promised, no documented contract is broken.

Closes #136