### PR TITLE
chore(release): cut v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This file starts at the merge that introduced it; for anything earlier, the git 
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-05-10
+
+First tagged release. Carries everything previously merged on `main` since repo init; the highlights below are what shipped during this cut's window.
+
 ### Added
 
 - **Per-transaction telemetry** on `GET /api/v1/transactions/{transaction_id}`. Response now carries a bounded `telemetry` block with SoC start/last percent and a per-phase voltage/current/power snapshot for `L1`/`L2`/`L3`. ClickHouse-backed; absent phases / `null` SoC fields when the charger never reported that dimension. List endpoints intentionally omit `telemetry` (would be N+1 fan-out per cursor row); use the detail endpoint per id, or `/meter-values?transaction_id=…` for the full curve. Contract: `docs/integration/02-gateway-rest-api.md`. (#134)

--- a/deploy/helm/eveys-ocpp/Chart.yaml
+++ b/deploy/helm/eveys-ocpp/Chart.yaml
@@ -19,7 +19,7 @@ description: |
   operator picks the source of truth.
 type: application
 version: 0.1.0
-appVersion: "0.0.0"
+appVersion: "0.1.0"
 keywords:
   - ocpp
   - ev-charging

--- a/deploy/helm/eveys-ocpp/values.yaml
+++ b/deploy/helm/eveys-ocpp/values.yaml
@@ -10,7 +10,7 @@
 gateway:
   image:
     repository: ""              # operator-set; e.g. ghcr.io/eveys-mobility/ocpp
-    tag: "0.0.0"
+    tag: "0.1.0"
     pullPolicy: IfNotPresent
 
   # Two replicas is the minimum that makes the graceful-drain

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -596,7 +596,7 @@
           },
           "request_id": "9b3c5d18-1f7c-4b6a-8e0e-5b9a3c4f2e10",
           "status": "ok",
-          "version": "0.0.0"
+          "version": "0.1.0"
         },
         "properties": {
           "components": {
@@ -1412,7 +1412,7 @@
   "info": {
     "description": "Inbound REST surface (E3-7 / E3-8). Backend services read charger and transaction state under `/api/v1/charge-points`, `/api/v1/transactions`, etc., and dispatch OCPP commands via `/api/v1/charge-points/{cp_id}/commands/*`. All endpoints require a bearer token (`EVEYS_OCPP_REST_INBOUND_TOKENS`); `/api/v1/health` is exempt. Errors carry the closed-enum envelope `{error, error_code, request_id}` documented in [`docs/integration/02-gateway-rest-api.md`](https://github.com/eveys-mobility/OCPP/blob/main/docs/integration/02-gateway-rest-api.md).",
     "title": "eveys/ocpp gateway",
-    "version": "0.0.0"
+    "version": "0.1.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -402,7 +402,7 @@ components:
           redis: ok
         request_id: 9b3c5d18-1f7c-4b6a-8e0e-5b9a3c4f2e10
         status: ok
-        version: 0.0.0
+        version: 0.1.0
       properties:
         components:
           $ref: '#/components/schemas/HealthComponents'
@@ -968,7 +968,7 @@ info:
     is exempt. Errors carry the closed-enum envelope `{error, error_code, request_id}`
     documented in [`docs/integration/02-gateway-rest-api.md`](https://github.com/eveys-mobility/OCPP/blob/main/docs/integration/02-gateway-rest-api.md).
   title: eveys/ocpp gateway
-  version: 0.0.0
+  version: 0.1.0
 openapi: 3.1.0
 paths:
   /api/v1/admin/config:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "eveys-ocpp"
-version = "0.0.0"
+version = "0.1.0"
 description = "OCPP gateway service for the Eveys EV-charging platform"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/eveys_ocpp/__init__.py
+++ b/src/eveys_ocpp/__init__.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__version__ = "0.0.0"
+__version__ = "0.1.0"

--- a/src/eveys_ocpp/api/_schemas.py
+++ b/src/eveys_ocpp/api/_schemas.py
@@ -87,7 +87,7 @@ class HealthResponse(BaseModel):
         "json_schema_extra": {
             "example": {
                 "status": "ok",
-                "version": "0.0.0",
+                "version": "0.1.0",
                 "components": {"postgres": "ok", "redis": "ok"},
                 "request_id": "9b3c5d18-1f7c-4b6a-8e0e-5b9a3c4f2e10",
             }

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -6,4 +6,4 @@ import eveys_ocpp
 
 
 def test_version_is_set() -> None:
-    assert eveys_ocpp.__version__ == "0.0.0"
+    assert eveys_ocpp.__version__ == "0.1.0"


### PR DESCRIPTION
First tagged release.

## Bumps

- \`pyproject.toml\`, \`src/eveys_ocpp/__init__.py\` (drives \`--version\`, \`/api/v1/health.version\`, the \`gateway_info\` Prometheus label, and the OpenAPI \`info.version\` derived in \`api/_app.py\`).
- \`deploy/helm/eveys-ocpp/values.yaml\` (\`gateway.image.tag\`) and \`Chart.yaml\` (\`appVersion\`).
- \`tests/test_package.py\` literal assertion.
- \`_schemas.py\` health-response example (Swagger UI cosmetic).
- Regenerated \`docs/api/openapi.{json,yaml}\`.

## CHANGELOG

Moves the previously-\`[Unreleased]\` telemetry block (#134/#135/#136) under \`## [0.1.0] - 2026-05-10\`. Empty \`[Unreleased]\` heading left at the top.

## After merge

Tag \`v0.1.0\` (annotated) on the resulting main commit, push the tag, cut a GitHub Release whose body is the CHANGELOG \`[0.1.0]\` section verbatim.

## Test plan

- [x] Unit: 779 passed (incl. \`test_package.py\` asserting \`__version__\`).
- [x] OpenAPI snapshot regenerated; snapshot test passes.
- [x] No remaining \`0.0.0\` references in tracked files.

Closes #143