### PR TITLE
docs(changelog): add latest-release callout above the version sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to the gateway land here. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [SemVer](https://semver.org/) once a tag is cut; until then everything sits under `[Unreleased]`.
 
+> **Latest release: [v0.1.0](https://github.com/eveys-mobility/OCPP/releases/tag/v0.1.0)** (2026-05-10) — first tagged release; ships per-transaction telemetry on the gateway REST API. See [`[0.1.0]`](#010---2026-05-10) below for the full notes.
+
 This file starts at the merge that introduced it; for anything earlier, the git log is authoritative.
 
 ## [Unreleased]


### PR DESCRIPTION
Closes #145

One-line blockquote at the top of CHANGELOG.md naming the latest tag, linking to the GitHub Release, and jumping to the in-file section. Future tags update the same line.

## Test plan

- [x] Documentation only.
- [ ] Eyeball the rendered Markdown on this PR's Files tab to confirm the in-file anchor (`#010---2026-05-10`) actually jumps to the `## [0.1.0] - 2026-05-10` heading. If GitHub's slugifier produces a different anchor, fix-up patch before merge.