### PR TITLE
fix(test): pin backend_authorize_fallback in fallback-not-cached test

### DIFF
--- a/tests/unit/handlers/v16/test_authorize.py
+++ b/tests/unit/handlers/v16/test_authorize.py
@@ -296,10 +296,19 @@ async def test_business_error_is_not_cached(fake_cp: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_unavailable_fallback_is_not_cached(fake_cp: Any) -> None:
+async def test_unavailable_fallback_is_not_cached(fake_cp: Any, settings_factory: Any) -> None:
     """Fallback policy depends on current settings, not a stale call.
     The cache must not store a Backend*Error outcome — let the next
-    tap re-roundtrip and re-evaluate."""
+    tap re-roundtrip and re-evaluate.
+
+    Pin `backend_authorize_fallback="reject"` explicitly: the local
+    dev `.env` typically sets it to `accept_offline` (working config
+    when the toger.test backend is down), which would flip the
+    expected status from Invalid to Accepted and turn this test into
+    a `.env`-presence flake. Sibling tests in this file already set
+    the policy explicitly; this one was missed (#155). See #156 for
+    the broader unit-suite hermeticity fix."""
+    fake_cp.settings = settings_factory(backend_authorize_fallback="reject")
     fake_cp.backend_client = AsyncMock()
     fake_cp.backend_client.authorize = AsyncMock(
         side_effect=BackendTimeoutError("timed out"),


### PR DESCRIPTION
## Summary

\`tests/unit/handlers/v16/test_authorize.py::test_unavailable_fallback_is_not_cached\` was a \`.env\`-presence flake. It asserts the \`reject\`-fallback outcome (\`Invalid\`) but inherited the default \`Settings()\` fixture, which reads \`.env\`. Any developer whose \`.env\` sets \`EVEYS_OCPP_BACKEND_AUTHORIZE_FALLBACK=accept_offline\` (the working dev config when toger.test is unreachable) saw the test fail because the fallback flipped to \`Accepted\`. CI is green only because the runner has no \`.env\`.

Sibling tests in the same file already pin the policy explicitly via \`settings_factory(backend_authorize_fallback=\"reject\"|\"accept_offline\")\`. This one was missed.

## Test plan

- [x] \`pytest tests/unit\` (no deselect): 788 passed, 83.07% coverage. Previously the suite ran as 787-pass-1-deselected for several PRs.
- [x] Verified the test passes locally with the \`.env\` containing \`accept_offline\` (the case that previously failed).
- [x] CI will re-confirm.

## Follow-up

#156 tracks the broader fix: an autouse fixture that strips \`EVEYS_OCPP_*\` envvars so any future test is automatically hermetic against the developer's \`.env\`. This PR is the surgical right-now fix only.

Closes #155