### PR TITLE
feature(config): allowlist webhook URL + enable fields for runtime override

### DIFF
--- a/src/eveys_ocpp/runtime_overrides.py
+++ b/src/eveys_ocpp/runtime_overrides.py
@@ -114,6 +114,18 @@ def _coerce_url(value: Any) -> str:
     return stripped
 
 
+# Per-event webhook enable flags share an asymmetry that operators
+# need to know about, so we share the explanation rather than re-typing
+# it on every entry.
+_WEBHOOK_ENABLE_ASYMMETRY = (
+    " Asymmetry: turning OFF is fully live (delivery is suppressed on "
+    "the next event); turning ON is live ONLY if this event was already "
+    "enabled at boot — _enabled_topics() runs once at consumer start, so "
+    "a topic that wasn't subscribed then needs a pod restart to begin "
+    "delivering."
+)
+
+
 # The allowlist itself. See the module docstring for the criteria.
 _ALLOWLIST: dict[str, _AllowlistEntry] = {
     "log_level": _AllowlistEntry(
@@ -130,6 +142,107 @@ _ALLOWLIST: dict[str, _AllowlistEntry] = {
         name="backend_authorize_cache_enabled",
         coerce=_coerce_bool,
         description="Per-pod Authorize cache (E3-4) kill-switch.",
+    ),
+    "webhook_base_url": _AllowlistEntry(
+        name="webhook_base_url",
+        coerce=_coerce_url,
+        description=(
+            "Default base URL for webhook delivery. Per-event URLs that "
+            "are empty fall back to `<base>/<event-slug>`. Cannot be "
+            "cleared via runtime override — clearing it disables the "
+            "dispatcher entirely, which is a deploy-time call."
+        ),
+    ),
+    "webhook_url_cp_boot": _AllowlistEntry(
+        name="webhook_url_cp_boot",
+        coerce=_coerce_url_or_empty,
+        description=(
+            "Override URL for cp.boot webhook deliveries. Empty string "
+            "falls back to `<webhook_base_url>/cp-boot`."
+        ),
+    ),
+    "webhook_url_cp_online": _AllowlistEntry(
+        name="webhook_url_cp_online",
+        coerce=_coerce_url_or_empty,
+        description=(
+            "Override URL for cp.online webhook deliveries. Empty string "
+            "falls back to `<webhook_base_url>/cp-online`."
+        ),
+    ),
+    "webhook_url_cp_offline": _AllowlistEntry(
+        name="webhook_url_cp_offline",
+        coerce=_coerce_url_or_empty,
+        description=(
+            "Override URL for cp.offline webhook deliveries. Empty string "
+            "falls back to `<webhook_base_url>/cp-offline`."
+        ),
+    ),
+    "webhook_url_cp_status": _AllowlistEntry(
+        name="webhook_url_cp_status",
+        coerce=_coerce_url_or_empty,
+        description=(
+            "Override URL for cp.status_changed webhook deliveries. Empty "
+            "string falls back to `<webhook_base_url>/cp-status-changed`."
+        ),
+    ),
+    "webhook_url_cp_meter": _AllowlistEntry(
+        name="webhook_url_cp_meter",
+        coerce=_coerce_url_or_empty,
+        description=(
+            "Override URL for cp.meter webhook deliveries. Empty string "
+            "falls back to `<webhook_base_url>/cp-meter`."
+        ),
+    ),
+    "webhook_url_tx_started": _AllowlistEntry(
+        name="webhook_url_tx_started",
+        coerce=_coerce_url_or_empty,
+        description=(
+            "Override URL for tx.started webhook deliveries. Empty string "
+            "falls back to `<webhook_base_url>/tx-started`."
+        ),
+    ),
+    "webhook_url_tx_stopped": _AllowlistEntry(
+        name="webhook_url_tx_stopped",
+        coerce=_coerce_url_or_empty,
+        description=(
+            "Override URL for tx.stopped webhook deliveries. Empty string "
+            "falls back to `<webhook_base_url>/tx-stopped`."
+        ),
+    ),
+    "webhook_enable_cp_boot": _AllowlistEntry(
+        name="webhook_enable_cp_boot",
+        coerce=_coerce_bool,
+        description="cp.boot webhook delivery toggle." + _WEBHOOK_ENABLE_ASYMMETRY,
+    ),
+    "webhook_enable_cp_online": _AllowlistEntry(
+        name="webhook_enable_cp_online",
+        coerce=_coerce_bool,
+        description="cp.online webhook delivery toggle." + _WEBHOOK_ENABLE_ASYMMETRY,
+    ),
+    "webhook_enable_cp_offline": _AllowlistEntry(
+        name="webhook_enable_cp_offline",
+        coerce=_coerce_bool,
+        description="cp.offline webhook delivery toggle." + _WEBHOOK_ENABLE_ASYMMETRY,
+    ),
+    "webhook_enable_cp_status": _AllowlistEntry(
+        name="webhook_enable_cp_status",
+        coerce=_coerce_bool,
+        description="cp.status_changed webhook delivery toggle." + _WEBHOOK_ENABLE_ASYMMETRY,
+    ),
+    "webhook_enable_cp_meter": _AllowlistEntry(
+        name="webhook_enable_cp_meter",
+        coerce=_coerce_bool,
+        description="cp.meter webhook delivery toggle." + _WEBHOOK_ENABLE_ASYMMETRY,
+    ),
+    "webhook_enable_tx_started": _AllowlistEntry(
+        name="webhook_enable_tx_started",
+        coerce=_coerce_bool,
+        description="tx.started webhook delivery toggle." + _WEBHOOK_ENABLE_ASYMMETRY,
+    ),
+    "webhook_enable_tx_stopped": _AllowlistEntry(
+        name="webhook_enable_tx_stopped",
+        coerce=_coerce_bool,
+        description="tx.stopped webhook delivery toggle." + _WEBHOOK_ENABLE_ASYMMETRY,
     ),
 }
 
@@ -250,4 +363,19 @@ AllowlistName = Literal[
     "log_level",
     "ws_rate_limit_enabled",
     "backend_authorize_cache_enabled",
+    "webhook_base_url",
+    "webhook_url_cp_boot",
+    "webhook_url_cp_online",
+    "webhook_url_cp_offline",
+    "webhook_url_cp_status",
+    "webhook_url_cp_meter",
+    "webhook_url_tx_started",
+    "webhook_url_tx_stopped",
+    "webhook_enable_cp_boot",
+    "webhook_enable_cp_online",
+    "webhook_enable_cp_offline",
+    "webhook_enable_cp_status",
+    "webhook_enable_cp_meter",
+    "webhook_enable_tx_started",
+    "webhook_enable_tx_stopped",
 ]

--- a/src/eveys_ocpp/webhooks/dispatcher.py
+++ b/src/eveys_ocpp/webhooks/dispatcher.py
@@ -29,6 +29,7 @@ from aiokafka import AIOKafkaConsumer
 from eveys_ocpp._generated.events.v1 import events_pb2
 from eveys_ocpp.metrics import registry as metrics_registry
 from eveys_ocpp.observability import get_logger
+from eveys_ocpp.runtime_overrides import get_override
 from eveys_ocpp.webhooks.signer import compute_signature
 
 if TYPE_CHECKING:
@@ -334,6 +335,16 @@ class WebhookDispatcher:
 
     # ---- envelope → wire body ---------------------------------------------
 
+    def _enabled(self, name: str, default: bool) -> bool:
+        return bool(get_override(name, default))
+
+    def _url(self, name: str, default: str) -> str:
+        value = get_override(name, default)
+        return value if isinstance(value, str) else default
+
+    def _base_url(self) -> str:
+        return self._url("webhook_base_url", self._settings.webhook_base_url)
+
     def _build_body(self, envelope: events_pb2.EventEnvelope) -> dict[str, Any] | None:
         """Translate one EventEnvelope to the webhook JSON body, per
         `docs/integration/03-webhooks.md` § Event catalog. Returns
@@ -347,7 +358,9 @@ class WebhookDispatcher:
         them.
         """
         kind = envelope.WhichOneof("payload")
-        if kind == "cp_connected" and self._settings.webhook_enable_cp_online:
+        if kind == "cp_connected" and self._enabled(
+            "webhook_enable_cp_online", self._settings.webhook_enable_cp_online
+        ):
             p = envelope.cp_connected
             data = {
                 "event_id": envelope.event_id,
@@ -359,7 +372,9 @@ class WebhookDispatcher:
             }
             return _envelope(data)
 
-        if kind == "cp_disconnected" and self._settings.webhook_enable_cp_offline:
+        if kind == "cp_disconnected" and self._enabled(
+            "webhook_enable_cp_offline", self._settings.webhook_enable_cp_offline
+        ):
             p_off = envelope.cp_disconnected
             data = {
                 "event_id": envelope.event_id,
@@ -371,7 +386,9 @@ class WebhookDispatcher:
             }
             return _envelope(data)
 
-        if kind == "cp_boot" and self._settings.webhook_enable_cp_boot:
+        if kind == "cp_boot" and self._enabled(
+            "webhook_enable_cp_boot", self._settings.webhook_enable_cp_boot
+        ):
             p = envelope.cp_boot
             data = {
                 "event_id": envelope.event_id,
@@ -386,7 +403,9 @@ class WebhookDispatcher:
             }
             return _envelope(data)
 
-        if kind == "cp_status" and self._settings.webhook_enable_cp_status:
+        if kind == "cp_status" and self._enabled(
+            "webhook_enable_cp_status", self._settings.webhook_enable_cp_status
+        ):
             p = envelope.cp_status
             data = {
                 "event_id": envelope.event_id,
@@ -403,7 +422,9 @@ class WebhookDispatcher:
             }
             return _envelope(data)
 
-        if kind == "tx_started" and self._settings.webhook_enable_tx_started:
+        if kind == "tx_started" and self._enabled(
+            "webhook_enable_tx_started", self._settings.webhook_enable_tx_started
+        ):
             p = envelope.tx_started
             data = {
                 "event_id": envelope.event_id,
@@ -417,7 +438,9 @@ class WebhookDispatcher:
             }
             return _envelope(data)
 
-        if kind == "tx_stopped" and self._settings.webhook_enable_tx_stopped:
+        if kind == "tx_stopped" and self._enabled(
+            "webhook_enable_tx_stopped", self._settings.webhook_enable_tx_stopped
+        ):
             p = envelope.tx_stopped
             data = {
                 "event_id": envelope.event_id,
@@ -441,20 +464,46 @@ class WebhookDispatcher:
         """URL for this envelope's event type, or None if disabled."""
         kind = envelope.WhichOneof("payload")
         s = self._settings
-        if kind == "cp_connected" and s.webhook_enable_cp_online:
-            return s.webhook_url_cp_online or f"{s.webhook_base_url}/cp-online"
-        if kind == "cp_disconnected" and s.webhook_enable_cp_offline:
-            return s.webhook_url_cp_offline or f"{s.webhook_base_url}/cp-offline"
-        if kind == "cp_boot" and s.webhook_enable_cp_boot:
-            return s.webhook_url_cp_boot or f"{s.webhook_base_url}/cp-boot"
-        if kind == "cp_status" and s.webhook_enable_cp_status:
-            return s.webhook_url_cp_status or f"{s.webhook_base_url}/cp-status-changed"
-        if kind == "cp_meter" and s.webhook_enable_cp_meter:
-            return s.webhook_url_cp_meter or f"{s.webhook_base_url}/cp-meter"
-        if kind == "tx_started" and s.webhook_enable_tx_started:
-            return s.webhook_url_tx_started or f"{s.webhook_base_url}/tx-started"
-        if kind == "tx_stopped" and s.webhook_enable_tx_stopped:
-            return s.webhook_url_tx_stopped or f"{s.webhook_base_url}/tx-stopped"
+        if kind == "cp_connected" and self._enabled(
+            "webhook_enable_cp_online", s.webhook_enable_cp_online
+        ):
+            return self._url("webhook_url_cp_online", s.webhook_url_cp_online) or (
+                f"{self._base_url()}/cp-online"
+            )
+        if kind == "cp_disconnected" and self._enabled(
+            "webhook_enable_cp_offline", s.webhook_enable_cp_offline
+        ):
+            return self._url("webhook_url_cp_offline", s.webhook_url_cp_offline) or (
+                f"{self._base_url()}/cp-offline"
+            )
+        if kind == "cp_boot" and self._enabled("webhook_enable_cp_boot", s.webhook_enable_cp_boot):
+            return self._url("webhook_url_cp_boot", s.webhook_url_cp_boot) or (
+                f"{self._base_url()}/cp-boot"
+            )
+        if kind == "cp_status" and self._enabled(
+            "webhook_enable_cp_status", s.webhook_enable_cp_status
+        ):
+            return self._url("webhook_url_cp_status", s.webhook_url_cp_status) or (
+                f"{self._base_url()}/cp-status-changed"
+            )
+        if kind == "cp_meter" and self._enabled(
+            "webhook_enable_cp_meter", s.webhook_enable_cp_meter
+        ):
+            return self._url("webhook_url_cp_meter", s.webhook_url_cp_meter) or (
+                f"{self._base_url()}/cp-meter"
+            )
+        if kind == "tx_started" and self._enabled(
+            "webhook_enable_tx_started", s.webhook_enable_tx_started
+        ):
+            return self._url("webhook_url_tx_started", s.webhook_url_tx_started) or (
+                f"{self._base_url()}/tx-started"
+            )
+        if kind == "tx_stopped" and self._enabled(
+            "webhook_enable_tx_stopped", s.webhook_enable_tx_stopped
+        ):
+            return self._url("webhook_url_tx_stopped", s.webhook_url_tx_stopped) or (
+                f"{self._base_url()}/tx-stopped"
+            )
         return None
 
     def _enabled_topics(self) -> tuple[str, ...]:

--- a/tests/unit/api/test_admin.py
+++ b/tests/unit/api/test_admin.py
@@ -184,3 +184,113 @@ async def test_delete_on_unset_key_is_idempotent(
 
     assert response.status_code == 200
     assert response.json()["cleared"] is False
+
+
+# --- webhook allowlist additions ----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_allowlist_includes_webhook_fields(
+    client: httpx.AsyncClient,
+) -> None:
+    """The operator UI uses the allowlist to render the right form
+    controls. Every field PATCH will now accept must show up here."""
+    response = await client.get("/api/v1/admin/config")
+
+    assert response.status_code == 200, response.text
+    allowlist = response.json()["allowlist"]
+    expected = {
+        "webhook_base_url",
+        "webhook_url_cp_boot",
+        "webhook_url_cp_online",
+        "webhook_url_cp_offline",
+        "webhook_url_cp_status",
+        "webhook_url_cp_meter",
+        "webhook_url_tx_started",
+        "webhook_url_tx_stopped",
+        "webhook_enable_cp_boot",
+        "webhook_enable_cp_online",
+        "webhook_enable_cp_offline",
+        "webhook_enable_cp_status",
+        "webhook_enable_cp_meter",
+        "webhook_enable_tx_started",
+        "webhook_enable_tx_stopped",
+    }
+    missing = expected - set(allowlist)
+    assert not missing, f"missing from allowlist: {missing}"
+
+
+@pytest.mark.asyncio
+async def test_patch_webhook_url_with_valid_http_value(
+    client: httpx.AsyncClient,
+) -> None:
+    response = await client.patch(
+        "/api/v1/admin/config",
+        json={"updates": {"webhook_url_cp_boot": "https://hooks.example.com/cp-boot-v2"}},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["applied"] == {
+        "webhook_url_cp_boot": "https://hooks.example.com/cp-boot-v2"
+    }
+
+
+@pytest.mark.asyncio
+async def test_patch_webhook_url_accepts_empty_for_fallback(
+    client: httpx.AsyncClient,
+) -> None:
+    """Empty string is the sentinel for "fall back to <base>/<event>"
+    in the dispatcher; the per-event URL coerce must accept it."""
+    response = await client.patch(
+        "/api/v1/admin/config",
+        json={"updates": {"webhook_url_cp_boot": ""}},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["applied"] == {"webhook_url_cp_boot": ""}
+
+
+@pytest.mark.asyncio
+async def test_patch_webhook_url_rejects_non_http(
+    client: httpx.AsyncClient,
+) -> None:
+    response = await client.patch(
+        "/api/v1/admin/config",
+        json={"updates": {"webhook_url_cp_boot": "ftp://hooks.example.com/cp-boot"}},
+    )
+
+    assert response.status_code == 400, response.text
+    error = response.json()["error"]
+    assert "webhook_url_cp_boot" in error
+    assert "http" in error.lower()
+
+
+@pytest.mark.asyncio
+async def test_patch_webhook_base_url_rejects_empty(
+    client: httpx.AsyncClient,
+) -> None:
+    """Clearing the base URL would disable the dispatcher entirely —
+    that's a deploy-time call, not a runtime override. The coerce
+    rejects so an operator can't accidentally take delivery offline."""
+    response = await client.patch(
+        "/api/v1/admin/config",
+        json={"updates": {"webhook_base_url": ""}},
+    )
+
+    assert response.status_code == 400, response.text
+    assert "webhook_base_url" in response.json()["error"]
+
+
+@pytest.mark.asyncio
+async def test_patch_webhook_enable_flag_with_tolerant_bool(
+    client: httpx.AsyncClient,
+) -> None:
+    """The bool coerce takes JSON `false`, the string `"false"`, and
+    the int `0` interchangeably — operator tooling varies."""
+    for raw in ("false", False, 0):
+        response = await client.patch(
+            "/api/v1/admin/config",
+            json={"updates": {"webhook_enable_cp_boot": raw}},
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()["applied"] == {"webhook_enable_cp_boot": False}


### PR DESCRIPTION
Closes #170.

## What

Expand the `/api/v1/admin/config` allowlist from 3 fields to 18 by adding the webhook delivery surface:

- `webhook_base_url` (URL, non-empty — clearing it disables the dispatcher entirely, which is a deploy-time call)
- 7 per-event URL overrides (`webhook_url_cp_boot`, `_cp_online`, `_cp_offline`, `_cp_status`, `_cp_meter`, `_tx_started`, `_tx_stopped`) — empty string falls back to `<base>/<event-slug>`
- 7 per-event enable flags (`webhook_enable_*`)

Two new coerce helpers next to `_coerce_log_level` / `_coerce_bool`:

- `_coerce_url_or_empty` — accepts `""` or `http(s)://...`, used by the per-event URL overrides
- `_coerce_url` — like above but rejects `""`, used only by `webhook_base_url`

The dispatcher (`webhooks/dispatcher.py`) gets a small refactor so the per-event reads consult the runtime-override store. Three private helpers (`_enabled`, `_url`, `_base_url`) wrap `get_override(...)` with a `Settings` fallback. `_build_body` and `_url_for` use those helpers; nothing else moves.

## Asymmetry, called out in the descriptions

`_enabled_topics()` is invoked once at consumer startup and stays on `Settings` — that's deliberate. So:

- Turning an enable flag **OFF** is fully live (delivery suppressed on the next event).
- Turning an enable flag **ON** is live **only if** that event was already enabled at boot. Otherwise the Kafka topic isn't subscribed and a pod restart is needed.

The allowlist `description` for every `webhook_enable_*` entry says this in plain terms so an operator doesn't flip a flag, see no deliveries, and assume the runtime is broken.

## Tests

6 new tests in `tests/unit/api/test_admin.py`:

- allowlist exposes the new field names
- valid HTTPS URL accepted on a per-event override
- empty string accepted on a per-event override (the fallback sentinel)
- non-HTTP scheme rejected with the field name + "http" in the error
- empty string rejected for `webhook_base_url`
- tolerant bool coercion on enable flags (`"false"`, `False`, `0` → `False`)

Targeted: `pytest tests/unit/api/test_admin.py tests/unit/webhooks/` → 56 passed (50 existing + 6 new). Full unit: 817 passed, coverage 83.32% (gate is 80%).

## Out of scope

- `backend_register_fallback` and `heartbeat_interval_seconds` are read fresh per `BootNotification` and would be safe to allowlist too, but they need handler-side wiring across multiple files. Separate PR.
- Cluster-wide propagation of overrides (Redis pub/sub) — `runtime_overrides` is per-pod by design; documented in the module docstring.

## Test plan

- [x] `pytest tests/unit/api/test_admin.py tests/unit/webhooks/ --no-cov -q` — 56 passed
- [x] `pytest tests/unit -q` — 817 passed, coverage 83.32%
- [x] `make lint` — clean
- [x] `make config-export-check` — up to date
- [x] `make openapi-export-check` — up to date