### PR TITLE
fix(make): tolerate pre-commit cowardly-refusing when core.hooksPath set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,10 +94,24 @@ install: $(VENV)/bin/python
 	@$(MAKE) protoc
 	@# Activate pre-commit hooks if the config exists. Idempotent — safe
 	@# to re-run; pre-commit detects an already-installed hook script.
+	@#
+	@# `pre-commit install` returns non-zero ("cowardly refusing") when
+	@# `core.hooksPath` is set, even to the default `.git/hooks`. That's
+	@# a tooling-side opt-out, not an installation failure — treat it
+	@# as benign and print the same hint pre-commit prints. Without
+	@# this guard, every `make install` on a laptop with that config
+	@# returns 1, which cascades through every dependent target
+	@# (`lint`, `types`, `openapi-export-check`, …).
 	@if [ -f .pre-commit-config.yaml ] && [ -d .git ]; then \
-		$(VENV)/bin/pre-commit install --install-hooks >/dev/null 2>&1 && \
-		$(VENV)/bin/pre-commit install --hook-type commit-msg >/dev/null 2>&1 && \
-		echo "pre-commit hooks installed" >&2; \
+		out=$$($(VENV)/bin/pre-commit install --install-hooks 2>&1); rc=$$?; \
+		if [ $$rc -eq 0 ]; then \
+			$(VENV)/bin/pre-commit install --hook-type commit-msg >/dev/null 2>&1 && \
+				echo "pre-commit hooks installed" >&2; \
+		elif echo "$$out" | grep -q "core.hooksPath"; then \
+			echo "pre-commit skipped: core.hooksPath is set (run \`git config --unset core.hooksPath\` to enable hook install)" >&2; \
+		else \
+			echo "$$out" >&2; exit $$rc; \
+		fi; \
 	fi
 
 # Regenerate Python stubs from proto/ into src/eveys_ocpp/_generated/.

--- a/docs/04-contributing.md
+++ b/docs/04-contributing.md
@@ -34,6 +34,8 @@ Every PR must:
 - **stock hygiene** — trailing whitespace, end-of-file fixer, large-file guard, merge-conflict markers, mixed line endings.
 - **conventional-pre-commit** — enforces the commit-message format below.
 
+If `make install` prints `pre-commit skipped: core.hooksPath is set`, your repo has `core.hooksPath` configured (often by an editor / dev-environment manager). Pre-commit refuses to install when that's set — even to the default `.git/hooks`. Run `git config --unset core.hooksPath` to enable hook auto-install. The rest of `make install` succeeds either way; you can also invoke the hooks manually with `pre-commit run --all-files`.
+
 To run the hooks against the whole tree without committing:
 
 ```bash


### PR DESCRIPTION
## Summary

`make install` exits 1 on any laptop where the repo has `core.hooksPath` set (often by an editor or dev-environment manager), even when set to the default `.git/hooks`. `pre-commit install` refuses with 'Cowardly refusing to install hooks with `core.hooksPath` set' — exit code propagates through the Makefile's `&&`-chain.

**Cascading effect**: every target that depends on `install` (most of them — `lint`, `types`, `tests`, `format`, `openapi-export-check`, `config-export-check`, `compose-up`, …) inherits the failure even though the actual work succeeded. User-facing symptom: `make: *** [install] Error 1` after every otherwise-successful run.

Surfaced when the full local quality sweep (`pytest tests/unit` 837 ✅, `ruff check .` ✅, `mypy src` ✅, direct doc-snapshot scripts ✅) all passed but make-driven targets returned 1.

## Fix

Per AGENTS rule 'never modify git config,' the right fix is on the Makefile side: treat pre-commit's cowardly-refusing exit as a benign skip with a clear hint pointing at the same `git config --unset core.hooksPath` line pre-commit itself prints. Other failure modes (missing config file, broken venv, etc.) still propagate as before.

Brief note added to `docs/04-contributing.md` so contributors who hit the message understand it's a tooling opt-out, not a bug.

## Test plan

- [x] `make install` → exits 0 with the new hint when `core.hooksPath` is set.
- [x] `make openapi-export-check` and `make config-export-check` now run cleanly through the chained `install` dependency. No drift in either snapshot.
- [x] `pytest tests/unit` — 837 pass, 83.48% coverage.

Closes #178