### PR TITLE
feature(slo): add stop_transactions_received_total + fix SLO 4 SLI shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file starts at the merge that introduced it; for anything earlier, the git 
 ### Changed
 
 - CHANGELOG header now carries a one-line "Latest release" callout above the version sections, linking to both the GitHub Release and the in-file section. Each tag updates the same line. (#146)
+- **SLO 4 (transaction durability)** now uses a dedicated `eveys_ocpp_stop_transactions_received_total` counter as its denominator. Previously the SLI summed `stop_transactions_total + handler_errors_total` to approximate "received," which both double-counted failures (the entry-time `_total` inc *and* the error inc) and was misdescribed in the docs. New shape: numerator = persisted (`_total`, now incremented after a successful DB commit only), denominator = received (`_received_total`, incremented at handler entry). Recording rule + SLO doc updated. Dashboards using `eveys_ocpp_stop_transactions_total` won't notice in normal operation (transactions almost always persist); during an incident, the metric will lag the received count, which is exactly the signal SLO 4 is built to surface. (#163)
 
 ## [0.1.0] - 2026-05-10
 

--- a/deploy/prometheus/rules.yml
+++ b/deploy/prometheus/rules.yml
@@ -66,22 +66,21 @@ groups:
       # SLI: fraction of StopTransactions that landed in Postgres.
       # Target: 100% (any miss is a billing incident).
       #
-      # Caveat: we don't currently emit a separate "received but not
-      # persisted" counter — `eveys_ocpp_stop_transactions_total` is
-      # incremented after the handler's DB commit, so a stop that
-      # fails to persist gets counted in `eveys_ocpp_handler_errors_total
-      # {action="StopTransaction"}` instead. The SLI sums both as the
-      # denominator and only the persisted total as the numerator. If a
-      # future task adds a dedicated `received` counter, switch the
-      # denominator to that — see docs/14-slos.md.
+      # Numerator:   `_total`             — incremented after a successful
+      #                                     DB commit in the handler
+      #                                     (StopTransaction.applied path).
+      # Denominator: `_received_total`    — incremented at handler entry,
+      #                                     before any DB work. So a stop
+      #                                     that fails to persist still
+      #                                     counts in the denominator —
+      #                                     which is the bug SLO 4 is
+      #                                     designed to flag.
       - record: slo:transaction_durability:ratio_30d
         expr: |
           sum(rate(eveys_ocpp_stop_transactions_total[30d]))
           /
           clamp_min(
-            sum(rate(eveys_ocpp_stop_transactions_total[30d]))
-            +
-            sum(rate(eveys_ocpp_handler_errors_total{action="StopTransaction"}[30d])),
+            sum(rate(eveys_ocpp_stop_transactions_received_total[30d])),
             1
           )
 

--- a/docs/14-slos.md
+++ b/docs/14-slos.md
@@ -98,21 +98,18 @@ Money flows on this. Any StopTransaction we received but didn't persist is a bil
 ```promql
 sum(rate(eveys_ocpp_stop_transactions_total[30d]))
 /
-(
-  sum(rate(eveys_ocpp_stop_transactions_total[30d]))
-  +
-  sum(rate(eveys_ocpp_handler_errors_total{action="StopTransaction"}[30d]))
-)
+sum(rate(eveys_ocpp_stop_transactions_received_total[30d]))
 ```
 Recorded as `slo:transaction_durability:ratio_30d`.
+
+- **Numerator** — `eveys_ocpp_stop_transactions_total`: incremented after a successful DB commit in the StopTransaction handler. "Persisted."
+- **Denominator** — `eveys_ocpp_stop_transactions_received_total`: incremented at handler entry, before any DB work. A stop that fails to persist still counts here — which is the case the SLO is designed to flag.
 
 **Target** — `= 100%`. Zero-tolerance.
 
 **Window** — rolling 30 days.
 
 **Error budget** — `0%`. Every drop in this number is a postmortem.
-
-**Caveat (current implementation)** — we don't currently emit a separate "received but not persisted" counter. `eveys_ocpp_stop_transactions_total` is incremented after the handler's DB commit, so a stop that fails to persist gets counted in `eveys_ocpp_handler_errors_total{action="StopTransaction"}` instead. The SLI sums both as the denominator and only the persisted total as the numerator. **If a future task adds a dedicated `_received_total` counter, switch the denominator to that** — the recording rule has a comment pointing here.
 
 **Consequence on breach (Phase 7)** — wake the on-call engineer regardless of hour. Investigate via Sentry (E4-4) for the StopTransaction handler exception; cross-reference the `transaction_id` in OCPP charger replays via `eveys_ocpp_stop_transaction_replays_total` (a healthy idempotency cache absorbs most retries).
 

--- a/src/eveys_ocpp/handlers/v16/stop_transaction.py
+++ b/src/eveys_ocpp/handlers/v16/stop_transaction.py
@@ -113,7 +113,12 @@ async def handle(
         transaction_id=transaction_id,
     )
 
-    metrics_registry.STOP_TRANSACTIONS_TOTAL.labels(reason=reason or "unknown").inc()
+    # Counted regardless of what happens next — SLO 4 (transaction
+    # durability) needs the denominator to include stops that fail
+    # to persist (those are precisely what the SLO flags). The
+    # `_total` (persisted) counter is bumped after the DB commit
+    # below so the SLO ratio is meaningful.
+    metrics_registry.STOP_TRANSACTIONS_RECEIVED_TOTAL.inc()
     with time_handler("StopTransaction") as set_outcome:
         try:
             return await _stop_inner(
@@ -186,6 +191,9 @@ async def _stop_inner(
             set_outcome("replay")
         return _response(_local_status(id_tag))
 
+    # Persisted — SLO 4 numerator. (Received counter at the top is
+    # the denominator; the difference is what SLO 4 alerts on.)
+    metrics_registry.STOP_TRANSACTIONS_TOTAL.labels(reason=reason or "unknown").inc()
     log.info("stop_transaction.applied", reason=reason, meter_stop=meter_stop)
 
     # Backend round-trip (E3-6). The DB row is now durably marked

--- a/src/eveys_ocpp/metrics/registry.py
+++ b/src/eveys_ocpp/metrics/registry.py
@@ -179,10 +179,20 @@ START_TRANSACTIONS_TOTAL: Counter = Counter(
     labelnames=("decision",),
 )
 
+STOP_TRANSACTIONS_RECEIVED_TOTAL: Counter = Counter(
+    "eveys_ocpp_stop_transactions_received_total",
+    "StopTransaction OCPP CALLs received by the handler — incremented at "
+    "handler entry, *before* any DB work. SLO 4's denominator uses this so "
+    "a stop that fails to persist still counts toward the durability ratio "
+    "(a stop we received but didn't persist is the billing incident the SLO "
+    "is designed to flag).",
+)
 STOP_TRANSACTIONS_TOTAL: Counter = Counter(
     "eveys_ocpp_stop_transactions_total",
-    "StopTransaction events, grouped by reported reason. Bounded — "
-    "OCPP 1.6 § 6.10 fixes the `Reason` enum.",
+    "StopTransaction events that successfully landed in Postgres, grouped by "
+    "reported reason. Bounded — OCPP 1.6 § 6.10 fixes the `Reason` enum. SLO "
+    "4 numerator. For the count of *received* StopTransactions (incl. ones "
+    "that failed to persist) see `eveys_ocpp_stop_transactions_received_total`.",
     labelnames=("reason",),
 )
 STOP_TRANSACTION_REPLAYS_TOTAL: Counter = Counter(
@@ -551,6 +561,7 @@ __all__ = [
     "REST_REQUEST_LATENCY_SECONDS",
     "START_TRANSACTIONS_TOTAL",
     "STATUS_NOTIFICATIONS_TOTAL",
+    "STOP_TRANSACTIONS_RECEIVED_TOTAL",
     "STOP_TRANSACTIONS_TOTAL",
     "STOP_TRANSACTION_REPLAYS_TOTAL",
     "WEBHOOK_ATTEMPTS_TOTAL",

--- a/tests/unit/handlers/v16/test_stop_transaction.py
+++ b/tests/unit/handlers/v16/test_stop_transaction.py
@@ -359,3 +359,83 @@ async def test_forwards_backend_status_through_status_map(
     )
 
     assert result.id_tag_info.status == AuthorizationStatus.blocked
+
+
+# ----- SLO 4 counter discipline (#163) --------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_received_counter_bumps_before_persist(
+    fake_cp: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """SLO 4 needs the denominator (`received`) to fire even when the
+    DB write fails — that's exactly the case the SLO is designed to
+    flag (received but not persisted == billing incident). Simulate a
+    DB-layer exception and assert: `received` ticks up; `_total`
+    (persisted) does not."""
+    from eveys_ocpp.metrics import registry
+
+    received_before = registry.STOP_TRANSACTIONS_RECEIVED_TOTAL._value.get()
+    persisted_before = registry.STOP_TRANSACTIONS_TOTAL.labels(reason="Local")._value.get()
+
+    monkeypatch.setattr(
+        stop_transaction,
+        "stop_transaction",
+        AsyncMock(side_effect=RuntimeError("DB went away")),
+    )
+
+    with pytest.raises(RuntimeError):
+        await stop_transaction.handle(
+            fake_cp,
+            transaction_id=999,
+            meter_stop=12345,
+            timestamp="2026-04-29T01:00:00+00:00",
+            reason="Local",
+            id_tag="VALID_RFID_001",
+        )
+
+    assert registry.STOP_TRANSACTIONS_RECEIVED_TOTAL._value.get() == received_before + 1
+    assert registry.STOP_TRANSACTIONS_TOTAL.labels(reason="Local")._value.get() == persisted_before
+
+
+@pytest.mark.asyncio
+async def test_persisted_counter_bumps_only_on_successful_apply(
+    fake_cp: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Happy path: both counters tick up. Replay path: only `received`
+    bumps — the row was already in Postgres, so the persisted counter
+    must NOT inflate (would skew SLO 4 numerator above 1.0 over time)."""
+    from eveys_ocpp.metrics import registry
+
+    received_before = registry.STOP_TRANSACTIONS_RECEIVED_TOTAL._value.get()
+    persisted_before = registry.STOP_TRANSACTIONS_TOTAL.labels(reason="Other")._value.get()
+
+    monkeypatch.setattr(stop_transaction, "stop_transaction", AsyncMock(return_value=True))
+    await stop_transaction.handle(
+        fake_cp,
+        transaction_id=1,
+        meter_stop=100,
+        timestamp="2026-04-29T01:00:00+00:00",
+        reason="Other",
+    )
+
+    assert registry.STOP_TRANSACTIONS_RECEIVED_TOTAL._value.get() == received_before + 1
+    assert (
+        registry.STOP_TRANSACTIONS_TOTAL.labels(reason="Other")._value.get() == persisted_before + 1
+    )
+
+    # Replay: same triple → applied=False, neither persisted nor received
+    # double-counted (received bumps once per CALL; persisted not at all).
+    monkeypatch.setattr(stop_transaction, "stop_transaction", AsyncMock(return_value=False))
+    await stop_transaction.handle(
+        fake_cp,
+        transaction_id=1,
+        meter_stop=100,
+        timestamp="2026-04-29T01:00:00+00:00",
+        reason="Other",
+    )
+    assert registry.STOP_TRANSACTIONS_RECEIVED_TOTAL._value.get() == received_before + 2
+    assert (
+        registry.STOP_TRANSACTIONS_TOTAL.labels(reason="Other")._value.get()
+        == persisted_before + 1  # unchanged
+    )

--- a/tests/unit/metrics/test_registry.py
+++ b/tests/unit/metrics/test_registry.py
@@ -27,7 +27,8 @@ from eveys_ocpp.metrics import registry as m
 # grows in a future PR.
 # 56: +1 SECURITY_EVENTS_TOTAL for SecurityEventNotification (TC_077/078)
 # 57: +1 LOG_STATUS_TOTAL for LogStatusNotification (TC_079)
-EXPECTED_METRIC_COUNT = 57
+# 58: +1 STOP_TRANSACTIONS_RECEIVED_TOTAL for SLO 4 denominator (#163)
+EXPECTED_METRIC_COUNT = 58
 
 
 def _gateway_metric_attrs() -> list[tuple[str, object]]:


### PR DESCRIPTION
## Summary

SLO 4 (transaction durability) was computed as:

\`\`\`
sum(rate(stop_transactions_total[30d]))
/
sum(rate(stop_transactions_total[30d])) + sum(rate(handler_errors_total{action=\"StopTransaction\"}[30d]))
\`\`\`

The doc explained this as a workaround pending a \`received\` counter, claiming \`stop_transactions_total\` was incremented after the DB commit. **The doc was wrong** — that counter was bumped at handler entry, before any DB work. So failed stops got double-counted in the denominator (once via the entry-time inc, once via \`handler_errors_total\`), making the ratio worse than reality.

This PR cleans the whole thing up:

- New \`STOP_TRANSACTIONS_RECEIVED_TOTAL\` at handler entry → SLO 4 denominator.
- Existing \`STOP_TRANSACTIONS_TOTAL\` inc moved to after the DB commit → really means \"persisted\" → SLO 4 numerator.
- Recording rule simplified to \`total / received\`. Caveat removed from doc.

## Tests

- \`test_received_counter_bumps_before_persist\` — simulates a DB exception; asserts \`received\` ticks but \`_total\` (persisted) does not. This is the SLO-4-bug-class case the metric is built to flag.
- \`test_persisted_counter_bumps_only_on_successful_apply\` — happy path bumps both; replay bumps only \`received\` (replays were already persisted; double-counting would push the ratio above 1.0).

## Test plan

- [x] \`pytest tests/unit\` — 796 passed (was 794, +2 new), 83.14% coverage.
- [x] ruff + mypy clean.
- [x] CHANGELOG entry under \`[Unreleased]\` / Changed.

## Compatibility

\`STOP_TRANSACTIONS_TOTAL\` semantics shift slightly (entry-time → after-DB-commit). Dashboards using it won't notice in normal operation (transactions almost always persist); during an incident the metric will lag the received count, which is exactly the signal SLO 4 is built to surface. No dashboards in \`deploy/grafana/dashboards/\` consume the difference today.

Closes #163