### PR TITLE
docs(userdocs): add end-user documentation set

### DIFF
--- a/userdocs/01-what-is-this.md
+++ b/userdocs/01-what-is-this.md
@@ -1,0 +1,133 @@
+# What is eveys/ocpp?
+
+**Audience.** Anyone evaluating this project for the first time.
+
+**What this answers.** What the gateway does, what OCPP is in 60 seconds, where this fits in a charging platform, and what it deliberately does not do.
+
+---
+
+## In one paragraph
+
+**eveys/ocpp** is a production-ready gateway service for an EV-charging platform. It owns every EV charger's WebSocket connection, speaks the OCPP protocol on that socket, and gives the rest of your platform a clean, stable surface — REST and gRPC for sending commands, Kafka and webhooks for receiving events. It is horizontally scalable, fully containerised, and Apache-2.0 licensed.
+
+---
+
+## OCPP in 60 seconds
+
+OCPP — the **Open Charge Point Protocol** — is the industry-standard language EV chargers use to talk to a central management system. A charger opens a single long-lived **WebSocket** connection to that system on boot and keeps it open for its entire operational life, reconnecting if the link drops.
+
+Over that socket, two flows happen:
+
+1. **The charger initiates.** "I just booted." "Here's a heartbeat." "User RFID-12345 tapped, can they charge?" "Here's a meter reading every 30 seconds." "The session just ended; the meter went from 12,345 Wh to 18,902 Wh."
+2. **The central system initiates.** "Start charging on connector 1 for user RFID-12345." "Stop the current session." "Reset yourself." "Unlock the cable."
+
+Both directions use the same JSON-RPC-ish envelope; each message has a schema and a tightly bounded set of allowed values. The protocol is the contract between the charger manufacturer and the platform.
+
+The two versions that matter today are **OCPP 1.6-J** (the de-facto incumbent, widely deployed) and **OCPP 2.0.1** (the security-hardened successor, gaining ground). This gateway speaks both.
+
+You do not need to be an OCPP expert to use this project. The terms you will meet — `BootNotification`, `Authorize`, `StartTransaction`, `MeterValues`, `StopTransaction`, `RemoteStart` — each get a one-line definition in [`04-glossary.md`](./04-glossary.md), and the end-to-end picture is in [`concepts/how-ocpp-flows-work.md`](./concepts/how-ocpp-flows-work.md).
+
+---
+
+## What this gateway owns
+
+It owns the WebSocket. That's the load-bearing point.
+
+Every charger in your fleet has exactly one TCP/TLS WebSocket connection open to this gateway. Some of those chargers are sending a heartbeat every 30 seconds; some are mid-session reporting meter readings every 60 seconds; some are idle but online; some are in a fault state.
+
+The gateway:
+
+- **Terminates the WebSocket.** Negotiates the OCPP subprotocol (`ocpp1.6` or `ocpp2.0.1`), authenticates the charger (Basic Auth, mTLS at the edge, or both), and keeps the socket alive.
+- **Schema-validates every message** against the published OCPP JSON schemas. Malformed messages are rejected at the wire boundary; your platform never sees them.
+- **Routes inbound events.** Persists what needs persisting (transactions, status, telemetry), and publishes envelopes to Kafka topics for downstream consumers — your billing engine, your dashboards, your alerting.
+- **Dispatches outbound commands.** When your backend says "remote start", the gateway finds the right charger's socket (even if it's on a different pod), serialises the OCPP `RemoteStartTransaction.req`, sends it, waits for the reply, and returns the result.
+- **Survives reconnects, restarts, and pod failures.** Chargers reconnect to whichever pod they land on; the gateway tracks "which pod has which charger" through a Redis-backed online registry and routes commands across pods over a pub/sub bus.
+
+---
+
+## What this gateway does *not* own
+
+A common source of confusion: the gateway is **not** the rest of your platform. It does not:
+
+- **Authenticate end users.** When a user taps an RFID card, the gateway receives an `Authorize` request from the charger and asks *your backend* "is this user allowed to charge?". Your backend owns the user database, the wallet, the tariff. The gateway forwards the answer to the charger verbatim.
+- **Bill or invoice.** The gateway publishes session start, session stop, and meter readings. Your billing service consumes those events and produces invoices.
+- **Manage chargers as physical assets.** Site IDs, asset tags, geo-location, install date — those belong in your asset-management system. The gateway only cares about each charger's logical identifier (`cp_id`) and current connectivity state.
+- **Run the smart-charging algorithm.** It accepts charging profiles from your platform and forwards them to chargers; the chargers themselves resolve which profile is active at any moment. The gateway is the transport, not the optimiser.
+- **Provide a user-facing UI.** It exposes REST and gRPC for your apps and dashboards to consume. Building those is your team's job.
+
+The boundary is deliberate. The gateway is the single component that has to know OCPP intimately; everything else on your platform consumes a clean, OCPP-free contract.
+
+---
+
+## How it fits into a charging platform
+
+```
+                                Chargers
+                                   │ WSS / OCPP-J
+                                   ▼
+                         ┌──────────────────┐
+                         │   eveys/ocpp     │   ← you are here
+                         │   the gateway    │
+                         └────┬──────┬──────┘
+                              │      │
+        REST + gRPC (commands)│      │ Kafka + webhooks (events)
+                              │      ▼
+                              │   ┌────────────────────────────────┐
+                              │   │ Your platform                  │
+                              └──►│  (auth · sessions · billing ·  │
+                                  │   dashboards · alerting · ...)  │
+                                  └────────────────────────────────┘
+```
+
+Your platform reaches chargers *through* the gateway. It learns about charger events by tailing Kafka topics or by receiving webhook deliveries. It never opens a WebSocket of its own.
+
+That asymmetry is the whole product:
+
+- **The gateway speaks OCPP** so you don't have to write a single line of `mobilityhouse/ocpp` glue in your business code.
+- **Your platform speaks REST, gRPC, Kafka, and webhooks** — surfaces every backend team already knows.
+
+---
+
+## What you get out of the box
+
+- **OCPP 1.6 Core profile**: BootNotification, Heartbeat, StatusNotification, Authorize, StartTransaction, MeterValues, StopTransaction, DataTransfer — every inbound message handled and persisted; every outbound command (RemoteStart, RemoteStop, Reset, UnlockConnector, ChangeAvailability, ChangeConfiguration, GetConfiguration, ClearCache, TriggerMessage, DataTransfer) dispatched and round-tripped.
+- **OCPP 1.6 LocalAuthList**, **Reservations**, **SmartCharging**, **Firmware Management**, and the **Security Whitepaper** extensions (security events, signed firmware updates, certificate install/delete, log retrieval, CSR signing). Coverage continues to expand toward OCPP 2.0.1.
+- **REST API** for backend integration, with bearer-token auth, cursor pagination, a stable error envelope, and an OpenAPI schema served at `/api/v1/openapi.json`.
+- **gRPC API** for the same operations at lower overhead; protobuf definitions are part of the release.
+- **Kafka event topics** carrying a versioned protobuf envelope: `cp.boot`, `cp.status`, `cp.meter`, `cp.connected`, `cp.disconnected`, `cp.firmware_status`, `cp.diagnostics_status`, `cp.security_event`, `cp.csr_submitted`, `tx.started`, `tx.stopped`.
+- **Webhooks** carrying the same envelopes for backends that prefer push delivery to consuming Kafka.
+- **Prometheus metrics**, structured JSON logs, OpenTelemetry traces.
+- **Horizontal scaling.** Envoy ring-hashes chargers to pods by `cp_id`; the gateway uses Redis as an online registry and pub/sub bus so commands routed to the wrong pod find their way home. Pods drain cleanly on `SIGTERM`.
+- **Helm chart and Docker images** ready for production use.
+
+---
+
+## What it costs to run
+
+The runtime stack is:
+
+- **The gateway pods** themselves — Python 3.13 on `asyncio` + `uvloop`. Each pod handles hundreds to low-thousands of concurrent charger sockets depending on traffic pattern and instance size.
+- **Postgres** for relational state (chargers, transactions, reservations, charging profiles, security events).
+- **Redis** for the online registry, the cross-pod command bus, the Authorize cache, and idempotency tracking.
+- **Kafka** for the event firehose.
+- **ClickHouse** for time-series telemetry (meter readings, status history). Optional but recommended at scale.
+- **Envoy** in front of the pods, providing TLS termination and ring-hash routing on `cp_id`.
+
+The Quickstart ([`02-quickstart.md`](./02-quickstart.md)) brings all of these up locally on a laptop via Docker Compose in about 30 seconds.
+
+---
+
+## What this gateway is not
+
+- **Not a charger emulator.** It speaks OCPP *to* chargers; it doesn't pretend to *be* one.
+- **Not a billing system.** It publishes events; the rest is yours.
+- **Not OCPP-certified yet.** Implementation is complete and unit-tested against the published schemas; formal OCTT (Open Charge Alliance Testing Tool) certification requires OCA membership and is on a separate track. Until that lands, treat the gateway as conformant-by-implementation rather than conformant-by-certification.
+- **Not bundled with a frontend.** This is a gateway service, not a platform-in-a-box.
+
+---
+
+## Where to go from here
+
+- Trying it for the first time: [`02-quickstart.md`](./02-quickstart.md).
+- Need to understand the surfaces before integrating: [`03-architecture.md`](./03-architecture.md).
+- Coming back to look up an OCPP term: [`04-glossary.md`](./04-glossary.md).

--- a/userdocs/02-quickstart.md
+++ b/userdocs/02-quickstart.md
@@ -1,0 +1,178 @@
+# Quickstart — boot a charger, send a command, see an event
+
+**Audience.** A developer trying the gateway for the first time. Docker Desktop on a laptop is enough.
+
+**What this answers.** Bring the stack up, point a simulated charger at it, send a `RemoteStart` over REST, and watch the matching event land in Kafka.
+
+This takes about ten minutes start to finish, most of which is the first-time image pull.
+
+---
+
+## What you'll have running
+
+```
+   tools.sim charger(s)            eveys/ocpp gateway pod          Postgres / Redis / Kafka / ClickHouse
+   ─────────────────────           ────────────────────────         ────────────────────────────────────
+   ws://localhost:19000  ◄──────►  WS  :9000  (host :19000)         in their own containers
+   (you run this last)             REST :8080 (host :8080)
+                                   gRPC :50051
+                                   metrics :9100
+```
+
+Four containers come up alongside the gateway. You don't need to know their internals — just that they're managed by `docker compose` and you can tear them down in one command at the end.
+
+---
+
+## Prerequisites
+
+| Tool | Why |
+|---|---|
+| Docker Desktop 4.30+ (or Docker Engine + Compose v2) | Brings up the stack. |
+| `make` | One-liner targets. |
+| Python 3.13 + [`uv`](https://docs.astral.sh/uv/) | The simulator runs as a Python module. `uv` installs deps in seconds. |
+| `curl` | For the REST call. Anything that POSTs JSON will do. |
+
+To confirm everything's installed:
+
+```bash
+docker --version && docker compose version && make --version && python3 --version && uv --version
+```
+
+If any of those is missing, install it and come back.
+
+---
+
+## 1. Clone the repository
+
+```bash
+git clone https://github.com/eveys-mobility/OCPP.git
+cd OCPP
+```
+
+## 2. Install the Python deps once
+
+Used by the simulator and by a few helper scripts:
+
+```bash
+make install
+```
+
+This creates a `.venv/`, installs the package in editable mode with dev extras, and registers pre-commit hooks. Takes 30–60 seconds the first time.
+
+## 3. Bring the stack up
+
+```bash
+make compose-up
+```
+
+This:
+
+- Pulls Postgres, Redis, Kafka, ClickHouse, Envoy, and the gateway image.
+- Runs database migrations against Postgres and ClickHouse.
+- Starts every container and waits until the gateway answers `200 OK` on `/api/v1/ready`.
+
+Expect 60–90 seconds the first time (image pulls). Subsequent runs take ~10 seconds.
+
+You're ready when `make compose-up` exits 0. Confirm with:
+
+```bash
+curl -s http://localhost:8080/api/v1/ready
+```
+
+You should see a JSON document with `"status": "ready"`.
+
+## 4. Point a virtual charger at the gateway
+
+Open a second terminal so you can watch its output while you drive the REST API:
+
+```bash
+.venv/bin/python -m tools.sim --count 1 --duration 600 --target ws://localhost:19000
+```
+
+That brings up one simulated OCPP 1.6 charger called `sim-cp-001` (the default) and keeps it connected for ten minutes. You'll see structured log lines as it sends a `BootNotification`, starts heartbeating, and reports a `StatusNotification` of `Available`.
+
+The charger is now online. You can prove that to yourself from another terminal:
+
+```bash
+curl -s http://localhost:8080/api/v1/charge-points/sim-cp-001 \
+  -H "Authorization: Bearer change-me-in-dev" | python3 -m json.tool
+```
+
+`last_boot_at` is freshly populated and the `connectors` array shows the connector state.
+
+> **Note on auth.** The local stack ships with `EVEYS_OCPP_REST_INBOUND_TOKENS=change-me-in-dev`. That's a development default. Never set the same value in production — see [`concepts/security-model.md`](./concepts/security-model.md).
+
+## 5. Send a command
+
+Tell the gateway to start a charging session on connector 1:
+
+```bash
+curl -s -X POST http://localhost:8080/api/v1/charge-points/sim-cp-001/commands/remote-start \
+  -H "Authorization: Bearer change-me-in-dev" \
+  -H "Content-Type: application/json" \
+  -d '{"id_tag": "TEST_TAG_001", "connector_id": 1}' \
+  | python3 -m json.tool
+```
+
+The response is `{"status": "Accepted", ...}`. The simulator's terminal will print a `StartTransaction.req` and the gateway will reply with a `transactionId` (the simulator logs both sides).
+
+## 6. Watch the event land in Kafka
+
+Open a third terminal. The Kafka container is reachable on `localhost:9092` from the host:
+
+```bash
+docker exec -it eveys-ocpp-kafka \
+  kafka-console-consumer.sh \
+    --bootstrap-server localhost:9092 \
+    --topic tx.started \
+    --from-beginning
+```
+
+You'll see a single protobuf-encoded message: the `EventEnvelope` carrying the `TxStarted` payload that the gateway published when your `RemoteStart` resulted in a `StartTransaction`. (It's binary; for a human-readable view, [`reference/events.md`](./reference/events.md) shows how to deserialise it.)
+
+## 7. Stop the session
+
+```bash
+curl -s -X POST http://localhost:8080/api/v1/charge-points/sim-cp-001/commands/remote-stop \
+  -H "Authorization: Bearer change-me-in-dev" \
+  -H "Content-Type: application/json" \
+  -d '{"transaction_id": 1}' \
+  | python3 -m json.tool
+```
+
+(Replace `1` with whatever `transactionId` came back in step 5.)
+
+A `tx.stopped` event lands on the corresponding Kafka topic. Both events are also delivered as webhooks if you configure a destination — see [`guides/consume-events.md`](./guides/consume-events.md).
+
+## 8. Tear it down
+
+```bash
+make compose-down
+```
+
+This stops the containers but **keeps your data volumes**. Next `make compose-up` resumes against the same state.
+
+If you want a clean slate:
+
+```bash
+make compose-down-volumes
+```
+
+Drops the volumes too. Destructive — only use it when you want to start over.
+
+---
+
+## What just happened
+
+You ran the gateway against a real data plane. A virtual charger logged in over WebSocket, you sent a backend-style REST call, the gateway found the charger's socket and dispatched the OCPP `RemoteStartTransaction.req`, the charger replied, the resulting `StartTransaction` got persisted to Postgres, and the gateway published a `TxStarted` envelope to Kafka.
+
+That's the whole loop. Everything else in this documentation set elaborates on one of those steps.
+
+---
+
+## Where to go from here
+
+- **Curious how the pieces fit together?** [`03-architecture.md`](./03-architecture.md).
+- **Want to connect a real charger?** [`guides/connect-a-charger.md`](./guides/connect-a-charger.md).
+- **Building a backend integration?** [`guides/use-the-rest-api.md`](./guides/use-the-rest-api.md) and [`guides/consume-events.md`](./guides/consume-events.md).
+- **Want to understand the OCPP terms you just saw?** [`04-glossary.md`](./04-glossary.md).

--- a/userdocs/03-architecture.md
+++ b/userdocs/03-architecture.md
@@ -1,0 +1,140 @@
+# Architecture at a glance
+
+**Audience.** Anyone deciding whether to integrate or operate this gateway.
+
+**What this answers.** One diagram, one page. The four surfaces, what owns what, and where state lives.
+
+---
+
+## The one diagram
+
+```
+                      Chargers (1 ... N)
+                              │
+                              │ WSS / OCPP 1.6-J  (or 2.0.1)
+                              ▼
+                    ┌──────────────────┐
+                    │      Envoy       │   TLS termination
+                    │   ring-hash by   │   Sticky routing on cp_id
+                    │       cp_id      │
+                    └────────┬─────────┘
+                             │
+                ┌────────────┼────────────┐
+                │            │            │
+                ▼            ▼            ▼
+        ┌────────────┐ ┌────────────┐ ┌────────────┐
+        │  Gateway   │ │  Gateway   │ │  Gateway   │     N pods, stateless
+        │   pod #1   │ │   pod #2   │ │   pod #N   │     Each owns ~few-K sockets
+        └─────┬──────┘ └─────┬──────┘ └─────┬──────┘
+              │              │              │
+              │              │              │
+       ┌──────┴──────────────┴──────────────┴──────┐
+       │                                            │
+       ▼                                            ▼
+  ┌─────────────────┐                  ┌──────────────────────┐
+  │ Shared state    │                  │  Event distribution  │
+  │                 │                  │                      │
+  │  Postgres       │ ◄── relational   │  Kafka topics        │ ──► Your consumers
+  │  Redis          │     state        │  Webhook deliveries  │ ──► Your endpoints
+  │  ClickHouse     │ ◄── time-series  │                      │
+  └─────────────────┘                  └──────────────────────┘
+
+         ▲                                       ▲
+         │                                       │
+         │  REST  / gRPC                         │
+         │  (commands, queries)                  │
+         │                                       │
+         └──────── Your platform ────────────────┘
+```
+
+That's everything. Below is what each part of it is for.
+
+---
+
+## The four surfaces
+
+The gateway exposes — and consumes — four interfaces. Pick the one that matches your role.
+
+### 1. WebSocket (charger-facing, inbound)
+
+- **Who:** every EV charger in your fleet.
+- **Protocol:** OCPP 1.6-J or OCPP 2.0.1 over WebSocket Secure.
+- **Auth:** per-charger Basic Auth credentials and/or client mTLS at the Envoy edge.
+- **Direction:** bidirectional. Chargers initiate `BootNotification`, `Heartbeat`, `StatusNotification`, `Authorize`, `StartTransaction`, `MeterValues`, `StopTransaction`, `DataTransfer`, security events, firmware/diagnostics status, CSR submissions. The gateway initiates `RemoteStartTransaction`, `RemoteStopTransaction`, `Reset`, `UnlockConnector`, `ChangeAvailability`, `ChangeConfiguration`, `GetConfiguration`, `ClearCache`, `TriggerMessage`, smart-charging profile operations, local-list updates, reservations, certificate install/delete, firmware updates, log retrieval, and `DataTransfer`.
+- **Hostport in dev:** `ws://localhost:19000/<cp_id>`. In production it's `wss://...` behind Envoy.
+
+You don't talk to this surface unless you're a charger.
+
+### 2. REST + gRPC (platform-facing, outbound from your code)
+
+- **Who:** your backend service, your operations dashboard, your scripts.
+- **Protocol:** HTTP/1.1 (REST) on port `8080`, HTTP/2 (gRPC) on port `50051`. Both speak the same operations; gRPC is lower overhead, REST is more familiar.
+- **Auth:** bearer token in `Authorization: Bearer <token>`. Tokens are a CSV in the gateway's config.
+- **Direction:** request/response. Your code calls; the gateway answers.
+- **What's on it:** list chargers, fetch one charger, list transactions, fetch transactions with telemetry, list / approve / reject pending CSRs, query meter-value time series, query status history — plus every OCPP-initiated command above wrapped as a `POST .../commands/<verb>`.
+
+Full surface in [`reference/rest-api.md`](./reference/rest-api.md) and [`reference/grpc-api.md`](./reference/grpc-api.md).
+
+### 3. Kafka (events firehose, outbound from gateway)
+
+- **Who:** any number of consumers in your platform.
+- **Protocol:** Kafka. Payload is a versioned protobuf `EventEnvelope` carrying a `oneof payload`.
+- **Direction:** the gateway publishes; you consume.
+- **Topics in scope today:** `cp.connected`, `cp.disconnected`, `cp.boot`, `cp.status`, `cp.meter`, `cp.firmware_status`, `cp.diagnostics_status`, `cp.security_event`, `cp.csr_submitted`, `tx.started`, `tx.stopped`.
+- **Partition key:** every record uses `cp_id`. Per-charger ordering is preserved; cross-charger ordering is not.
+
+Topics and envelope shapes in [`reference/events.md`](./reference/events.md).
+
+### 4. Webhooks (events for backends that prefer push, outbound from gateway)
+
+- **Who:** your backend, if you'd rather receive HTTP POSTs than tail Kafka.
+- **Protocol:** HTTPS POST with an HMAC signature header.
+- **Direction:** the gateway calls your endpoints.
+- **Delivery:** at-least-once, with exponential backoff and a configurable retry budget. Same envelope as Kafka; same set of events.
+
+Webhooks and Kafka are not exclusive — you can subscribe to one event by webhook and another by Kafka.
+
+---
+
+## Where state lives
+
+The gateway is stateless. Every fact survives a pod restart because it's persisted outside the pod.
+
+| Store | What it holds | Why it's there |
+|---|---|---|
+| **Postgres** | Chargers, transactions, reservations, charging profiles, local auth lists, security events, charge-point credentials, certificate mirror, pending CSRs. | Relational state with a clear schema. Audit-grade. |
+| **Redis** | Online registry (which pod has which `cp_id`), cross-pod command bus (`RemoteStart` to a charger on another pod), Authorize cache, idempotency cache for replays. | Sub-millisecond hot path; ephemeral by design. |
+| **ClickHouse** | Time-series telemetry — `MeterValues` samples, status history, boot history, transaction starts. | Hundreds of thousands of inserts per minute at fleet scale; bad shape for Postgres. |
+| **Kafka** | The event firehose itself. | Decouples producers (the gateway) from consumers (your platform). |
+
+The gateway itself holds only one thing in memory: the live WebSocket per charger plus a small cache of metadata. Lose a pod, lose those sockets — chargers reconnect to another pod within seconds and the rest of the state is intact.
+
+---
+
+## Horizontal scaling in one paragraph
+
+Chargers do not pick a pod. Envoy does — by computing a consistent hash of the `cp_id` and steering the WebSocket upgrade to the same pod each time. When your backend wants to send `RemoteStart` to charger `cp_id=X`, the gateway pod that receives the REST call doesn't necessarily own `X`'s socket. It looks up `X` in the Redis online registry, finds the pod ID that owns it, and forwards the command over a Redis pub/sub bus. The owning pod dispatches the OCPP CALL on the socket, gets the reply, hands it back. Your REST call sees a single response with the charger's verdict.
+
+This means three things in practice: the gateway scales horizontally by adding pods; chargers reconnect to whichever pod they land on; and a single backend call always returns the right answer regardless of which pod served it.
+
+[`concepts/multi-pod-and-routing.md`](./concepts/multi-pod-and-routing.md) goes into the mechanics.
+
+---
+
+## What the gateway is *not* responsible for
+
+Worth restating with the diagram in mind:
+
+- **User authentication** lives in your backend. The gateway forwards `Authorize` to your backend via a hot-path REST call you implement.
+- **Billing** lives downstream of the events. The gateway publishes `tx.started` and `tx.stopped`; your billing service consumes them.
+- **The smart-charging algorithm** runs on the charger itself. The gateway transports charging profiles; the charger resolves which is active.
+
+The boundary is deliberate. The gateway is the *only* component that has to know OCPP intimately; everything else on your platform sees a clean, OCPP-free contract.
+
+---
+
+## Where to go from here
+
+- **Want to operate this?** [`guides/install.md`](./guides/install.md) then [`guides/deploy-to-production.md`](./guides/deploy-to-production.md).
+- **Want to integrate?** [`guides/use-the-rest-api.md`](./guides/use-the-rest-api.md) and [`guides/consume-events.md`](./guides/consume-events.md).
+- **Want the deeper story of how a charging session flows?** [`concepts/how-ocpp-flows-work.md`](./concepts/how-ocpp-flows-work.md).

--- a/userdocs/04-glossary.md
+++ b/userdocs/04-glossary.md
@@ -1,0 +1,175 @@
+# Glossary
+
+**Audience.** Anyone meeting an OCPP term for the first time.
+
+**What this answers.** One-line definitions for every OCPP-specific term used elsewhere in this set, alphabetised. Keep nearby while you read.
+
+> OCPP itself stands for **Open Charge Point Protocol**, defined by the **Open Charge Alliance (OCA)**. This page covers the terms that turn up when you actually use it. If a term you need is missing, open an issue against the repo.
+
+---
+
+## A
+
+**`Action`.** The OCPP message name that identifies what a CALL is — for example `BootNotification`, `MeterValues`, `RemoteStartTransaction`. Carried as a string in every wire envelope.
+
+**`Authorize`.** OCPP message a charger sends when a user presents an identification token (RFID card, app QR code, plug-and-charge). Asks the central system "is this `id_tag` allowed to charge?". The central system answers with an `IdTagInfo` containing `status` ∈ `Accepted`, `Blocked`, `Expired`, `Invalid`, `ConcurrentTx`.
+
+**`AvailabilityType`.** Enum on `ChangeAvailability`: `Operative` (in service) or `Inoperative` (out of service for maintenance).
+
+## B
+
+**Basic Auth.** Per-charger username and password supplied in the WebSocket upgrade's `Authorization: Basic` header. The username is the charger's `cp_id`; the password is provisioned by the operator. The gateway checks the password against a bcrypt hash in Postgres.
+
+**`BootNotification`.** First message a charger sends on connecting. Carries vendor, model, firmware version, serial number. The central system replies with `Accepted | Pending | Rejected`, a `currentTime` for clock sync, and a `interval` (how often the charger should heartbeat).
+
+## C
+
+**CALL / CALLRESULT / CALLERROR.** The three OCPP wire envelope types. `[2, "message_id", "Action", {…payload…}]` is a CALL; `[3, "message_id", {…payload…}]` is its CALLRESULT; `[4, "message_id", "errorCode", "description", {…}]` is a CALLERROR. The leading integer is the **message type ID**.
+
+**`CertificateSigned`.** Central-system-initiated message: "here is your signed certificate chain". Used to deliver the chain back to a charger after it sent a `SignCertificate.req` with a CSR. Defined by the OCPP Security Whitepaper.
+
+**`ChangeAvailability`.** Central-system-initiated. Take a connector — or the whole charger when `connector_id = 0` — Operative or Inoperative. Reply can be `Accepted | Rejected | Scheduled` (Scheduled means "I have a session in progress; I'll honour this when the session ends").
+
+**`ChangeConfiguration`.** Set one configuration key on a charger. Reply: `Accepted | Rejected | RebootRequired | NotSupported`.
+
+**Charge Point (CP).** OCPP's term for the physical charger device. Identified by a string `cp_id`.
+
+**Charge Point Identity / `cp_id`.** Unique stable identifier for one charger. Appears in the WebSocket URL path, as the partition key on every Kafka event, and as the path parameter on every REST endpoint that targets a specific charger.
+
+**`ChargingProfile`.** A schedule describing how much current/power a charger may draw over time. Pushed from the central system; resolved on the charger.
+
+**`ClearCache`.** "Wipe your authorization cache." The charger's local cache of recent authorize results.
+
+**`ClearChargingProfile`.** Remove one or more `ChargingProfile`s by id / connector / purpose / stack-level.
+
+**Connector.** A specific socket on a charger. A charger has one or more; they are numbered starting from `1`. `connector_id = 0` refers to the whole charger in some commands.
+
+**Central System / Central Management System / CSMS.** The OCPP term for the platform-side service that chargers connect to. This gateway is one component of a CSMS.
+
+**CSR.** Certificate Signing Request. A blob of base64-PEM the charger sends when it wants the central system to mint a signed certificate (see `SignCertificate`).
+
+## D
+
+**`DataTransfer`.** A vendor extension escape hatch. Either side can send `{vendorId, messageId, data}` to convey something not in the standard OCPP spec.
+
+**`DeleteCertificate`.** Central-system-initiated. Delete a certificate the charger has installed, identified by its SHA-256 hash.
+
+**`DiagnosticsStatusNotification`.** Charger-initiated lifecycle for an uploaded diagnostics dump: `Idle | Uploading | Uploaded | UploadFailed`.
+
+## E
+
+**`ExtendedTriggerMessage`.** Security Whitepaper §4.7. Same shape as `TriggerMessage` but supports the wider set of message types added by the Whitepaper (`LogStatusNotification`, `SignChargePointCertificate`).
+
+## F
+
+**`FirmwareStatusNotification`.** Charger-initiated lifecycle for a firmware update: `Idle | Downloading | Downloaded | DownloadFailed | Installing | Installed | InstallationFailed` plus security-profile extensions.
+
+## G
+
+**`GetCompositeSchedule`.** "What schedule is currently effective on this connector for the next N seconds?" The charger answers with the merged result of every active `ChargingProfile`.
+
+**`GetConfiguration`.** Read one or more configuration keys from a charger. Empty key list means "all".
+
+**`GetDiagnostics`.** Central-system-initiated. "Upload your diagnostics blob to this URL." Followed asynchronously by `DiagnosticsStatusNotification`s as the upload progresses.
+
+**`GetInstalledCertificateIds`.** Security Whitepaper §4.8. "What CA certificates do you have installed right now?" Answer is a list of `hash_data` items.
+
+**`GetLocalListVersion`.** "What version of the local auth list is loaded on you right now?" Used before deciding whether to send a full or differential update.
+
+**`GetLog`.** Security Whitepaper §4.6. "Upload a diagnostics or security log to this URL." Followed by `LogStatusNotification`s.
+
+## H
+
+**`hash_data`.** A 4-tuple identifying an installed certificate: `hashAlgorithm`, `issuerNameHash`, `issuerKeyHash`, `serialNumber`. The OCPP §5.1 form.
+
+**`Heartbeat`.** Charger-initiated keep-alive. Carries no data; reply is the central system's `currentTime` for clock sync.
+
+## I
+
+**`id_tag`.** The user identifier the charger reports when a user presents themselves — RFID card UID, app-generated token, plug-and-charge cert thumbprint. Up to 20 characters in OCPP 1.6.
+
+**`IdTagInfo`.** The response shape for `Authorize`: `{status, expiryDate?, parentIdTag?}`.
+
+**`InstallCertificate`.** Security Whitepaper §4.5. Central-system-initiated. "Install this root certificate so you can verify CSMS signatures."
+
+## L
+
+**Local Auth List.** A local copy of accepted `id_tag`s the charger consults when it can't reach the central system. Synced by `SendLocalList` (full or differential).
+
+**`LogStatusNotification`.** Charger-initiated lifecycle for a `GetLog` upload: `Idle | Uploading | Uploaded | UploadFailed`.
+
+## M
+
+**`MeterValues`.** Charger-initiated periodic samples of meter readings during a session — `Energy.Active.Import.Register`, `Voltage`, `Current.Import`, `Power.Active.Import`, `SoC`, etc. The substance of every charging session for billing and dashboards.
+
+**Measurand.** What a `MeterValues` sample measures. Around 25 standard measurands; the ones you'll see most are `Energy.Active.Import.Register` (cumulative Wh), `Voltage`, `Current.Import`, `Power.Active.Import`, `SoC` (state of charge, %).
+
+**mTLS.** Mutual TLS — both endpoints present a certificate to authenticate the other. At the charger ↔ Envoy boundary this means the charger has its own client cert; at the Envoy ↔ gateway boundary it means Envoy and gateway authenticate each other.
+
+## O
+
+**OCPP.** Open Charge Point Protocol. The standard.
+
+**OCPP-J.** JSON-over-WebSocket variant of OCPP. The other variant, OCPP-S (SOAP), is legacy and not supported here.
+
+**OCPP 1.6 / 2.0.1.** Two protocol versions in current deployment. 1.6 is the wide-deploy incumbent; 2.0.1 adds security primitives and a richer device-model.
+
+**OCA / Open Charge Alliance.** The standards body that defines OCPP. Owns the testing tool used for formal conformance.
+
+**OCTT.** Open Charge Test Tool. The OCA-published conformance suite. Required for an officially certified implementation; access is gated on OCA membership.
+
+## R
+
+**`RemoteStartTransaction`.** Central-system-initiated. "Start a charging session for this `id_tag` on this `connector_id` (optionally with this `ChargingProfile`)." Reply `Accepted | Rejected`. **Accepted means "I will try"**, not "the session has started" — the actual session start is signalled by a subsequent `StartTransaction.req` from the charger.
+
+**`RemoteStopTransaction`.** Central-system-initiated. "End this transaction by ID." Reply `Accepted | Rejected`.
+
+**Replay.** OCPP allows chargers to re-send messages they think didn't land. The gateway dedupes these — see [`concepts/idempotency-and-replay.md`](./concepts/idempotency-and-replay.md).
+
+**`ReserveNow` / `CancelReservation`.** Central-system-initiated. Hold a connector for a specific `id_tag` until an expiry time.
+
+**`Reset`.** Central-system-initiated. `Soft` reboots the controller; `Hard` cycles power.
+
+## S
+
+**`SecurityEventNotification`.** Charger-initiated audit event from the Security Whitepaper: `InvalidSignature`, `InvalidCertificate`, `InvalidCsmsCertificate`, `TamperDetectionActivated`, …
+
+**`SendLocalList`.** Central-system-initiated. Push the Local Auth List (full or differential) to a charger.
+
+**`SetChargingProfile`.** Central-system-initiated. Install a `ChargingProfile` on a charger.
+
+**`SignCertificate`.** Security Whitepaper §4.13. Charger-initiated. "Please sign this CSR for me." Reply `Accepted | Rejected`. The signed chain is delivered later via `CertificateSigned`.
+
+**`SignedFirmwareStatusNotification`.** Like `FirmwareStatusNotification` but for `SignedUpdateFirmware`; adds `SignatureVerified`, `InvalidSignature`, etc. to the status set.
+
+**`SignedUpdateFirmware`.** Security Whitepaper §4.4. Central-system-initiated firmware update with a cryptographic signature.
+
+**SoC.** State of charge — battery percentage. Reported in `MeterValues` when the EV supplies it.
+
+**`StartTransaction`.** Charger-initiated. "I just started session N for `id_tag` on connector C at meter reading M." Reply assigns a `transactionId`. This is the canonical session-start signal; `RemoteStart`'s reply is *not*.
+
+**`StatusNotification`.** Charger-initiated. Reports a connector's state machine transition: `Available | Preparing | Charging | SuspendedEVSE | SuspendedEV | Finishing | Reserved | Unavailable | Faulted`, plus an OCPP-defined `errorCode`.
+
+**`StopTransaction`.** Charger-initiated. "Session N ended at meter reading M, with reason R." Carries the final `MeterValues` for that session.
+
+**Subprotocol.** The WebSocket subprotocol negotiated on the upgrade handshake. `ocpp1.6` or `ocpp2.0.1`. Without a matching negotiation, the WebSocket is rejected.
+
+## T
+
+**Transaction.** One charging session, from `StartTransaction` to `StopTransaction`. Identified by `transactionId` (assigned by the central system in the `StartTransaction.conf`).
+
+**`TriggerMessage`.** Central-system-initiated. "Please send me a fresh `BootNotification` / `StatusNotification` / `MeterValues` / `Heartbeat` / `DiagnosticsStatusNotification` / `FirmwareStatusNotification`." Reply `Accepted | Rejected | NotImplemented`. See also `ExtendedTriggerMessage`.
+
+## U
+
+**`UnlockConnector`.** Central-system-initiated. Mechanically unlock the cable on `connector_id`. Reply `Unlocked | UnlockFailed | NotSupported`.
+
+**`UpdateFirmware`.** Central-system-initiated firmware update without signature verification (legacy; superseded by `SignedUpdateFirmware` in the Security Whitepaper).
+
+---
+
+## Where to go from here
+
+- Want to see these terms in their natural habitat? [`concepts/how-ocpp-flows-work.md`](./concepts/how-ocpp-flows-work.md) walks a full session.
+- Looking up a REST endpoint? [`reference/rest-api.md`](./reference/rest-api.md).
+- Looking up an event? [`reference/events.md`](./reference/events.md).

--- a/userdocs/README.md
+++ b/userdocs/README.md
@@ -1,0 +1,95 @@
+# eveys/ocpp — user documentation
+
+**Audience.** Developers and operators new to this gateway. Comfortable with Python 3.13, Docker, Kubernetes, REST, and Kafka. Not assumed to know OCPP.
+
+**What this answers.** Where to find what, which order to read in for your role, and what you can rely on across versions.
+
+---
+
+## What this set is
+
+This is the *external* documentation for the eveys/ocpp gateway — the OCPP CSMS gateway that owns charger WebSocket connections and exposes a stable surface to the rest of the platform.
+
+It is **self-contained**. Every concept, command, and contract a reader needs is inside this directory. There are no references to internal design notes, ADRs, or implementation walkthroughs.
+
+If a page mentions a file path under `src/eveys_ocpp/...`, it's because you may want to open that file directly. That is the only kind of cross-link you'll see.
+
+---
+
+## Pick your reading path
+
+### "I just want to try it." (~30 minutes)
+
+1. [`01-what-is-this.md`](./01-what-is-this.md) — what the project is and what OCPP is in 60 seconds.
+2. [`02-quickstart.md`](./02-quickstart.md) — Docker Compose, simulator charger, send a command, watch an event. Ten minutes if your laptop already has Docker.
+3. [`03-architecture.md`](./03-architecture.md) — one diagram, one page. Now you know what you ran.
+
+### "I'm building a backend integration." (~2 hours, repeat as needed)
+
+1. [`03-architecture.md`](./03-architecture.md) — see how the gateway expects to talk to your backend.
+2. [`guides/use-the-rest-api.md`](./guides/use-the-rest-api.md) — auth, errors, pagination, the commands you'll call most.
+3. [`guides/consume-events.md`](./guides/consume-events.md) — Kafka vs webhooks, idempotency on your side.
+4. [`reference/rest-api.md`](./reference/rest-api.md), [`reference/events.md`](./reference/events.md) — keep open while you code.
+5. [`concepts/how-ocpp-flows-work.md`](./concepts/how-ocpp-flows-work.md) — when you hit "why is this event arriving twice?" or "why didn't a `StartTransaction` follow my `RemoteStart`?".
+
+### "I'm operating this in production." (read in order)
+
+1. [`03-architecture.md`](./03-architecture.md) — what owns what.
+2. [`guides/install.md`](./guides/install.md) — Helm chart and what it expects from your cluster.
+3. [`guides/deploy-to-production.md`](./guides/deploy-to-production.md) — TLS, mTLS, autoscaling, secrets, drain. Ends in a pre-flight sign-off checklist.
+4. [`concepts/security-model.md`](./concepts/security-model.md) — what you're trusting; non-negotiable to read before going live.
+5. [`guides/operate.md`](./guides/operate.md) — health probes, logs, metrics, drain, rollback.
+6. [`reference/configuration.md`](./reference/configuration.md), [`reference/metrics.md`](./reference/metrics.md) — keep open.
+7. [`guides/upgrade.md`](./guides/upgrade.md) — when the next version drops.
+
+---
+
+## Full table of contents
+
+### Top level
+
+- [`01-what-is-this.md`](./01-what-is-this.md) — product framing and a 60-second OCPP primer.
+- [`02-quickstart.md`](./02-quickstart.md) — 10-minute hands-on: simulator → boot → `RemoteStart` → event.
+- [`03-architecture.md`](./03-architecture.md) — one diagram, one page, all four surfaces.
+- [`04-glossary.md`](./04-glossary.md) — OCPP terms, one line each, alphabetised. Keep nearby.
+
+### Guides — read in order if you're new
+
+- [`guides/install.md`](./guides/install.md) — bring the stack up locally (Compose) or in a cluster (Helm).
+- [`guides/connect-a-charger.md`](./guides/connect-a-charger.md) — first real charger; URL, auth, common failures.
+- [`guides/use-the-rest-api.md`](./guides/use-the-rest-api.md) — drive the gateway from a backend.
+- [`guides/consume-events.md`](./guides/consume-events.md) — Kafka and webhooks, one envelope.
+- [`guides/deploy-to-production.md`](./guides/deploy-to-production.md) — TLS, mTLS, autoscaling, sign-off checklist.
+- [`guides/operate.md`](./guides/operate.md) — probes, logs, metrics, drain, rollback.
+- [`guides/upgrade.md`](./guides/upgrade.md) — version policy and zero-downtime motions.
+
+### Reference — keep open while you code or operate
+
+- [`reference/rest-api.md`](./reference/rest-api.md) — every HTTP endpoint.
+- [`reference/grpc-api.md`](./reference/grpc-api.md) — every gRPC RPC.
+- [`reference/events.md`](./reference/events.md) — every Kafka topic and webhook event.
+- [`reference/configuration.md`](./reference/configuration.md) — every environment variable.
+- [`reference/metrics.md`](./reference/metrics.md) — every Prometheus series.
+
+### Concepts — read once, refer back
+
+- [`concepts/how-ocpp-flows-work.md`](./concepts/how-ocpp-flows-work.md) — the charging session end-to-end.
+- [`concepts/security-model.md`](./concepts/security-model.md) — what is trusted, what is not.
+- [`concepts/multi-pod-and-routing.md`](./concepts/multi-pod-and-routing.md) — Envoy ring-hash, registry, cross-pod dispatch.
+- [`concepts/idempotency-and-replay.md`](./concepts/idempotency-and-replay.md) — duplicate-message handling.
+
+---
+
+## Conventions used in these pages
+
+- Every page opens with bold **Audience** and **What this answers** lines, in that order. If you read those and the page isn't for you, close it.
+- The first time any OCPP-specific term appears on a page (`BootNotification`, `MeterValues`, `id_tag`, …), it links to [`04-glossary.md`](./04-glossary.md).
+- Every code block declares its language. Every shell example is copy-pasteable as written.
+- Every reference page opens with a "use this if you…" line so you can decide from the TOC.
+- No internal design or implementation prose is linked. Source-code paths (e.g. `src/eveys_ocpp/...`) appear only when you may want to open the file directly.
+
+---
+
+## What to do if something is wrong
+
+If a step in these pages doesn't work, treat it as a doc bug. Open an issue against the repository describing what you ran, what happened, and what you expected. The docs should be the single source of truth; if reality has drifted, the docs are wrong and we fix them.

--- a/userdocs/_plan.md
+++ b/userdocs/_plan.md
@@ -1,0 +1,126 @@
+# Userdocs implementation plan
+
+**Status:** approved, in progress.
+**Started:** 2026-05-11.
+
+This file is the source of truth for the `userdocs/` build-out. Each task is checked off as it lands. If a task is split, sub-bullets appear under it. If a task is dropped, it stays in the list with `~~strikethrough~~` and a one-line reason.
+
+---
+
+## Audience promise
+
+A developer comfortable with Python 3.13, Docker, Kubernetes basics, REST, and Kafka — **new to OCPP and to this gateway**. Every page assumes that baseline; nothing more.
+
+## Self-containment rule
+
+This set is complete on its own. **No links to or references of any internal / implementation / ADR documents.** Source-code path references (e.g. `src/eveys_ocpp/...`) are allowed when an example needs a path, but no narrative cross-links to existing prose docs.
+
+## Conventions every page follows
+
+- One H1 (the page title), then a one-line **audience** note, then a one-line **what this answers** note. Both bold, on their own lines. Then content.
+- First mention of any OCPP term links to `userdocs/04-glossary.md`.
+- Every code block specifies its language. Every shell example is copy-pasteable.
+- Every reference page opens with a "use this if you…" line.
+- No external / implementation prose links.
+
+---
+
+## Final tree (18 pages)
+
+```
+userdocs/
+  _plan.md                        — this file
+  README.md                       — entry, TOC, audience promise, self-containment rule
+  01-what-is-this.md              — product framing + 60-second OCPP primer
+  02-quickstart.md                — Docker Compose: simulator → boot → RemoteStart → event (10 min max)
+  03-architecture.md              — 1 diagram + 1-page narrative covering all 4 surfaces
+  04-glossary.md                  — OCPP terms with one-line definitions, alphabetised
+  guides/
+    install.md                    — bring up the stack locally (Compose) and in Kubernetes (Helm)
+    connect-a-charger.md          — first real charger; networking, basic auth, common failures
+    use-the-rest-api.md           — driving the gateway from a backend; auth, pagination, error model
+    consume-events.md             — Kafka + webhooks; one envelope, two transports, when to use each
+    deploy-to-production.md       — TLS, mTLS, autoscaling, secrets, drain semantics; closes with sign-off checklist
+    operate.md                    — health/ready, structured logs, metrics, drain, rollback motions
+    upgrade.md                    — version policy, supported upgrade paths, stability across releases
+  reference/
+    rest-api.md                   — every endpoint, request/response, errors
+    grpc-api.md                   — every RPC, payload shapes, code examples
+    events.md                     — every event, envelope, delivery semantics, idempotency
+    configuration.md              — every env var, default, stability tier
+    metrics.md                    — every Prometheus series, label set, what it means
+  concepts/
+    how-ocpp-flows-work.md        — Authorize → Start → Meter → Stop end-to-end
+    security-model.md             — what the gateway trusts, what it doesn't
+    multi-pod-and-routing.md      — ring-hash, registry, cross-pod dispatch, drain
+    idempotency-and-replay.md     — duplicate-message handling, two-layer dedup
+```
+
+---
+
+## Tasks (execution order)
+
+- [x] **0. Scaffold the plan file on disk.** (this file)
+- [x] **1. Scaffold the 18 doc files.** Each file gets the H1 + audience + what-this-answers stub. Nothing else.
+- [x] **2. Entry README.** TOC, audience promise, self-containment rule, three suggested read paths (trying it / shipping a backend integration / operating in production).
+- [x] **3. Top-level four pages.** Aim: readable in 20 min total.
+  - [x] 3a. `01-what-is-this.md`
+  - [x] 3b. `02-quickstart.md`
+  - [x] 3c. `03-architecture.md`
+  - [x] 3d. `04-glossary.md`
+- [x] **4. Guides** (order matches real user journey):
+  - [x] 4a. `guides/install.md`
+  - [x] 4b. `guides/connect-a-charger.md`
+  - [x] 4c. `guides/use-the-rest-api.md`
+  - [x] 4d. `guides/consume-events.md`
+  - [x] 4e. `guides/deploy-to-production.md`
+  - [x] 4f. `guides/operate.md`
+  - [x] 4g. `guides/upgrade.md`
+- [x] **5. Reference pages.**
+  - [x] 5a. `reference/rest-api.md`
+  - [x] 5b. `reference/grpc-api.md`
+  - [x] 5c. `reference/events.md`
+  - [x] 5d. `reference/configuration.md`
+  - [x] 5e. `reference/metrics.md`
+- [x] **6. Concepts.**
+  - [x] 6a. `concepts/how-ocpp-flows-work.md` (load-bearing; first)
+  - [x] 6b. `concepts/security-model.md`
+  - [x] 6c. `concepts/multi-pod-and-routing.md`
+  - [x] 6d. `concepts/idempotency-and-replay.md`
+- [x] **7. Cross-link sweep.** First-mention glossary links; "see also" footer on each guide.
+- [x] **8. Self-containment check.** `grep -rE "docs/|adr/|ADR-" userdocs/` returns nothing.
+- [x] **9. Final read-through.** Walk every page as the target reader; one tightening pass.
+
+---
+
+## Final pass notes (2026-05-11)
+
+Fixes applied during the read-through:
+
+- Footer heading standardised: "Where to go next" → "Where to go from here" in `02-quickstart.md` and `03-architecture.md`.
+- Metric name typo: `eveys_ocpp_ws_active_connections` → `eveys_ocpp_ws_connections_active` across `operate.md` and `deploy-to-production.md`.
+- Non-existent metric `eveys_ocpp_kafka_publish_failures_total` → `eveys_ocpp_kafka_publish_total{outcome="failed"}` in `operate.md`.
+- Env var corrections:
+  - `EVEYS_OCPP_WEBHOOK_SIGNING_SECRET` → `EVEYS_OCPP_WEBHOOK_SECRET` (4 pages).
+  - `EVEYS_OCPP_OTLP_ENDPOINT` → `EVEYS_OCPP_TRACING_OTLP_ENDPOINT` (2 pages).
+  - `EVEYS_OCPP_DB_POOL_MAX_OVERFLOW` → `EVEYS_OCPP_DB_MAX_OVERFLOW`.
+  - Removed fictional `EVEYS_OCPP_BACKEND_CA_PATH` reference; replaced with the actual approach (trust roots at image-build time).
+- Reworded one sentence in `01-what-is-this.md` that implied an "elsewhere in this set" doc that doesn't exist.
+- Verified: every internal `.md` link resolves; every reference page opens with "Use this if you"; every page opens with bold **Audience** + **What this answers**.
+- Verified: zero hits for `docs/`, `adr/`, `ADR-` anywhere in `userdocs/` outside `_plan.md`.
+
+The set is ready.
+
+---
+
+## Iteration history (for the record)
+
+**v1** — Three subdirs + 16 files; OCPP terms assumed known; dev-only quickstart; metrics misfiled under "reference"; no prod / security / upgrade pages.
+
+**Iteration 1** — Caught: subdirs heavy for ~16 pages; no prod page; no security; metrics misclassified; no upgrade page; quickstart scope undisciplined.
+
+**Iteration 2** — Caught: glossary must stay top-level (referenced constantly); `send-your-first-command.md` was filler; missing OCPP-101 primer; reader-intent grouping clearer than format-based; prod needs checklist shape.
+
+**Iteration 3** — Caught: don't fragment prod checklist (fold into deploy page); concept order matters (how-ocpp-flows first); security its own page after deploy; webhooks + Kafka collapse to `events.md`; reference pages need "use this if you…" opener; stability promise needs explicit upgrade page.
+
+**Final:** 18 pages, two-tier nav, self-containment rule pinned, audience promise pinned, conventions codified above.

--- a/userdocs/concepts/how-ocpp-flows-work.md
+++ b/userdocs/concepts/how-ocpp-flows-work.md
@@ -1,0 +1,373 @@
+# How OCPP flows work
+
+**Audience.** Anyone who wants to understand what's happening between a charger, this gateway, and the backend during a charging session.
+
+**What this answers.** The full Authorize → StartTransaction → MeterValues → StopTransaction loop, walked end-to-end with all four surfaces in play. By the end you'll be able to read a log and predict what message comes next.
+
+> Term not familiar? [`../04-glossary.md`](../04-glossary.md) has the one-line definition.
+
+---
+
+## The shape of every conversation
+
+OCPP defines a small alphabet of message types and a finite set of rules about when each may appear. Every conversation between a charger and the gateway is a sequence of these messages over a single long-lived WebSocket. There are only two roles in the alphabet:
+
+- **Inbound**: the charger initiates; the gateway answers.
+- **Outbound**: the gateway initiates (usually because your backend asked); the charger answers.
+
+Both directions use the same envelope:
+
+```text
+[2, <message_id>, "<Action>", { ...payload... }]                     # CALL
+[3, <message_id>, { ...payload... }]                                 # CALLRESULT (reply)
+[4, <message_id>, "<errorCode>", "<description>", { ... }]           # CALLERROR
+```
+
+The leading `2`/`3`/`4` is the message type ID. The `message_id` correlates a CALL with its eventual CALLRESULT — same id, same socket. The protocol has a **hard 30-second ceiling** on how long the answering side may take.
+
+That's it. Everything below this point is just *which* CALL appears *when*.
+
+---
+
+## A whole session in one diagram
+
+```
+   Charger                  Gateway                  Backend                  Kafka / webhooks
+   ───────                  ───────                  ───────                  ────────────────
+
+   open WS upgrade ──────►  accept; auth check
+                            mark online (Redis)
+                                                                                  cp.connected ─►
+
+   BootNotification ─────►  persist; reply Accepted
+                                                                                  cp.boot ─►
+
+   StatusNotification ───►  persist
+                                                                                  cp.status ─►
+
+   Heartbeat        ─────►  refresh registry
+   ...                      (no event published; high volume)
+
+                            ◄──────  POST /commands/remote-start (your code)
+   ◄──── RemoteStartTransaction
+   ──── Accepted ────────►
+                            ──────►  (no event; synchronous response)
+
+   Authorize        ─────►  forward to backend ──►  POST /api/eveys/authorize
+                            ◄────── { status: Accepted, ... }
+   ◄──── Accepted
+
+   StartTransaction ────►   persist; assign transaction_id
+   ◄──── { transactionId: 12345, idTagInfo: Accepted }
+                                                                                  tx.started ─►
+
+   MeterValues      ─────►  persist (Kafka → ClickHouse)
+   MeterValues      ─────►  ...
+   MeterValues      ─────►  ...
+                                                                                  cp.meter ─► (each)
+
+                            ◄──────  POST /commands/remote-stop (your code)
+   ◄──── RemoteStopTransaction
+   ──── Accepted ────────►
+
+   StopTransaction  ─────►  persist
+   ◄──── { idTagInfo: Accepted }
+                                                                                  tx.stopped ─►
+
+                            (charger remains connected, idle)
+
+   StatusNotification ───►  Available
+                                                                                  cp.status ─►
+```
+
+The rest of this page is a walkthrough of that diagram — what each step does, what your code can rely on, and where things can go sideways.
+
+---
+
+## 1. Connection: the WebSocket comes up
+
+A charger boots; its firmware opens a WebSocket to `wss://<your-edge>/<cp_id>` with subprotocol `ocpp1.6`. Envoy ring-hashes on `cp_id` and forwards the upgrade to a gateway pod. That pod is now responsible for this charger until the socket drops.
+
+What happens inside the gateway:
+
+1. The TLS handshake completes (Envoy terminates).
+2. The gateway validates the WebSocket upgrade headers — subprotocol matches; Basic Auth password verifies against the row in `charge_point_credentials`.
+3. The pod marks the charger online in the Redis registry: `cp:online:<cp_id> → <pod_id>`. Other pods can now route commands to this one.
+4. The gateway publishes a `cp.connected` envelope to Kafka.
+
+If any of those steps fails, the upgrade returns a 4xx and no socket is opened. The charger retries.
+
+**What your code can rely on.** Once `cp.connected` lands, the gateway has a usable socket and will route commands successfully. There's no separate "ready" signal — connection = ready.
+
+---
+
+## 2. Boot: the charger announces itself
+
+Within ~1 second of the socket opening, the charger sends its first CALL:
+
+```text
+[2, "msg-001", "BootNotification", {
+  "chargePointVendor": "ACME",
+  "chargePointModel":  "Charger-V2",
+  "chargePointSerialNumber": "SN-001",
+  "firmwareVersion":   "1.4.2"
+}]
+```
+
+The gateway:
+
+1. Persists or upserts the row in `charge_points` (creates if first time).
+2. Replies with `{ status: "Accepted", currentTime: "...", interval: 60 }`.
+3. Publishes `cp.boot`.
+
+`currentTime` is the clock the charger should sync to — chargers can have wildly wrong clocks until they hear this. `interval` is how often it should heartbeat (a default of 60s is gentle; tune via `EVEYS_OCPP_HEARTBEAT_INTERVAL_SECONDS`).
+
+**Why `Accepted` by default.** Some platforms gatekeep registration — `Pending` while a human approves, `Rejected` for unknown chargers. The gateway is `Accepted`-by-default because the Basic Auth check at the WebSocket upgrade is the load-bearing gate. By the time you see a `BootNotification`, the charger is already authenticated.
+
+---
+
+## 3. Status: connectors come online
+
+Once booted, the charger reports the state of each connector:
+
+```text
+[2, "msg-002", "StatusNotification", {
+  "connectorId": 1,
+  "status":      "Available",
+  "errorCode":   "NoError"
+}]
+```
+
+Connector `0` refers to "the whole charger" — chargers report a `connectorId=0` status to signal an overall fault.
+
+Status transitions follow a well-defined state machine:
+
+```
+Available → Preparing → Charging → SuspendedEVSE → Finishing → Available
+                    └→ SuspendedEV ─┘
+                    └→ Faulted ─────┘   (from any state)
+                    └→ Unavailable ─┘   (operator-initiated)
+                    └→ Reserved ────┘   (after ReserveNow accepted)
+```
+
+Each transition produces a `cp.status` event. Dashboards usually project the latest status per connector; audit consumers tail the full stream.
+
+---
+
+## 4. Heartbeat: keepalive without events
+
+Every `interval` seconds, the charger sends:
+
+```text
+[2, "msg-N", "Heartbeat", {}]
+```
+
+The gateway refreshes the TTL on the registry's online key and replies with the current time. **No event is published.** Heartbeats at fleet scale are noise — the fact that a charger heartbeated is reflected in `last_heartbeat_at` on the REST surface.
+
+If three heartbeats go by without a message, the registry expires the key and the charger is considered offline. (Most chargers also re-establish the socket on timeout.)
+
+---
+
+## 5. Remote start: the asymmetric one
+
+This is where the most common backend bug lives. Read carefully.
+
+Your backend wants a session to start:
+
+```bash
+POST /api/v1/charge-points/CP_X/commands/remote-start
+{ "id_tag": "USER_RFID_123", "connector_id": 1 }
+```
+
+The gateway:
+
+1. Looks up `CP_X` in the registry. **If it's owned by another pod**, the request is forwarded over the Redis pub/sub bus; that pod executes step 2 and returns the result. Your REST caller never sees the hop.
+2. The owning pod dispatches an OCPP CALL on the socket:
+
+   ```text
+   [2, "msg-K", "RemoteStartTransaction", {
+     "idTag":       "USER_RFID_123",
+     "connectorId": 1
+   }]
+   ```
+
+3. The charger answers (typically within seconds): `[3, "msg-K", { "status": "Accepted" }]`.
+4. The gateway returns `{ "status": "Accepted" }` to your REST caller.
+
+**Here's the subtle bit.** `Accepted` means "I, the charger, acknowledge this command and will try to start a session". It does **not** mean a session has started. The session begins when the charger sends its own `StartTransaction.req` — which may not happen, and there's no time guarantee.
+
+What can go wrong between `Accepted` and `StartTransaction`:
+
+- User walks away (no tag tap, no plug — depends on charger config).
+- Charger faults during preparation.
+- Charger reports `Authorize` for a different `id_tag` than you specified.
+
+**Your code must not assume `RemoteStart.Accepted` = session started.** The right signal is the `tx.started` event. Hold pending state on your side; resolve when `tx.started` arrives or after a timeout.
+
+---
+
+## 6. Authorize: the synchronous hop into your backend
+
+Some chargers fire `Authorize` before `StartTransaction` (plugin-then-tap flows). Many also fire `Authorize` mid-session when the user taps to stop. Both look the same:
+
+```text
+[2, "msg-N", "Authorize", { "idTag": "USER_RFID_123" }]
+```
+
+The gateway:
+
+1. Checks the Redis Authorize cache for a recent answer. **Cache hit**: replies immediately.
+2. **Cache miss**: makes a synchronous REST call to your backend:
+
+   ```http
+   POST /api/eveys/authorize
+   { "id_tag": "USER_RFID_123", "cp_id": "CP_X" }
+   ```
+
+   Your backend returns the `IdTagInfo` shape (`status` ∈ `Accepted/Blocked/Expired/Invalid/ConcurrentTx`, plus optional `parentIdTag`, `expiryDate`).
+
+3. Caches the answer for `authorize_cache_ttl_seconds` (default 5 minutes).
+4. Forwards the verdict to the charger verbatim.
+
+**Latency budget**: the charger has 30 seconds on the OCPP wire. The gateway needs most of that for itself; your backend should answer in < 200 ms p99.
+
+**Fallback**: when your backend is unreachable, the gateway falls back per `EVEYS_OCPP_BACKEND_AUTHORIZE_FALLBACK`:
+
+- `reject` (default) — Returns `Invalid` to the charger. Safe; no unauthorized charging.
+- `accept_offline` — Returns `Accepted`. Useful for pilot fleets where unavailability is preferable to outage. Don't use this in production without thinking it through.
+
+---
+
+## 7. StartTransaction: the session actually begins
+
+```text
+[2, "msg-N", "StartTransaction", {
+  "connectorId": 1,
+  "idTag":       "USER_RFID_123",
+  "meterStart":  12000,
+  "timestamp":   "2026-05-11T10:00:00Z"
+}]
+```
+
+The gateway:
+
+1. Authorizes (same path as §6 — yes, the charger may have just done this; cache-hit path makes it cheap).
+2. Assigns a `transactionId` (server-side; monotonic per gateway).
+3. Persists the `transactions` row.
+4. Replies `[3, "msg-N", { "transactionId": 12345, "idTagInfo": { "status": "Accepted" } }]`.
+5. Publishes `tx.started`.
+
+This is the canonical "session has begun" signal. Your billing / receipt logic hangs off this event.
+
+The `transactionId` returned here is what every subsequent `MeterValues` and `StopTransaction` carries.
+
+---
+
+## 8. MeterValues: the firehose
+
+While the session runs, the charger periodically reports samples:
+
+```text
+[2, "msg-N", "MeterValues", {
+  "connectorId":   1,
+  "transactionId": 12345,
+  "meterValue": [{
+    "timestamp": "2026-05-11T10:01:00Z",
+    "sampledValue": [
+      { "value": "13500", "measurand": "Energy.Active.Import.Register", "unit": "Wh" },
+      { "value": "230",   "measurand": "Voltage", "phase": "L1", "unit": "V" },
+      { "value": "16",    "measurand": "Current.Import", "phase": "L1", "unit": "A" },
+      { "value": "78",    "measurand": "SoC", "unit": "Percent" }
+    ]
+  }]
+}]
+```
+
+The sampling interval is operator-configurable (`MeterValueSampleInterval` on the charger; defaults to 60s for most OEMs).
+
+The gateway:
+
+1. Validates the samples (negative energy is quarantined; impossible voltages are rejected).
+2. Publishes `cp.meter` to Kafka — one envelope per `MeterValues` CALL.
+3. The ClickHouse ingestor sidecar tails the topic and writes batched inserts to ClickHouse. Your dashboards query ClickHouse for time-series.
+
+**This is the highest-volume event in the system.** At fleet scale (thousands of chargers, 60s sampling, multiple measurands per sample) it dominates everything else. The Kafka envelope is sized for this — `cp.meter` is not a webhook-friendly event.
+
+---
+
+## 9. RemoteStop / StopTransaction: ending cleanly
+
+The reverse asymmetry of §5.
+
+Your backend sends a stop:
+
+```bash
+POST /api/v1/charge-points/CP_X/commands/remote-stop
+{ "transaction_id": 12345 }
+```
+
+The gateway dispatches `RemoteStopTransaction`. Charger replies `Accepted` — meaning "I'll try to stop". The actual session-end signal is the charger's `StopTransaction`:
+
+```text
+[2, "msg-N", "StopTransaction", {
+  "transactionId": 12345,
+  "idTag":         "USER_RFID_123",
+  "meterStop":     18500,
+  "timestamp":     "2026-05-11T10:30:00Z",
+  "reason":        "Local",
+  "transactionData": [/* final MeterValues snapshot */]
+}]
+```
+
+The gateway:
+
+1. Looks up the matching `transactions` row.
+2. Updates `meter_stop_wh`, `stopped_*_at`, `stop_reason`.
+3. Replies `[3, "msg-N", { "idTagInfo": { "status": "Accepted" } }]`.
+4. Publishes `tx.stopped`.
+
+`stop_reason` can be `Local` (user tapped to stop), `Remote` (your `RemoteStop` succeeded), `EmergencyStop`, `PowerLoss`, `Reboot`, `SoftReset`, `HardReset`, `EVDisconnected`, and a handful of others. Your billing logic can use it to handle edge cases differently.
+
+---
+
+## 10. After the session
+
+The charger usually fires one more `StatusNotification` (`Finishing` → `Available`) and stays connected. Heartbeats resume. The socket stays open until power-cycle or the charger initiates a reconnect.
+
+If the socket drops at any point, the gateway's `mark_offline` runs compare-and-delete on the registry key — only the pod that *owns* the charger can mark it offline, so a reconnect-to-different-pod race doesn't produce a spurious `cp.offline` event.
+
+---
+
+## 11. The two corners that surprise people
+
+### 11.1 `Authorize` and `StartTransaction` can both fire authorization
+
+Both inbound messages produce a backend call (cache permitting). Most production chargers `Authorize` once and then `StartTransaction` immediately afterwards. The cache makes the second call free.
+
+A charger that **only** sends `StartTransaction` without a preceding `Authorize` (the "auth-first" flow vs "plugin-first" flow) still goes through the same backend check — `StartTransaction` is the spec-defined fallback authorization point.
+
+### 11.2 The wire ordering is not the persistence ordering
+
+`StartTransaction` arrives on the wire at time T₁; the gateway commits to Postgres at T₂; publishes `tx.started` at T₃. T₁ → T₂ → T₃ takes a few milliseconds normally, but a slow Postgres can stretch the window. Your `tx.started` consumer sees the event with `T₃` in `occurred_at`; the charger's claimed `timestamp` is in the payload.
+
+If you need wall-clock truth, **trust the server `occurred_at`**. The charger's clock is per-spec untrusted — it has just been told what time it is in the boot reply, but plenty of chargers ignore that.
+
+---
+
+## 12. Failure paths in one paragraph each
+
+**Charger drops mid-session.** The socket closes; the registry expires the online key; no `tx.stopped` event fires for the orphaned transaction. The charger reconnects (seconds to minutes), sends `StatusNotification`s, and (per spec) replays any `StopTransaction` it had queued. The gateway's idempotency cache dedupes the replay.
+
+**Backend times out on `Authorize`.** The gateway uses the `EVEYS_OCPP_BACKEND_AUTHORIZE_FALLBACK` policy. With `reject` the charger sees `Invalid`; with `accept_offline` it sees `Accepted` and the gateway logs a warning.
+
+**`RemoteStart` returns `Accepted` but no `tx.started` follows.** The user didn't engage — walked away, didn't plug in, or the charger faulted before the session could begin. Your backend should time out the pending state after a sensible window (60s is typical) and surface the failure to the user.
+
+**Kafka is unreachable.** The producer buffers and retries. The gateway's persistent state (Postgres, Redis) is unaffected; `tx.started`/`tx.stopped` get delivered eventually. Backends that synchronously block on the event should consider listening to Kafka *and* using the REST `transactions` endpoint as a backstop.
+
+---
+
+## Where to go from here
+
+- **Why duplicates happen and how the gateway protects against them:** [`idempotency-and-replay.md`](./idempotency-and-replay.md).
+- **How commands route when the receiving pod doesn't own the charger:** [`multi-pod-and-routing.md`](./multi-pod-and-routing.md).
+- **What's trusted at each boundary in this picture:** [`security-model.md`](./security-model.md).

--- a/userdocs/concepts/idempotency-and-replay.md
+++ b/userdocs/concepts/idempotency-and-replay.md
@@ -1,0 +1,179 @@
+# Idempotency and replay
+
+**Audience.** Anyone debugging duplicate messages, designing a consumer that must be idempotent, or understanding why the gateway never double-counts a charging session.
+
+**What this answers.** Why the gateway sees the same OCPP message twice sometimes, how it dedupes those replays, and what that means for *your* code receiving events on the other end.
+
+> Related: [`how-ocpp-flows-work.md`](./how-ocpp-flows-work.md) for the full message lifecycle; [`multi-pod-and-routing.md`](./multi-pod-and-routing.md) for the cross-pod side.
+
+---
+
+## Why duplicates happen at all
+
+OCPP is an at-least-once protocol over a flaky transport. Three sources of duplicates, all benign:
+
+### 1. The charger doesn't trust the network
+
+A charger sends `StopTransaction.req`. The TCP socket dies before the CALLRESULT comes back. The charger has no way to know whether the gateway received it. **Per spec**, the charger retries on reconnect — the message lands again, possibly with the same `message_id`, possibly with a fresh one.
+
+This is normal. A charger that *doesn't* retry would lose every message that crosses a flaky link, and field deployments are full of flaky links.
+
+### 2. The gateway sees a reconnection storm
+
+A pod restarts. Hundreds of chargers reconnect within seconds. Each may replay any messages they had queued during the disconnection — boots, status notifications, even transactions that had started before the disconnect.
+
+### 3. The internal pipeline is at-least-once too
+
+When the gateway publishes to Kafka, the producer retries on failure. A retry could deliver a message the broker had already accepted (the broker's `enable.idempotence` mostly prevents this at the partition level, but a producer failover can still leave the upstream observer seeing duplicates if the broker side wasn't fully idempotent for that partition state).
+
+The combination: a backend consumer might see the same `tx.started` event arrive twice. Once because the charger replayed `StartTransaction`; again because the Kafka producer retried.
+
+---
+
+## What the gateway protects against
+
+The gateway dedupes at two layers, in this order:
+
+### Layer 1: Redis idempotency cache (the hot path)
+
+Every inbound CALL goes through a check:
+
+```python
+key = f"idem:{cp_id}:{message_id}"
+already_seen = redis.set(key, "1", ex=IDEM_TTL, nx=True) is None
+if already_seen:
+    metrics.idempotency_lookups_total.labels(outcome="hit").inc()
+    return previous_response_from_redis
+# ... otherwise: handle normally, cache the response
+```
+
+`message_id` is the charger-supplied id from the OCPP wire envelope. A retry of the same message comes through with the **same** `message_id` — the gateway detects this, returns the previously-computed response, and **no side effects fire**: no Postgres write, no Kafka publish, no webhook delivery.
+
+Hit rate is observable via `eveys_ocpp_idempotency_lookups_total{outcome="hit"|"miss"}`. A normal fleet sees a handful of hits per minute — every blip in network connectivity contributes one or two.
+
+TTL is `EVEYS_OCPP_IDEMPOTENCY_TTL_SECONDS` (default a few minutes; long enough to cover charger retry windows, short enough to not pin a stale value forever).
+
+### Layer 2: Postgres natural-key defense
+
+The hot-path cache is a Redis backstop, not a primary key. If Redis is unreachable, or the TTL has expired, the gateway falls through and would try to write a duplicate row.
+
+The persistent tables defend against this with **natural-key uniqueness**:
+
+- `transactions.transaction_id` is unique. A duplicate `StartTransaction` that gets past the Redis cache attempts to insert with a different `id` but the same `transaction_id` — `INSERT ... ON CONFLICT (transaction_id) DO NOTHING` makes it a no-op.
+- `transactions.idempotency_key = sha256(cp_id, transaction_id, meter_stop_wh)` is unique. A duplicate `StopTransaction` that lands collides on this — same no-op semantics.
+- `security_events` and the migration history have their own append-only / `ON CONFLICT DO NOTHING` shapes.
+
+So even if both Redis layers fail simultaneously (impossible in practice; you'd need Redis *and* the in-process cache *and* the Postgres connection pool to all do something pathological), the database refuses the duplicate row. Counter: `eveys_ocpp_stop_transaction_replays_total` increments when this happens.
+
+---
+
+## What you must do on your side
+
+The gateway prevents duplicate **state mutations**. It does not prevent your consumers from seeing duplicate **events**.
+
+This is on purpose. Kafka is at-least-once. Webhooks are at-least-once. Even if the gateway's hot path is perfectly deduped, the consumer-side delivery isn't:
+
+- A Kafka consumer that crashes between processing a message and committing the offset will re-process it on restart.
+- A webhook endpoint that returns a 5xx triggers a retry; if your endpoint actually succeeded but the response got lost, the retry is a duplicate from your view.
+
+Therefore: **your consumers must be idempotent on `event_id`**.
+
+### The pattern that always works
+
+```python
+# Pseudocode for any event consumer
+def handle_event(envelope):
+    event_id = envelope.event_id
+    if already_processed(event_id):
+        return  # 200 OK; we've seen this one
+    with transaction():
+        do_the_work(envelope)
+        mark_processed(event_id)
+```
+
+`already_processed` is typically a small table or Redis set keyed on `event_id` with a TTL longer than the gateway's webhook retry budget. Sub-millisecond check; trivial to implement; bulletproof.
+
+The alternative — making the work itself idempotent (e.g. upserts everywhere) — is fine but doesn't generalise. The `event_id` check is cheap and covers every event regardless of payload shape.
+
+---
+
+## A worked example: a billing service
+
+Suppose your billing service issues invoices from `tx.stopped` events.
+
+Without idempotency:
+
+1. `tx.stopped` arrives for `transaction_id=12345`.
+2. Billing creates invoice `INV-001` for the user.
+3. Webhook retry arrives (your endpoint took too long to respond).
+4. Billing creates *another* invoice `INV-002` for the same transaction.
+5. User gets billed twice.
+
+With idempotency:
+
+1. `tx.stopped` arrives for `transaction_id=12345`, `event_id=abc-123`.
+2. Billing checks `seen_events`: `abc-123` not there → process. Creates `INV-001`. Writes `abc-123` to `seen_events`.
+3. Webhook retry arrives with `event_id=abc-123`.
+4. Billing checks `seen_events`: `abc-123` is there → 200 OK, no-op.
+5. User gets billed once.
+
+This works regardless of why the duplicate happened — charger retry, gateway retry, webhook retry, consumer crash. The `event_id` is the single anchor.
+
+---
+
+## What `event_id` is, exactly
+
+A UUID generated by the gateway at the moment the event is constructed. **Stable per logical event.** Even if the same `tx.stopped` is published to Kafka three times because of producer retries, all three carry the same `event_id`. The gateway does not generate a fresh `event_id` per delivery attempt.
+
+It's distinct from:
+
+- The OCPP `message_id` (charger-supplied; only meaningful within one CALL).
+- Your `request_id` (REST/gRPC trace anchor; one per HTTP request).
+- The Kafka offset (transport-level; partition-specific).
+
+Trust `event_id` for deduplication on your side. Don't try to compose a synthetic key from payload fields — `event_id` is the gateway's promise that "this is the same event."
+
+---
+
+## The two events that don't replay
+
+The gateway is conservative about emitting events: a deduped *handler* call doesn't emit. So:
+
+- A replayed `StartTransaction` does **not** produce a second `tx.started` event.
+- A replayed `StopTransaction` does **not** produce a second `tx.stopped` event.
+
+The metrics `eveys_ocpp_boot_replays_total` and `eveys_ocpp_stop_transaction_replays_total` count these — useful for diagnosing whether a charger is unusually retry-happy.
+
+This is a stronger guarantee than just consumer-side dedup: the firehose itself is not polluted with replays. Your consumer will still see *retry-induced* duplicates from Kafka/webhooks, but not *protocol-induced* ones.
+
+---
+
+## Edge case: in-flight replays during pod restart
+
+What if the gateway restarts mid-replay? The charger's retry arrives at a brand-new pod. The Redis cache is shared across pods, so the dedup still works. The Postgres natural-key check is also shared. Both layers survive pod churn.
+
+The one place where this could go wrong: if the Redis instance itself is reset (a `FLUSHALL`, or a new Redis brought up cold). The first replay after such an event might slip through Layer 1 and land in Postgres — where Layer 2 still catches it. The gateway logs at warn level when Layer 2 triggers (`replay caught by natural key`), so you'll know.
+
+In normal operation, Layer 2 should be silent. If you see it firing regularly, something is wrong with Layer 1 — usually Redis flapping or a TTL too short.
+
+---
+
+## Summary
+
+| Source of duplicate | Caught by |
+|---|---|
+| Charger retries a CALL with the same `message_id` | Redis idempotency cache (Layer 1) |
+| Charger retries with a different `message_id` but the same `transaction_id` / `meter_stop_wh` | Postgres natural key (Layer 2) |
+| Gateway producer retries a Kafka publish | Kafka producer idempotence + your consumer-side `event_id` check |
+| Webhook retries because your endpoint flapped | Your consumer-side `event_id` check |
+| Consumer crashes after processing but before committing | Your consumer-side `event_id` check |
+
+The gateway handles the upstream half. You handle the downstream half — with one cheap check per event.
+
+---
+
+## Where to go from here
+
+- The full message lifecycle that produces these events: [`how-ocpp-flows-work.md`](./how-ocpp-flows-work.md).
+- Why the gateway sometimes needs to route a command to a different pod (and how that interacts with replays): [`multi-pod-and-routing.md`](./multi-pod-and-routing.md).
+- How events actually reach your code: [`../guides/consume-events.md`](../guides/consume-events.md).

--- a/userdocs/concepts/multi-pod-and-routing.md
+++ b/userdocs/concepts/multi-pod-and-routing.md
@@ -1,0 +1,178 @@
+# Multi-pod and routing
+
+**Audience.** Anyone scaling the gateway past one replica, or debugging why a command ended up on a different pod than expected.
+
+**What this answers.** How Envoy hashes chargers to pods, how the gateway routes commands when the receiving pod doesn't own the charger, what happens during a rolling update, and why `cp.offline` events don't fire spuriously during reconnect storms.
+
+> The configuration knobs for this concept are in [`../reference/configuration.md`](../reference/configuration.md) under `cross_pod_bus` and `redis`. This page is the architectural reasoning behind those knobs.
+
+---
+
+## The problem
+
+The gateway holds a long-lived WebSocket per charger. That socket lives on exactly one pod. When your backend says "RemoteStart charger X", the REST/gRPC call lands on **any pod** behind your load balancer — usually *not* the one holding X's socket.
+
+There are three ways to handle this in a multi-pod design:
+
+1. **Make every pod know about every charger.** Each pod stores `cp_id → socket` in a shared store; route through a proxy. Doesn't work — sockets are not shareable.
+2. **Pin charger sockets to one pod with sticky routing.** Then the question becomes "how do I find that pod from another pod" — which is solvable.
+3. **Sidestep the problem with one pod.** Doesn't scale.
+
+The gateway picks (2). Two mechanisms make it work: Envoy ring-hash routing at the edge, and a Redis-backed registry + pub/sub bus across pods.
+
+---
+
+## Envoy ring-hash: chargers stick to pods
+
+Envoy sits in front of the gateway pods as the WSS terminator. Its upstream cluster is the **headless** Service for the gateway (so each pod has its own DNS A record). The cluster's load-balancing policy is `RING_HASH` keyed on the URL path — which contains `cp_id`.
+
+```yaml
+# Simplified excerpt of Envoy's upstream cluster config
+clusters:
+  - name: eveys-ocpp-gateway
+    lb_policy: RING_HASH
+    consistent_hashing_lb_config:
+      use_hostname_for_hashing: false
+    # ... headless service discovery
+    load_balancing_policy:
+      policies:
+        - typed_extension_config:
+            name: envoy.load_balancing_policies.ring_hash
+            typed_config:
+              minimum_ring_size: 1024
+```
+
+Combined with the route's `hash_policy` keyed on `:path`, charger `CP_X`'s WebSocket upgrade lands on the same pod every time — *as long as the pod set is stable*. When pods come and go, the consistent-hash ring rebalances minimally: a single pod join/leave moves ~1/N of chargers, not all of them.
+
+**What this means in practice.** A charger reconnects after a brief network blip → lands on the same pod, same registry key, no state churn. A pod crashes → its chargers redistribute across the remaining pods. A new pod scales out → it absorbs a fraction of new connections; existing connections stay where they are.
+
+---
+
+## The online registry: who owns whom
+
+When a charger's socket opens on pod `P`, `P` writes:
+
+```
+SET cp:online:<cp_id> <pod_id> EX <ttl>
+```
+
+`ttl` is a few multiples of the heartbeat interval — so even if a pod crashes without cleaning up, its keys expire on their own.
+
+Every heartbeat refreshes the TTL. Every command originating on a different pod reads this key to find the owner.
+
+The gauge `eveys_ocpp_registry_online_chargers` reflects this map's size from each pod's view (sum it across pods for the fleet truth; differences between pods indicate split-brain in Redis or stale TTLs).
+
+---
+
+## Cross-pod dispatch: the request bus
+
+Pod `A` receives `POST /commands/remote-start` for charger `X`. `X` is owned by pod `B`. What happens:
+
+1. `A` looks up `cp:online:X` in Redis → `pod_id=B`.
+2. `A` publishes a request envelope to the Redis pub/sub channel `bus:requests:B`:
+
+   ```json
+   {
+     "request_id": "8a3f2c40-3b8e-4d0a-9b62-7a3d5d1e9fa1",
+     "rpc": "RemoteStart",
+     "cp_id": "X",
+     "payload": { ... }
+   }
+   ```
+
+3. `A` opens an inproc future keyed on `request_id` with a 35-second deadline.
+4. `B`'s subscriber picks up the message, dispatches the OCPP CALL on `X`'s socket, awaits the reply, then publishes the response to `bus:responses:A` (same `request_id`).
+5. `A`'s subscriber wakes the inproc future; `A` returns the result to the original REST/gRPC caller.
+
+Total overhead in the steady state: ~5–10 ms on top of the OCPP round-trip. Metrics:
+
+- `eveys_ocpp_grpc_dispatch_route_total{route="local"|"remote"}` — how often the request was same-pod vs cross-pod.
+- `eveys_ocpp_bus_request_latency_seconds` — the cross-pod hop itself.
+- `eveys_ocpp_bus_inflight` — current in-flight bus requests on each pod.
+
+**Why pub/sub, not direct gRPC pod-to-pod.** A handful of reasons:
+
+- Redis is already in the stack (registry + caches). No new dependency.
+- Pub/sub doesn't need pod-to-pod discovery — both pods just talk to the same Redis.
+- Failover semantics are simple: if `B` is gone, the response never comes back; `A`'s future times out at 35 s and returns `CHARGER_OFFLINE` to the caller.
+
+The trade-off: Redis is in the critical path of every cross-pod call. Use a Redis with adequate capacity and a sane connection pool size.
+
+---
+
+## Online and offline events: avoiding spurious fires
+
+A subtle problem: charger `X` is on pod `B`. Pod `B` is restarted. `X` reconnects to pod `C` (different ring slot post-rebalance) within seconds. Naive logic would fire:
+
+- `B` sees its socket close → publishes `cp.offline` for `X`.
+- `C` sees a new socket open → publishes `cp.online` for `X`.
+
+But from a backend's perspective, `X` was never offline — the socket churn was a platform-internal hiccup. Spurious offline events are operationally annoying.
+
+The fix: **compare-and-delete** on the registry key, **only fire `cp.offline` if you still owned the key**.
+
+```python
+# On socket close, on pod B:
+was_ours = redis.eval("""
+  if redis.call("GET", KEYS[1]) == ARGV[1] then
+    return redis.call("DEL", KEYS[1])
+  else
+    return 0
+  end
+""", keys=["cp:online:X"], args=[B_pod_id])
+
+if was_ours:
+    publish("cp.offline", {"cp_id": "X", "pod_id": B_pod_id, "reason": "clean"})
+```
+
+If `C` has already overwritten the key (because `X` reconnected during `B`'s shutdown), `was_ours` is 0 and no offline event fires. Backends only see `cp.offline` when a charger is genuinely off.
+
+---
+
+## Rolling updates: zero-drop, mostly
+
+The chart configures rolling updates with `maxUnavailable: 0` and a `terminationGracePeriodSeconds` that exceeds the gateway's grace window. The sequence per pod is:
+
+1. New pod `P_new` comes up, fails liveness until ready, then passes readiness.
+2. Old pod `P_old` receives `SIGTERM`. It flips `/api/v1/ready` to 503 so Envoy stops sending new connections.
+3. `P_old` keeps servicing existing sockets and inflight requests for up to `EVEYS_OCPP_SHUTDOWN_GRACE_PERIOD_SECONDS`.
+4. After the grace window, `P_old` closes remaining sockets cleanly. Chargers reconnect; the consistent-hash ring distributes them across remaining pods.
+5. Kubernetes deletes `P_old` and moves on to the next pod.
+
+Net effect: charger sockets see at most one disconnect-and-reconnect during the whole rollout. Active charging sessions are not interrupted — the session continues, the socket churn is transparent to the user.
+
+The metric to watch during a rollout: `eveys_ocpp_ws_connections_active`. If you see a deeper dip than expected, something else is going on (Envoy didn't see the pod's readiness flip, or the charger fleet isn't reconnecting promptly).
+
+---
+
+## What can still go wrong
+
+### Redis as single point of failure
+
+Every cross-pod call routes through Redis pub/sub. A Redis outage means cross-pod dispatch fails (the pod that received the REST call returns `CHARGER_OFFLINE` after the timeout). Same-pod calls keep working.
+
+Mitigation: high-availability Redis (Sentinel or Cluster). The gateway accepts both modes via `EVEYS_OCPP_REDIS_URL`.
+
+### Pod-affinity mismatch during scale-down
+
+When the autoscaler removes pods, the ring rebalances. The chargers that *were* on the removed pod reconnect to whichever pod the new ring slot points to. There's a few-seconds gap during which a command for one of those chargers returns `CHARGER_OFFLINE` (the registry key expired on the removed pod, and the new pod hasn't seen a reconnect yet).
+
+Mitigation: conservative scale-down (the `stabilizationWindowSeconds: 300` recommendation in [`../guides/deploy-to-production.md`](../guides/deploy-to-production.md)).
+
+### Split-brain in Redis
+
+If Redis itself splits brain (rare with HA configured correctly), two pods may both think they own the same charger. The compare-and-delete on offline is defensive against this — only the pod that wrote its own value can delete it — but commands could route to either pod. The OCPP wire layer would catch this (the wrong pod has no socket; CALL fails) but the user-facing message is a confusing `CHARGER_TIMEOUT` rather than an offline error.
+
+This is a rare configuration bug rather than a normal failure mode.
+
+### Heartbeat-registry reclaims
+
+The `eveys_ocpp_heartbeat_registry_reclaims_total` counter tracks "a heartbeat arrived on pod P, but the registry said the charger was on pod Q". Non-zero values indicate a previous owner that didn't clean up its key (typically a pod that crashed without finalising). The gateway transparently reclaims the key for the new owner; you should expect this counter to be small and bursty, not zero.
+
+---
+
+## Where to go from here
+
+- The other half of "duplicate-protection": [`idempotency-and-replay.md`](./idempotency-and-replay.md).
+- How a single message threads through everything described here: [`how-ocpp-flows-work.md`](./how-ocpp-flows-work.md).
+- Operational view of pod churn: [`../guides/operate.md`](../guides/operate.md).

--- a/userdocs/concepts/security-model.md
+++ b/userdocs/concepts/security-model.md
@@ -1,0 +1,161 @@
+# Security model
+
+**Audience.** Anyone preparing this gateway for production or doing a security review.
+
+**What this answers.** What the gateway trusts, what it does not, where the authentication boundaries are, and the threat model in one page.
+
+> The operational levers (TLS, mTLS, tokens, secrets) live in [`../guides/deploy-to-production.md`](../guides/deploy-to-production.md). This page is the *why* — the mental model behind those levers.
+
+---
+
+## The boundaries
+
+The gateway sits between two kinds of system: chargers (low-trust, deployed in the field, sometimes physically accessible to the public) and your platform (higher-trust, inside your own infrastructure). Every connection crossing those boundaries has an authentication mechanism and a clear answer to "what does the gateway accept based on what evidence".
+
+```
+                    Chargers
+        (low trust; field-deployed; some are in public spaces)
+                       │
+                       │  wss://  ───────────────  TLS (cert from your CA or public)
+                       │           charger Basic Auth (cp_id:password)
+                       │           optional charger client cert (mTLS at the edge)
+                       ▼
+                  ┌────────┐
+                  │ Envoy  │
+                  └────┬───┘
+                       │  TCP cleartext  ─────────  (optional) mTLS Envoy↔gateway
+                       │                              gateway authenticates Envoy
+                       ▼
+                ┌────────────┐
+                │  Gateway   │
+                └────┬───────┘
+                     │
+        ┌────────────┼────────────────────┐
+        │            │                    │
+        ▼            ▼                    ▼
+  Postgres /     Your backend       Webhook endpoints
+  Redis /        (REST hot path)    (your endpoints)
+  Kafka          - bearer token     - HMAC-SHA256 sig
+  - DSN auth     - server TLS       - server TLS (yours)
+                 - mTLS optional
+                       ▲
+                       │
+                       │  Inbound REST / gRPC  ──  bearer token in `Authorization`
+                       │                            (rate-limited per token)
+                  Your platform
+                  (your services, your dashboards, your scripts)
+```
+
+---
+
+## What the gateway trusts
+
+In one list, ordered from "most trusted" to "least":
+
+1. **Settings from environment + the runtime overrides Redis key.** These are bound at startup by your platform.
+2. **The TLS chain to your backend, Postgres, Redis, Kafka, ClickHouse.** Standard PKI; you control the certs.
+3. **The bearer tokens you provisioned** for REST/gRPC inbound auth. Trusted because they came from your secret store.
+4. **Envoy** for the edge — once authenticated via mTLS (when enabled), the gateway treats incoming WebSocket connections as coming from Envoy.
+5. **The charger's Basic Auth credentials** (when the charger presents them). Trusted because the bcrypt hash matches what's in the per-charger credentials table.
+6. **The charger's OCPP wire content** — *only the schema and the fields that have transport-level meaning*. The charger's claimed clock, claimed `id_tag`, claimed measurand values: these are accepted but not authoritative.
+7. **Nothing else.**
+
+---
+
+## What the gateway does *not* trust
+
+Spelling out what gets second-guessed:
+
+- **The charger's clock.** Every charger-reported `timestamp` is captured and persisted, but the canonical wall-clock time for everything is the gateway's server-receive time. The boot reply tells the charger what time it is; some chargers ignore it. Don't build billing logic that uses `charger_reported_at` as truth.
+- **Charger-provided identifiers.** A charger can report any `id_tag` it likes. The gateway forwards the value to your backend's `Authorize` endpoint; **your backend is the source of truth for whether this `id_tag` represents an authorized user**.
+- **The charger's identity beyond Basic Auth.** Anyone who has stolen a charger's credential can impersonate it. mTLS at the edge (charger client certificate) is the additional layer when you need it; most fleets don't, but production-grade ones should.
+- **Measurand sanity.** Meter readings are filtered (negative energy → quarantined; impossible voltages → dropped). A maliciously crafted `MeterValues` cannot poison ClickHouse with rubbish that breaks downstream queries.
+- **Replays.** The same `BootNotification` / `StartTransaction` / `StopTransaction` can arrive twice; the gateway dedupes via the idempotency cache. See [`idempotency-and-replay.md`](./idempotency-and-replay.md).
+- **Any incoming command from inside the cluster on the gateway's WebSocket port.** With internal mTLS enabled, only Envoy can speak to the gateway's WS port. Without it, a compromised sidecar in the same namespace could potentially open an OCPP socket and pretend to be a charger.
+
+---
+
+## Threats in scope
+
+| Threat | Mitigation |
+|---|---|
+| **A bad actor on the public internet trying to open a charger socket** | TLS at the edge (Envoy); WS server requires `Authorization: Basic` on every upgrade. |
+| **Stolen charger credentials** | Per-charger Basic Auth, rotatable per charger via REST. Optional charger-side mTLS as a second factor. |
+| **A bad actor inside your cluster trying to send OCPP commands** | Internal mTLS (Envoy ↔ gateway). Without mTLS, NetworkPolicies are your only line. |
+| **A bad actor calling REST without credentials** | Bearer-token check; rate limiting per token. |
+| **A leaked bearer token** | Tokens are a CSV; rotate by adding the new token, deploying, removing the old. |
+| **A leaked webhook signing secret** | HMAC-SHA256 over the body; rotate with the same overlap strategy. |
+| **A charger sending forged events** | Cannot — the charger can only send messages on *its own* socket, identified by its `cp_id` (URL path). It can lie about its `id_tag`, but cannot pose as a different charger. |
+| **Backend compromise** | Out of scope; the gateway's blast radius is "the platform stops authorizing users". The gateway itself does not authorize. |
+| **OCPP protocol bugs** | Schema validation at the wire boundary; malformed messages are rejected before reaching the handler. |
+| **Replay attacks at the OCPP layer** | Idempotency cache; replays are at-most-once-effective. |
+| **Denial of service** | Rate limits per token, per charger. Kafka and webhook deliveries have bounded retry budgets. |
+| **Data exfiltration via the OpenAPI surface** | `EVEYS_OCPP_REST_OPENAPI_ENABLED=false` for internet-exposed deployments. |
+
+---
+
+## Threats *out of scope*
+
+The gateway does not address:
+
+- **Physical access to a charger.** A jailbroken charger can do whatever the OEM's firmware allows. The OCPP protocol assumes the charger is a participant, not an attacker.
+- **Compromised user devices.** RFID cloning, app-token theft — your platform's identity layer owns these.
+- **Side-channel attacks on the data plane.** Disk encryption, network-level monitoring, supply-chain integrity of the container images — your platform owns these.
+- **Insider threat at your operator level.** Anyone with cluster admin can do anything the gateway can do. Limit that role accordingly.
+
+---
+
+## The auth boundaries in detail
+
+### Charger → Envoy
+
+- **TLS**: the certificate the charger sees must chain back to a CA the charger trusts. Either a public CA (Let's Encrypt) if your edge hostname is public, or your own CA installed on every charger in the fleet.
+- **Optional mTLS**: configure Envoy to require a charger client certificate. Useful for high-trust fleets where every charger is provisioned with its own cert; overkill for most.
+
+### Envoy → Gateway
+
+- Cleartext by default — the assumption is that this hop lives inside a namespace or VPC.
+- **mTLS recommended in production.** Both sides reference the same `Secret`; rotation stays in lockstep. Without it, anything else in the same network that can reach the WebSocket port can pretend to be Envoy.
+
+### Charger → Gateway (above the TLS layer)
+
+- **Basic Auth.** `Authorization: Basic <base64(cp_id:password)>` on the WebSocket upgrade. Password is bcrypt-hashed in `charge_point_credentials`. Rotation: write a new hash and the charger picks it up on its next connection.
+- **Strict mode** (`EVEYS_OCPP_WS_BASIC_AUTH_REQUIRED=true`) is the production setting — no credential row, no connection.
+
+### Your platform → Gateway (REST / gRPC)
+
+- **Bearer token.** CSV in `EVEYS_OCPP_REST_INBOUND_TOKENS`. Rotation: add new, deploy, update callers, remove old, deploy.
+- **Rate limited** per token. Exceeding the limit returns 429.
+- **TLS on the public side** is your responsibility — `kubectl port-forward` for dev; a properly-fronted service in production.
+
+### Gateway → Your backend
+
+- **Server TLS**: the gateway trusts your backend's TLS cert via the system CA trust store. Roll a private CA by adding it to the container's trust roots at image-build time.
+- **Bearer token**: `EVEYS_OCPP_BACKEND_TOKEN`, sent in `Authorization: Bearer ...`.
+- **mTLS to the backend** is not in the chart today; if you need it, the backend integration would need to grow that option.
+
+### Gateway → Webhook endpoints
+
+- **Server TLS**: gateway respects your endpoint's cert.
+- **HMAC-SHA256 over the body**: `X-Eveys-Signature: sha256=<lowercase-hex>`. Your endpoint verifies; an attacker who learns your webhook URL cannot forge a delivery without the secret.
+
+---
+
+## Where you should think hardest
+
+A small list of things to actually decide for your deployment:
+
+1. **What CA signs your charger TLS certs?** A public CA is simplest if your edge is public. A private CA is unavoidable if chargers aren't on the public internet. Document the trust roots installed on every charger and how you rotate them.
+2. **Do you want charger mTLS?** Only worth it for fleets where credential theft is plausible. Adds operational complexity proportional to fleet size.
+3. **How are bearer tokens distributed and rotated?** A secret manager, not a config file. Define the rotation cadence; rehearse it.
+4. **Is your backend's `Authorize` endpoint protected against the gateway being compromised?** I.e., if someone got the gateway's `BACKEND_TOKEN`, could they cause the backend to admit users who shouldn't be admitted? If so, scope the token (rate limits, IP allow-list) on the backend side.
+5. **What does `BACKEND_AUTHORIZE_FALLBACK` say when your backend is down?** `reject` is the safe default. `accept_offline` is operationally convenient and a real risk if it stays on. Pick deliberately.
+6. **Does the OpenAPI surface need to be public?** It exposes the API shape but not data. Most prod deployments turn it off; some leave it on behind a VPN.
+
+---
+
+## Where to go from here
+
+- Concrete production hardening: [`../guides/deploy-to-production.md`](../guides/deploy-to-production.md).
+- What's actually configurable: [`../reference/configuration.md`](../reference/configuration.md).
+- The message flows these boundaries are protecting: [`how-ocpp-flows-work.md`](./how-ocpp-flows-work.md).

--- a/userdocs/guides/connect-a-charger.md
+++ b/userdocs/guides/connect-a-charger.md
@@ -1,0 +1,198 @@
+# Connect a charger
+
+**Audience.** A site engineer or integrator pointing an OCPP 1.6 charger at this gateway for the first time. The charger itself can be a real piece of hardware on a workbench or a simulator on the same laptop.
+
+**What this answers.** What URL the charger uses, how Basic Auth works, what a successful boot looks like, and the most common failures with the fix for each.
+
+> If you're brand new, read [`../02-quickstart.md`](../02-quickstart.md) first — it brings a simulator up against a local Compose stack in ten minutes. This page is the next layer: real chargers, real networks, real fault modes.
+
+---
+
+## 1. What the charger needs to know
+
+Every OCPP 1.6 charger configuration screen asks the same three things:
+
+| Field | Value | Example |
+|---|---|---|
+| **Server URL** | The base WebSocket URL the gateway is reachable at. | `wss://ocpp.example.com` (production) or `ws://10.0.0.5:19000` (dev) |
+| **Charge Point ID** | A stable identifier you assign per charger. | `CP_ACME_BERLIN_42` |
+| **Authorization key** (Basic Auth password) | The shared secret for this charger. | An opaque string you provisioned |
+
+The final WebSocket URL the charger opens is `<server-url>/<cp_id>`. The charger sends `Authorization: Basic <base64(cp_id:password)>` on the WebSocket upgrade.
+
+The WebSocket subprotocol the charger requests must be exactly `ocpp1.6` (or `ocpp2.0.1` for 2.0.1 chargers). The gateway rejects upgrades that don't negotiate one of those.
+
+---
+
+## 2. Provisioning the charger in the gateway
+
+Two things have to happen on the gateway side before a charger can connect.
+
+### 2.1 Pick the `cp_id`
+
+It's a string. Pick a scheme that:
+
+- **Is stable.** Once chosen for a physical charger, never reuse for another. The whole platform indexes on this.
+- **Survives URLs.** Letters, digits, `_` and `-`. Avoid `/`, spaces, anything that needs escaping.
+- **Tells you something at a glance.** `CP_SITE_42` beats `CP_42` beats an opaque UUID.
+
+The same `cp_id` becomes the partition key on every Kafka event and the path parameter on every REST query about this charger.
+
+### 2.2 Provision the credential
+
+The gateway looks up the per-charger password in Postgres on every WebSocket upgrade. To add a charger:
+
+```bash
+# Generate a strong password
+PASSWORD=$(openssl rand -base64 32)
+
+# Hash it (bcrypt) and store in the credentials table.
+# Replace CP_ACME_42 with the cp_id you chose.
+# Replace the DSN with your gateway's database.
+psql "$EVEYS_OCPP_DB_URL" <<SQL
+INSERT INTO charge_points (cp_id) VALUES ('CP_ACME_42')
+  ON CONFLICT (cp_id) DO NOTHING;
+
+INSERT INTO charge_point_credentials (charge_point_id, password_hash)
+SELECT id, crypt('$PASSWORD', gen_salt('bf', 12))
+FROM charge_points WHERE cp_id = 'CP_ACME_42'
+ON CONFLICT (charge_point_id) DO UPDATE SET password_hash = EXCLUDED.password_hash;
+SQL
+
+# Hand $PASSWORD to whoever configures the charger.
+```
+
+> **About `EVEYS_OCPP_WS_BASIC_AUTH_REQUIRED`.** By default this is `false` — chargers without a credential row connect anyway. That's a migration shim for fleets onboarding to OCPP for the first time. Production should set it to `true` once every charger is provisioned, so an un-provisioned charger fails fast at the WebSocket upgrade instead of slipping through unauthenticated.
+
+---
+
+## 3. Pointing the charger at the gateway
+
+This step lives on the charger's web interface, vendor app, or DIP-switch configuration — every OEM has a different mechanism. The values are the same:
+
+- **Server URL.** Production: `wss://<your-edge-hostname>` (TLS via Envoy). Local dev: `ws://<gateway-host>:19000`.
+- **Charge Point ID.** The `cp_id` you provisioned in §2.
+- **Authorization key.** The password from §2.
+
+Once configured, the charger opens the WebSocket within a few seconds (typically on reboot or on hitting "Apply" on the config page).
+
+---
+
+## 4. What a healthy boot looks like
+
+Watch the gateway's logs. A successful first connection produces a sequence:
+
+```
+ws.upgrade.accepted          cp_id=CP_ACME_42 subprotocol=ocpp1.6
+boot_notification            cp_id=CP_ACME_42 vendor=ACME model=Charger-V2 firmware=1.4.2 status=Accepted
+status_notification          cp_id=CP_ACME_42 connector_id=1 status=Available error_code=NoError
+heartbeat                    cp_id=CP_ACME_42
+heartbeat                    cp_id=CP_ACME_42      # every interval seconds...
+```
+
+On Kafka you'll see one envelope on `cp.connected`, one on `cp.boot`, one on `cp.status`, and a stream of heartbeats absorbed by the registry (heartbeats don't publish events by default — they're noise at fleet scale).
+
+Confirm from REST:
+
+```bash
+curl -s http://<gateway>/api/v1/charge-points/CP_ACME_42 \
+  -H "Authorization: Bearer $TOKEN" \
+  | python3 -m json.tool
+```
+
+`last_boot_at`, `last_heartbeat_at`, and the `connectors` array all reflect what just happened.
+
+---
+
+## 5. When it doesn't work — the failure catalogue
+
+These are the failures you'll see in roughly the order they occur as a charger boots.
+
+### 5.1 Connection refused / no response
+
+The charger logs a TCP-level failure trying to open the socket.
+
+- **Cause:** the gateway isn't reachable on the configured host:port.
+- **Check:** from the charger's network, `nc -vz <host> <port>`. If that fails, the charger can't reach the gateway. Firewall, NAT, wrong port.
+- **Fix:** confirm the WebSocket port is exposed (`19000` in Compose; `443` behind Envoy in production).
+
+### 5.2 TLS handshake fails
+
+Charger logs an SSL error.
+
+- **Cause:** the charger doesn't trust your TLS certificate, or the certificate's SAN doesn't include the hostname the charger is dialling.
+- **Check:** `openssl s_client -connect <host>:443 -servername <host>` from a machine on the charger's network.
+- **Fix:** install your CA on the charger (most chargers have a "trusted roots" upload), or re-issue the cert with the right SAN.
+
+### 5.3 HTTP 401 / 403 on the WebSocket upgrade
+
+Charger logs an authentication error.
+
+- **Cause:** the `Authorization` header didn't match what's in Postgres.
+- **Check:** gateway log line `ws.basic_auth.failed cp_id=CP_X reason=...`.
+- **Fix:** re-provision the password (§2.2). If the gateway logs `reason=no_credential_row` and `EVEYS_OCPP_WS_BASIC_AUTH_REQUIRED=true`, you need to insert the row.
+
+### 5.4 HTTP 426 / "Upgrade required" / subprotocol error
+
+- **Cause:** the charger isn't requesting `ocpp1.6` (or `ocpp2.0.1`) as the WebSocket subprotocol.
+- **Check:** gateway log line `ws.upgrade.rejected reason=no_acceptable_subprotocol`.
+- **Fix:** firmware config issue on the charger; some OEMs let you override the subprotocol string. The exact value the charger sends should be `ocpp1.6`.
+
+### 5.5 WebSocket connects but `BootNotification` is `Rejected`
+
+The connection opened, but the gateway answered the very first OCPP CALL with `status: Rejected`.
+
+- **Cause:** the gateway's policy for new chargers is "Rejected" (rare; the default is "Accepted"). Or your backend's `charge-points/register` endpoint returned a negative answer.
+- **Check:** gateway log line `boot_notification ... status=Rejected reason=...`.
+- **Fix:** review the backend's registration response — see how it's expected to behave in the security model concept page.
+
+### 5.6 `BootNotification` succeeds, but no `Heartbeat`s
+
+- **Cause:** the charger interprets the boot reply's `interval` as `0` and so never heartbeats. Some older firmwares mishandle that.
+- **Check:** `BootNotification` reply payload in gateway logs — `interval` should be a positive integer (typically 30–300).
+- **Fix:** raise `EVEYS_OCPP_HEARTBEAT_INTERVAL_SECONDS` to a sane default (e.g. 60) so even buggy firmwares hold the socket open with traffic.
+
+### 5.7 Heartbeat works but no `StatusNotification`
+
+- **Cause:** the charger thinks every connector is faulted or unavailable and isn't reporting state changes.
+- **Check:** charger's own diagnostic UI — most OEMs show connector state directly. Also: dispatch a `TriggerMessage` of type `StatusNotification` from the gateway:
+
+  ```bash
+  curl -s -X POST http://<gateway>/api/v1/charge-points/CP_ACME_42/commands/trigger-message \
+    -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+    -d '{"requested_message":"StatusNotification","connector_id":1}'
+  ```
+- **Fix:** charger-side. If `TriggerMessage` returns `NotImplemented`, the OEM doesn't support it (uncommon).
+
+### 5.8 Socket disconnects every few minutes
+
+- **Cause:** a network device between the charger and the gateway is killing idle TCP connections. Heartbeats every 30–300 s normally prevent this, but some routers are aggressive.
+- **Fix:** lower `EVEYS_OCPP_HEARTBEAT_INTERVAL_SECONDS` (the gateway returns this as the boot reply's `interval`). Don't go below 10 s — you'll flood Kafka and Postgres without gaining anything.
+
+### 5.9 Disconnects after a `RemoteStart` from the backend
+
+- **Cause:** typically a charger-side firmware bug; the OCPP CALL exceeds whatever the charger expects.
+- **Check:** gateway log around the RemoteStart, then the charger's own log.
+- **Fix:** OEM-specific. File against the OEM with the exact request payload from the gateway log.
+
+---
+
+## 6. When you're stuck
+
+The gateway emits a structured JSON log line per OCPP CALL. Filter by `cp_id` and you'll see exactly what crossed the wire in both directions:
+
+```bash
+docker logs eveys-ocpp 2>&1 | jq 'select(.cp_id == "CP_ACME_42")'
+# or in k8s:
+kubectl -n eveys-ocpp logs -l app=eveys-ocpp -f | jq 'select(.cp_id == "CP_ACME_42")'
+```
+
+If you can't reproduce the issue, the simulator can drive an arbitrary sequence of CALLs at the gateway from your laptop — useful for proving the gateway works in isolation when the charger keeps crashing. See [`../02-quickstart.md`](../02-quickstart.md) §4 for the one-liner.
+
+---
+
+## Where to go from here
+
+- **Backend integration**: [`use-the-rest-api.md`](./use-the-rest-api.md), [`consume-events.md`](./consume-events.md).
+- **Production**: [`deploy-to-production.md`](./deploy-to-production.md).
+- **What's happening end-to-end**: [`../concepts/how-ocpp-flows-work.md`](../concepts/how-ocpp-flows-work.md).

--- a/userdocs/guides/consume-events.md
+++ b/userdocs/guides/consume-events.md
@@ -1,0 +1,215 @@
+# Consume events
+
+**Audience.** A backend or data developer subscribing to charger events.
+
+**What this answers.** Two transports — Kafka and webhooks — one envelope shape. When to pick which. Ordering, idempotency, and at-least-once semantics you can rely on.
+
+> The full event catalogue (every topic, every payload) is [`../reference/events.md`](../reference/events.md). This page is the *integration shape* — how to consume them, not what each one says.
+
+---
+
+## 1. One envelope, two transports
+
+Every event the gateway publishes carries the same protobuf wrapper:
+
+```protobuf
+message EventEnvelope {
+  string event_id      = 1;   // UUID, unique per event
+  string occurred_at   = 2;   // ISO-8601 server-receive timestamp (UTC)
+  string cp_id         = 3;   // charger this event is about
+  string schema_version = 4;  // "v1"
+  string trace_id      = 5;   // optional, for distributed tracing
+  oneof payload {
+    CpConnected             cp_connected             = 100;
+    CpBoot                  cp_boot                  = 101;
+    CpStatus                cp_status                = 102;
+    CpMeter                 cp_meter                 = 103;
+    TxStarted               tx_started               = 104;
+    CpSecurityEvent         cp_security_event        = 105;
+    TxStopped               tx_stopped               = 106;
+    CpDisconnected          cp_disconnected          = 107;
+    CpFirmwareStatusChanged cp_firmware_status_changed = 108;
+    CpDiagnosticsStatusChanged cp_diagnostics_status_changed = 109;
+    CpCsrSubmitted          cp_csr_submitted         = 110;
+  }
+}
+```
+
+Which payload is set is what tells the consumer "what kind of event is this". The wrapper is the same regardless of transport.
+
+The proto file lives at `proto/events/v1/events.proto` in the repository — point your build system at it to generate consumer-side bindings in your language.
+
+---
+
+## 2. When to choose Kafka
+
+Pick Kafka when you want:
+
+- **A firehose** you can replay from any offset. The consumer chooses when to read; the gateway publishes and forgets.
+- **Multiple consumers** for the same events without the gateway needing to know about them. New consumers come up, read from `earliest`, and catch up.
+- **Strong ordering per charger.** Every event uses `cp_id` as the partition key, so a single charger's events are strictly ordered. Cross-charger ordering is not guaranteed and you should not depend on it.
+- **At-least-once delivery** with consumer-side idempotency. Standard Kafka semantics.
+
+Typical use cases: a billing service tailing `tx.stopped`, a fleet-status dashboard tailing `cp.status` and `cp.connected`/`cp.disconnected`, an audit pipeline tailing `cp.security_event`, an analytics warehouse ingesting everything.
+
+### 2.1 Topic names
+
+The defaults are:
+
+| Topic | Payload | Volume |
+|---|---|---|
+| `cp.connected` | `CpConnected` | per WS connection establish |
+| `cp.disconnected` | `CpDisconnected` | per WS connection end |
+| `cp.boot` | `CpBoot` | rare; on charger reboot |
+| `cp.status` | `CpStatus` | bursts of a few per state change |
+| `cp.meter` | `CpMeter` | high — every meter sample on every active session |
+| `cp.firmware_status` | `CpFirmwareStatusChanged` | low; firmware-update lifecycle |
+| `cp.diagnostics_status` | `CpDiagnosticsStatusChanged` | low; diagnostics-upload lifecycle |
+| `cp.security_event` | `CpSecurityEvent` | sparse; audit-grade |
+| `cp.csr_submitted` | `CpCsrSubmitted` | sparse; cert-rotation cycles |
+| `tx.started` | `TxStarted` | one per charging session start |
+| `tx.stopped` | `TxStopped` | one per charging session end |
+
+The names are configurable via `EVEYS_OCPP_KAFKA_TOPIC_*` env vars in case your platform uses a different naming convention.
+
+### 2.2 Consumer example (Python)
+
+```python
+from aiokafka import AIOKafkaConsumer
+import asyncio
+from events.v1 import events_pb2     # your generated bindings
+
+async def main():
+    consumer = AIOKafkaConsumer(
+        "tx.stopped",
+        bootstrap_servers="kafka.example.com:9092",
+        group_id="billing-service",
+        enable_auto_commit=False,
+    )
+    await consumer.start()
+    try:
+        async for msg in consumer:
+            env = events_pb2.EventEnvelope()
+            env.ParseFromString(msg.value)
+            if env.WhichOneof("payload") != "tx_stopped":
+                continue
+            handle_tx_stopped(env.cp_id, env.tx_stopped)
+            await consumer.commit()
+    finally:
+        await consumer.stop()
+
+asyncio.run(main())
+```
+
+`enable_auto_commit=False` plus an explicit commit after handling is the standard "at-least-once with consumer-side idempotency" pattern.
+
+---
+
+## 3. When to choose webhooks
+
+Pick webhooks when:
+
+- **You don't run a Kafka client.** Your backend already accepts HTTPS POSTs and that's the only push mechanism you want to maintain.
+- **You want immediate delivery** rather than running a long-lived consumer loop.
+- **The event volume is low.** Webhooks are a great fit for `tx.started`, `tx.stopped`, `cp.online`, `cp.offline`, security events. They are a *bad* fit for `cp.meter` and `cp.status` at fleet scale (high frequency × HTTP overhead).
+
+### 3.1 The delivery shape
+
+The gateway POSTs JSON (not protobuf — the wire is HTTP, the payload is the same envelope JSON-encoded):
+
+```http
+POST /api/eveys/webhooks/tx.stopped HTTP/1.1
+Host: <your-backend>
+Content-Type: application/json
+X-Eveys-Signature: sha256=<lowercase-hex-digest>
+X-Eveys-Event-Type: tx.stopped
+X-Eveys-Event-Id: <uuid>
+X-Eveys-Delivery-Attempt: 1
+
+{
+  "event_id":   "...",
+  "occurred_at":"2026-05-11T10:00:00Z",
+  "cp_id":      "CP_X",
+  "schema_version": "v1",
+  "payload": {
+    "tx_stopped": { ... }
+  }
+}
+```
+
+### 3.2 Verify the signature
+
+Every delivery is HMAC-SHA256 signed with `EVEYS_OCPP_WEBHOOK_SECRET`:
+
+```python
+import hmac, hashlib
+
+def is_valid(body: bytes, header: str, secret: bytes) -> bool:
+    expected = "sha256=" + hmac.new(secret, body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, header)
+```
+
+Reject deliveries with a missing or wrong signature. Use a constant-time comparison (above; `hmac.compare_digest` in Python) to dodge timing attacks.
+
+### 3.3 At-least-once with retries
+
+The gateway treats your endpoint as "successful" on any 2xx. On non-2xx or a network error, it retries with exponential backoff up to a configurable budget. Your endpoint will receive duplicates from time to time — **be idempotent on `event_id`**.
+
+A simple shape: maintain a recent `event_id` cache on your side. First time you see one, process; subsequent deliveries, 200 OK without doing anything.
+
+### 3.4 Configure delivery
+
+In the gateway environment:
+
+```bash
+EVEYS_OCPP_WEBHOOK_URL_TX_STOPPED=https://backend.example.com/api/eveys/webhooks/tx.stopped
+EVEYS_OCPP_WEBHOOK_ENABLE_TX_STOPPED=true
+EVEYS_OCPP_WEBHOOK_SECRET=<32+ bytes of base64>
+```
+
+Each event has its own `WEBHOOK_URL_*` and `WEBHOOK_ENABLE_*` pair. Mix and match — subscribe to some events by webhook and some by Kafka, your call.
+
+---
+
+## 4. Both at once?
+
+Yes. The gateway publishes to Kafka and (independently) dispatches webhooks. Subscribing to the same event over both is allowed; you'll see the event arrive twice, once per transport, each carrying the same `event_id`. Idempotency on `event_id` makes that safe.
+
+A common pattern: subscribe to high-volume events (`cp.meter`, `cp.status`) over Kafka and low-volume "I want to know now" events (`tx.started`, `tx.stopped`, `cp.security_event`) over webhooks. Lets the backend keep its synchronous billing logic in the webhook handler while shipping the firehose to a separate analytics consumer.
+
+---
+
+## 5. Ordering — what you can and can't rely on
+
+What you **can** rely on:
+
+- **Per-`cp_id` ordering on Kafka.** All events for one charger arrive in the order the gateway saw them.
+- **Per-`cp_id` ordering across event types.** A `tx.started` for charger X arrives before the `cp.meter` samples for the same charger's session.
+- **Webhook order is best-effort.** Concurrent retries can deliver out of order.
+
+What you **cannot** rely on:
+
+- **Cross-charger ordering.** `tx.started` for charger X may arrive before or after `tx.stopped` for charger Y — they're on different partitions.
+- **Synchronous causality between REST commands and events.** A `RemoteStart` REST call returns `Accepted` independently of the `tx.started` event publishing. Don't block your REST caller on the Kafka offset advancing.
+
+For the deeper picture of what messages flow when, [`../concepts/how-ocpp-flows-work.md`](../concepts/how-ocpp-flows-work.md).
+
+---
+
+## 6. What's not on either transport
+
+A handful of OCPP messages have no dedicated event:
+
+- **Heartbeats** — absorbed by the online registry. The fact that a charger heartbeated is reflected in `last_heartbeat_at` on the REST surface, not as a Kafka message. At fleet scale, "heartbeat received" events would drown everything else.
+- **Authorize** — synchronous; the gateway forwards the charger's request to your backend's hot-path REST endpoint. No event because the backend was already in the loop.
+- **Outbound command results** (`RemoteStart` reply, `Reset` reply, etc.) — synchronous REST responses; not republished as events.
+
+If a downstream consumer wants any of these, the right hook is the metrics endpoint (`/metrics`) or the REST read endpoints.
+
+---
+
+## Where to go from here
+
+- Full per-event reference: [`../reference/events.md`](../reference/events.md).
+- The synchronous side of the same flow: [`use-the-rest-api.md`](./use-the-rest-api.md).
+- Why duplicates happen and how the gateway prevents *its own* duplicates: [`../concepts/idempotency-and-replay.md`](../concepts/idempotency-and-replay.md).

--- a/userdocs/guides/deploy-to-production.md
+++ b/userdocs/guides/deploy-to-production.md
@@ -1,0 +1,287 @@
+# Deploy to production
+
+**Audience.** An operator about to run this in production.
+
+**What this answers.** TLS at the charger edge, mTLS internally, autoscaling, secrets, graceful drain. Closes with a pre-flight sign-off checklist.
+
+> If you're not yet running on a cluster, start with [`install.md`](./install.md). This page assumes the chart is installed and walks through what to harden before chargers hit it.
+
+---
+
+## 1. TLS at the charger edge
+
+Chargers connect over `wss://` to Envoy. Envoy terminates TLS and forwards the cleartext WebSocket upstream to the gateway pod.
+
+### 1.1 Get a certificate
+
+Two reasonable paths:
+
+- **cert-manager** with a public ACME issuer (Let's Encrypt, ZeroSSL) if your edge hostname is internet-resolvable.
+- **A private CA** if your charger fleet trusts your own roots (common when chargers and the platform are operated by the same entity).
+
+Either way, you end up with a Kubernetes `Secret` of type `kubernetes.io/tls` carrying `tls.crt` and `tls.key`. The chart references it by name:
+
+```yaml
+envoy:
+  tls:
+    secretName: eveys-ocpp-edge-tls
+```
+
+### 1.2 Confirm the SAN
+
+The certificate's Subject Alternative Name **must** match the hostname the chargers are configured to dial. If a charger is configured for `wss://ocpp.example.com` and your cert is for `wss://gateway.example.com`, the TLS handshake fails and you'll see it in Envoy's access logs.
+
+```bash
+openssl x509 -in cert.crt -noout -text | grep -A1 "Subject Alternative Name"
+```
+
+### 1.3 Rotation
+
+cert-manager renews on its own; the Envoy pods need to pick up the new Secret. The chart does *not* do automatic reload — the cleanest way is to roll the Envoy Deployment:
+
+```bash
+kubectl -n eveys-ocpp rollout restart deployment/eveys-ocpp-envoy
+```
+
+A few-second blip in new connections; existing sockets are unaffected. Schedule rotations off-peak.
+
+---
+
+## 2. mTLS between Envoy and the gateway
+
+The chargers ↔ Envoy leg uses standard TLS (server cert; optional charger client cert). The Envoy ↔ gateway leg can be locked down with mutual TLS so anything other than Envoy hitting the gateway's WebSocket port fails the TLS handshake.
+
+This is **off by default** in the chart. Turning it on is a two-side change:
+
+```yaml
+gateway:
+  mtls:
+    enabled: true
+    secretName: eveys-ocpp-internal-mtls   # tls.crt, tls.key, ca.crt
+envoy:
+  upstreamMtls:
+    secretName: eveys-ocpp-internal-mtls   # same Secret; Envoy presents the client side
+```
+
+The `ca.crt` in the Secret is what the gateway uses to verify Envoy's client cert; the `tls.crt`/`tls.key` is the server side. Use the same Secret on both Deployments so rotations stay in lockstep.
+
+### 2.1 Why bother
+
+In a single-namespace cluster, network policies are often considered sufficient. mTLS is the additional layer that means a compromised sidecar can't speak OCPP to your gateway pods even if it reaches the port. Recommended for any deployment that processes payments or runs in a shared cluster.
+
+---
+
+## 3. Bearer tokens and per-charger Basic Auth
+
+Two auth boundaries on the gateway:
+
+### 3.1 REST inbound (`EVEYS_OCPP_REST_INBOUND_TOKENS`)
+
+CSV of acceptable bearer tokens. **At least one is required in production.** Tokens are validated constant-time.
+
+Generate, store in your secrets manager, mount as the Helm Secret's `rest-inbound-tokens` key:
+
+```bash
+TOKEN=$(openssl rand -base64 48)
+# put $TOKEN into the secrets manager
+```
+
+Rotation: the env var is a CSV, so two tokens coexist during the rollout window. Issue a new one, deploy, update your backend to use it, then remove the old one and deploy again.
+
+### 3.2 Per-charger Basic Auth (`EVEYS_OCPP_WS_BASIC_AUTH_REQUIRED`)
+
+The WebSocket upgrade checks the charger's `Authorization: Basic <cp_id:password>` header against a bcrypt hash in `charge_point_credentials`. Two modes:
+
+- **Permissive (default).** A charger with no credential row connects anyway. Migration shim — useful when onboarding a fleet that wasn't OCPP-secured before.
+- **Strict.** A charger with no credential row, or with a wrong password, is rejected at the upgrade. **Production should set this to `true`.**
+
+```yaml
+gateway:
+  basicAuth:
+    required: true
+```
+
+Provision credentials for every charger first (see [`connect-a-charger.md`](./connect-a-charger.md) §2). Flip strict mode on once you've verified every charger is in the table.
+
+---
+
+## 4. Backend integration
+
+The gateway calls *into* your backend for hot-path lookups (`Authorize`, session open/close) and pushes events to your webhook endpoints. Two env vars front this:
+
+```bash
+EVEYS_OCPP_BACKEND_BASE_URL=https://api.example.com
+EVEYS_OCPP_BACKEND_TOKEN=<bearer token your backend accepts>
+```
+
+`backend-base-url` empty disables the hot path cleanly — the gateway falls back to the configured local behaviour. That's fine for dev; in production you almost certainly want the backend wired up so user authorization actually happens.
+
+For webhooks:
+
+```bash
+EVEYS_OCPP_WEBHOOK_SECRET=<32+ bytes>
+EVEYS_OCPP_WEBHOOK_URL_TX_STARTED=https://api.example.com/api/eveys/webhooks/tx.started
+EVEYS_OCPP_WEBHOOK_ENABLE_TX_STARTED=true
+# ... same pair for every event you want delivered
+```
+
+Rotation of the webhook secret follows the same overlap pattern as bearer tokens: your backend's verifier should accept either of two valid secrets for the rollover window.
+
+---
+
+## 5. Autoscaling
+
+The gateway is built for horizontal scale. The chart ships `replicaCount: 2` as the floor; raise it as the fleet grows.
+
+A common rule of thumb is one pod per ~2000 concurrent charger sockets, but the right number depends on CPU per pod and meter-sample volume. Let production traffic and the `eveys_ocpp_ws_connections_active` metric tell you.
+
+### 5.1 HPA pattern
+
+The chart does not ship an HPA — autoscaling target choice depends on your fleet. A workable shape:
+
+```yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: eveys-ocpp-gateway
+  namespace: eveys-ocpp
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: eveys-ocpp-gateway
+  minReplicas: 3
+  maxReplicas: 30
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 60
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300        # don't thrash on minor dips
+```
+
+Scale-down is conservative on purpose: every pod that goes away takes its open WebSocket sockets with it; chargers reconnect, but you don't want to churn them every few minutes.
+
+### 5.2 What *not* to autoscale on
+
+Don't autoscale on Kafka-publish latency, on charger count, or on inbound-request rate — those are correlated with CPU but lag it. CPU utilisation tracks the actual workload most reliably.
+
+---
+
+## 6. Graceful drain
+
+When a pod gets `SIGTERM`, it does three things, in order:
+
+1. Flips `/api/v1/ready` to `503` so Envoy stops sending it new connections.
+2. Continues to service existing sockets and inflight requests for up to `EVEYS_OCPP_SHUTDOWN_GRACE_PERIOD_SECONDS` (default 25 s).
+3. Closes the remaining sockets cleanly. Chargers reconnect to a healthy pod, usually within 1–3 seconds.
+
+The chart's `terminationGracePeriodSeconds: 30` gives the kubelet a 5-second buffer past the gateway's grace window. If you raise the grace, raise the termination period in lockstep.
+
+```yaml
+gateway:
+  terminationGracePeriodSeconds: 45        # if you raise it...
+# and in env: EVEYS_OCPP_SHUTDOWN_GRACE_PERIOD_SECONDS=40   # then also raise this
+```
+
+---
+
+## 7. Database, Redis, Kafka, ClickHouse
+
+These are platform-provided; the chart only references them by DSN. A few things to get right.
+
+### 7.1 Postgres
+
+- **Use a managed Postgres** (RDS / Cloud SQL / equivalent) unless you have a clear reason not to.
+- **Enable connection pooling** between the gateway and Postgres (PgBouncer or your provider's built-in pooler). At fleet scale, raw connection counts explode.
+- **The gateway expects schema version pinned to its app version.** Migrations run at pod start via Alembic; rolling back the gateway version may also require a Postgres downgrade. See [`upgrade.md`](./upgrade.md).
+
+### 7.2 Redis
+
+- The gateway uses Redis for the online registry, the cross-pod command bus, the Authorize cache, and the idempotency cache. All four are ephemeral by design.
+- **Persistence is optional.** AOF / RDB doesn't add value here — losing Redis means chargers lose ~1 minute of online state and the registry rebuilds.
+- Use a single Redis (or Redis Cluster) shared by all gateway pods. The online registry is the cross-pod state.
+
+### 7.3 Kafka
+
+- The gateway is a producer only.
+- Topics are auto-created if your cluster allows it; otherwise create them ahead of time with retention configured to your audit needs.
+- Production-grade settings: `acks=all`, `enable.idempotence=true` (the gateway does this — relevant for your consumer-side reasoning).
+
+### 7.4 ClickHouse
+
+- Used for time-series telemetry (meter values, status history).
+- Sits behind the Kafka topics — a sidecar reads `cp.meter`, `cp.status`, etc. and writes batched inserts to ClickHouse. The gateway itself doesn't talk to ClickHouse synchronously.
+- A few hundred million rows is comfortable; partition by month, drop old partitions per your retention policy.
+
+---
+
+## 8. Observability hooks
+
+- **Prometheus.** Pods expose `/metrics` on port `9100`. Add a `ServiceMonitor` if you run kube-prometheus.
+- **Logs.** Structured JSON to stdout. Configure your log shipper to forward; index on `cp_id`, `request_id`, `event`.
+- **Traces.** OpenTelemetry; configure `EVEYS_OCPP_TRACING_OTLP_ENDPOINT` to your collector.
+- **Sentry.** `EVEYS_OCPP_SENTRY_DSN` if you want exception capture.
+
+Detailed metric and log catalogues in [`../reference/metrics.md`](../reference/metrics.md) and [`operate.md`](./operate.md).
+
+---
+
+## 9. The pre-flight sign-off checklist
+
+Before chargers hit production traffic, every line must be ✅:
+
+### TLS and auth
+
+- [ ] WSS certificate installed and its SAN matches the hostname chargers are configured for.
+- [ ] Internal mTLS (Envoy ↔ gateway) enabled.
+- [ ] `EVEYS_OCPP_REST_INBOUND_TOKENS` set and tokens distributed to every caller.
+- [ ] `EVEYS_OCPP_WS_BASIC_AUTH_REQUIRED=true` and every charger has a row in `charge_point_credentials`.
+- [ ] Webhook signing secret set; backend verifies signatures.
+- [ ] `EVEYS_OCPP_REST_OPENAPI_ENABLED=false` (or restricted to a private network).
+
+### Capacity
+
+- [ ] Minimum replica count ≥ 2; PDB `maxUnavailable: 1`.
+- [ ] HPA wired up and tested with a load drill.
+- [ ] Postgres pool sized for `(pod count × per-pod pool)`; PgBouncer in front if appropriate.
+
+### Lifecycle
+
+- [ ] `terminationGracePeriodSeconds` exceeds `EVEYS_OCPP_SHUTDOWN_GRACE_PERIOD_SECONDS` by ≥ 5 s.
+- [ ] Liveness probes the `/api/v1/health` endpoint; readiness probes `/api/v1/ready`.
+- [ ] Rolling-update test passes — `kubectl rollout restart` and confirm zero charger drops on Prometheus.
+
+### Observability
+
+- [ ] Prometheus scraping the gateway and Envoy.
+- [ ] Grafana dashboards loaded (the chart ships JSON dashboards under `deploy/grafana/dashboards/`).
+- [ ] At least one alert wired: 5xx rate, `eveys_ocpp_ws_connections_active` cliff, Postgres-pool-saturation.
+- [ ] Logs flowing to your aggregator with `cp_id` indexed.
+- [ ] Traces flowing to a collector and sampled at a rate you can afford.
+
+### Integration
+
+- [ ] Backend `Authorize` endpoint responds within 200 ms p99 from inside the cluster.
+- [ ] Webhook endpoints respond within their timeout, with idempotency on `event_id`.
+- [ ] Kafka consumers have a `group_id` set and are consuming from `latest` (or `earliest` if you've already provisioned topics).
+
+### Operational readiness
+
+- [ ] Rollback documented and rehearsed. See [`upgrade.md`](./upgrade.md).
+- [ ] On-call rota knows where the dashboards are.
+- [ ] One run-through of [`operate.md`](./operate.md) §"common motions" with the on-call engineer.
+
+When every box is ticked, you're ready.
+
+---
+
+## Where to go from here
+
+- Day-2 operations: [`operate.md`](./operate.md).
+- Security model: [`../concepts/security-model.md`](../concepts/security-model.md).
+- Configuration reference: [`../reference/configuration.md`](../reference/configuration.md).

--- a/userdocs/guides/install.md
+++ b/userdocs/guides/install.md
@@ -1,0 +1,239 @@
+# Install
+
+**Audience.** A developer or operator bringing the stack up for the first time.
+
+**What this answers.** Two paths — Docker Compose for development; Helm chart for Kubernetes. What's required, what's optional, how to verify the install is healthy.
+
+> The fastest path is the Compose one in §1. The Helm path in §2 is the production shape. Pick by intent, not by capability — both bring up the same gateway.
+
+---
+
+## Prerequisites
+
+| Tool | Version | Compose | Helm |
+|---|---|---|---|
+| Docker Desktop / Docker Engine | 4.30+ | ✅ | — |
+| Docker Compose v2 | (bundled with Docker Desktop) | ✅ | — |
+| `make` | any recent | ✅ | ✅ (helper targets) |
+| `git` | 2.30+ | ✅ | ✅ |
+| Python 3.13 | 3.13.x | optional, only for the simulator | — |
+| [`uv`](https://docs.astral.sh/uv/) | 0.5+ | optional, only for the simulator | — |
+| `kubectl` | 1.30+ | — | ✅ |
+| `helm` | 3.15+ | — | ✅ |
+| A Kubernetes cluster | 1.30+ | — | ✅ |
+
+To confirm tools are installed:
+
+```bash
+docker --version && docker compose version && make --version && git --version
+# plus, if you're going to Kubernetes:
+kubectl version --client && helm version
+```
+
+The repository ships a single-command check too:
+
+```bash
+make doctor
+```
+
+It exits 0 when every required tool is present and reports exactly what's missing otherwise.
+
+---
+
+## 1. Local install with Docker Compose
+
+The shortest path from `git clone` to a running gateway.
+
+### 1.1 What you get
+
+Six containers wired together by `deploy/compose/docker-compose.yml`:
+
+| Container | What it is | Host port |
+|---|---|---|
+| `eveys-ocpp-postgres` | Postgres 16, schema migrations applied at start. | `5432` |
+| `eveys-ocpp-redis` | Redis 7, online registry + command bus + caches. | `6379` |
+| `eveys-ocpp-kafka` | Kafka (KRaft mode), event firehose. | `9092` |
+| `eveys-ocpp-clickhouse` | ClickHouse for time-series telemetry. | `8123` (HTTP), `9000` (native, remapped to `9100` on the host so it doesn't clash with the gateway). |
+| `eveys-ocpp` | The gateway pod. | WebSocket `19000`, REST `8080`, gRPC `50051`, Prometheus `9100`. |
+| `eveys-ocpp-envoy` | Envoy with TLS termination + ring-hash. | `19443` (wss). |
+
+The gateway is also fronted by the `clickhouse-ingestor` sidecar that tails Kafka and writes to ClickHouse.
+
+### 1.2 Bring it up
+
+```bash
+git clone https://github.com/eveys-mobility/OCPP.git
+cd OCPP
+make compose-up
+```
+
+`make compose-up`:
+
+1. Pulls or rebuilds the gateway image.
+2. Starts every container in the right order.
+3. Waits until the gateway answers `200 OK` on `/api/v1/ready`.
+4. Runs database migrations (Postgres via Alembic; ClickHouse via the schema-migrations table).
+
+When it exits 0, the stack is ready.
+
+### 1.3 Verify it's healthy
+
+```bash
+# REST surface up?
+curl -s http://localhost:8080/api/v1/health
+# expected: {"status":"ok",...}
+
+# Ready to accept charger connections?
+curl -s http://localhost:8080/api/v1/ready
+# expected: {"status":"ready",...}
+
+# Swagger UI:
+open http://localhost:8080/api/v1/docs
+
+# Charger WebSocket reachable?
+# (Cannot probe with curl alone; open ws://localhost:19000/<cp_id>
+# with the OCPP subprotocol. The Quickstart shows how.)
+```
+
+### 1.4 Tear it down
+
+```bash
+make compose-down              # stops containers, keeps data volumes
+make compose-down-volumes      # also wipes data — destructive
+```
+
+### 1.5 Common Compose tweaks
+
+- **Need the metrics endpoint?** Visit `http://localhost:9100/metrics` while the stack is up.
+- **Want to point at a real backend?** Set `EVEYS_OCPP_BACKEND_BASE_URL` in the gateway service's environment block; restart the container.
+- **Need to see what's running?** `make compose-status` lists containers and their health.
+
+---
+
+## 2. Kubernetes install with Helm
+
+For staging, production, or anything beyond a laptop.
+
+### 2.1 What's in the chart
+
+`deploy/helm/eveys-ocpp/` ships two workloads in a single release:
+
+- **Gateway** — a `Deployment` with a headless `Service` so Envoy can hash to individual pod IPs. PodDisruptionBudget enforces `maxUnavailable: 0` during rolling updates so chargers always have a healthy pod to land on.
+- **Envoy** — a `Deployment` with a `LoadBalancer` `Service` for the WSS edge. Ring-hashes inbound charger connections on `cp_id` to the gateway pods.
+
+The chart does **not** ship Postgres, Redis, Kafka, ClickHouse — those are platform infrastructure and you provide them. Connection strings go into the chart values.
+
+### 2.2 Prepare the cluster
+
+Before installing the chart you need:
+
+1. **The platform dependencies** reachable from the cluster — Postgres, Redis, Kafka, ClickHouse.
+2. **A container registry** holding the gateway image. The repo ships a multi-stage `deploy/Dockerfile`; `make build-image` builds `eveys-ocpp:dev` locally. Push it to your registry with whatever tag you want to pin.
+3. **A TLS certificate** for the WSS edge — either via cert-manager, external-secrets, or hand-rolled. The chart references a `Secret` by name; how it gets there is your platform's call.
+4. **A bearer-token Secret** for the REST inbound auth — see §2.4.
+
+### 2.3 Minimal values file
+
+Create `eveys-ocpp.values.yaml` next to wherever you keep cluster manifests:
+
+```yaml
+gateway:
+  image:
+    repository: registry.example.com/eveys-mobility/ocpp
+    tag: "0.1.0"
+  replicaCount: 3
+
+  config:
+    logLevel: INFO
+    logJson: true
+    backendBaseUrl: https://api.example.com
+
+  # Secret with these keys: db-url, backend-token, webhook-secret,
+  # rest-inbound-tokens, sentry-dsn. Provisioned outside this chart.
+  secrets:
+    name: eveys-ocpp-secrets
+
+envoy:
+  service:
+    type: LoadBalancer
+  tls:
+    secretName: eveys-ocpp-edge-tls    # the WSS cert Secret
+```
+
+### 2.4 The bearer-token Secret
+
+The REST API uses bearer-token auth (`Authorization: Bearer <token>`). Tokens are a CSV in the gateway env var `EVEYS_OCPP_REST_INBOUND_TOKENS`, sourced from the Secret you named above.
+
+Create one (or rotate one):
+
+```bash
+TOKEN=$(openssl rand -base64 32)
+kubectl create secret generic eveys-ocpp-secrets \
+  --from-literal=rest-inbound-tokens="$TOKEN" \
+  --from-literal=db-url="postgresql+asyncpg://eveys:...@postgres.../eveys_ocpp" \
+  --from-literal=backend-token="$BACKEND_TOKEN" \
+  --from-literal=webhook-secret="$WEBHOOK_HMAC_SECRET" \
+  --from-literal=sentry-dsn=""
+```
+
+Distribute the token to whoever calls the API — your backend service, your dashboards, your scripts.
+
+### 2.5 Install
+
+```bash
+helm install eveys-ocpp ./deploy/helm/eveys-ocpp \
+  --namespace eveys-ocpp \
+  --create-namespace \
+  --values eveys-ocpp.values.yaml
+```
+
+### 2.6 Verify the install
+
+```bash
+# Pods rolling out?
+kubectl -n eveys-ocpp get pods
+
+# Gateway healthy?
+kubectl -n eveys-ocpp port-forward svc/eveys-ocpp-gateway 8080:8080
+curl -s http://localhost:8080/api/v1/ready
+
+# Envoy got an external IP?
+kubectl -n eveys-ocpp get svc eveys-ocpp-envoy
+```
+
+A charger connects to `wss://<envoy-external-host>/<cp_id>` once DNS and the TLS cert are in place.
+
+### 2.7 Upgrade and rollback
+
+```bash
+# Roll forward
+helm upgrade eveys-ocpp ./deploy/helm/eveys-ocpp \
+  --namespace eveys-ocpp \
+  --values eveys-ocpp.values.yaml
+
+# Roll back if it goes wrong
+helm rollback eveys-ocpp 1 --namespace eveys-ocpp
+```
+
+The gateway is built for rolling updates — `maxUnavailable: 0`, `terminationGracePeriodSeconds: 30`, drain on `SIGTERM`. Active sockets stay on the old pods until those drain; new connections land on the new pods immediately.
+
+Full upgrade semantics: [`upgrade.md`](./upgrade.md).
+
+---
+
+## 3. What's *not* in scope here
+
+This guide stops at "the gateway is healthy and answering probes". Beyond that, two reads to queue up:
+
+- **Connect a real charger** — [`connect-a-charger.md`](./connect-a-charger.md).
+- **Go to production** — TLS, mTLS, autoscaling, secrets rotation, and the pre-flight checklist live in [`deploy-to-production.md`](./deploy-to-production.md).
+
+If the install isn't healthy, the diagnostic moves are in [`operate.md`](./operate.md).
+
+---
+
+## Where to go from here
+
+- Next steps once installed: [`connect-a-charger.md`](./connect-a-charger.md).
+- Configuring further: [`../reference/configuration.md`](../reference/configuration.md).
+- Operational concerns: [`operate.md`](./operate.md).

--- a/userdocs/guides/operate.md
+++ b/userdocs/guides/operate.md
@@ -1,0 +1,209 @@
+# Operate
+
+**Audience.** On-call engineers and platform operators.
+
+**What this answers.** Health and readiness probes, structured logs, the metrics dashboard, how to drain a pod, how to roll back. The motions you do most often.
+
+> First-time deployment lives in [`install.md`](./install.md) and [`deploy-to-production.md`](./deploy-to-production.md). This page is day-2.
+
+---
+
+## 1. Health and readiness
+
+Two endpoints, two purposes.
+
+### `/api/v1/health` — liveness
+
+Answers "is this pod able to function at all?" Returns `200 OK` whenever the process is up and the load-bearing connections to dependencies (Postgres, Redis) work. Flips to `503` only when something downstream is genuinely sick.
+
+Used by the Kubernetes **livenessProbe**. A red liveness means the pod is killed and rescheduled.
+
+```bash
+curl -s http://<pod-or-svc>:8080/api/v1/health
+```
+
+### `/api/v1/ready` — readiness / drain signal
+
+Answers "should I receive new connections right now?" Returns `200 OK` normally. Returns `503` during graceful shutdown so the load balancer drains the pod cleanly.
+
+Used by the Kubernetes **readinessProbe** *and* by Envoy's upstream health check.
+
+```bash
+curl -s http://<pod-or-svc>:8080/api/v1/ready
+```
+
+The two endpoints serve different goals. Liveness must stay green during drain; readiness must flip red. Don't conflate them.
+
+---
+
+## 2. Logs
+
+Structured JSON to stdout, one record per line. Every log carries (at minimum) `level`, `event`, `request_id`. Context-rich logs add `cp_id`, `action` (the OCPP message name), `direction` (`rx`/`tx`).
+
+### 2.1 Tail one charger
+
+```bash
+# kubectl
+kubectl -n eveys-ocpp logs -l app=eveys-ocpp -f --since=10m | \
+  jq 'select(.cp_id == "CP_X")'
+
+# docker compose
+docker logs -f eveys-ocpp 2>&1 | jq 'select(.cp_id == "CP_X")'
+```
+
+### 2.2 Grep by error
+
+```bash
+kubectl -n eveys-ocpp logs -l app=eveys-ocpp --since=1h | \
+  jq 'select(.level == "error" or .level == "warning")'
+```
+
+### 2.3 Correlate one request across pods
+
+When a backend call routes cross-pod, the `request_id` appears in two pods' logs — the pod that received the REST call and the pod that owned the charger's socket.
+
+```bash
+kubectl -n eveys-ocpp logs -l app=eveys-ocpp --since=10m | \
+  jq 'select(.request_id == "8a3f2c40-3b8e-4d0a-9b62-7a3d5d1e9fa1")'
+```
+
+### 2.4 Don't grep for stack traces
+
+The gateway treats expected errors (charger offline, validation failures, etc.) as logged warnings *without* a stack trace. Genuine bugs raise a `level=error` record with `exception` populated. Filter accordingly:
+
+```bash
+kubectl -n eveys-ocpp logs -l app=eveys-ocpp --since=1h | \
+  jq 'select(.exception != null)'
+```
+
+If you see a stack trace, it's a bug worth filing.
+
+---
+
+## 3. Metrics
+
+Pods expose Prometheus metrics on port `9100` at `/metrics`. The full catalogue is in [`../reference/metrics.md`](../reference/metrics.md). The headline four you should know by heart:
+
+| Metric | What it tells you |
+|---|---|
+| `eveys_ocpp_ws_connections_active` | How many charger sockets are open right now, per pod. The fleet's pulse. |
+| `eveys_ocpp_ocpp_handler_latency_seconds` | Inbound OCPP handling latency by action. p99 spikes here are the first sign something's slow. |
+| `eveys_ocpp_grpc_request_latency_seconds` | Outbound dispatch latency. p99 spikes mean the WS leg or the charger side is slow. |
+| `eveys_ocpp_handler_errors_total` | Per-action error count. Trend matters more than absolute. |
+
+Dashboards under `deploy/grafana/dashboards/` cover fleet overview, per-pod, per-charger, reconnect storms, transactions, and the SLOs.
+
+### Alert ideas (no specific recommendation; what's most actionable)
+
+- 5xx rate on REST > 1% for 5m.
+- `eveys_ocpp_ws_connections_active` drops > 20% over 1 minute (chargers got booted).
+- Postgres-pool checkout latency > 100ms p99.
+- `eveys_ocpp_handler_errors_total{action="StopTransaction"}` rate > 0 for 1 minute (financial path).
+
+---
+
+## 4. Common motions
+
+### 4.1 Restart one pod
+
+```bash
+kubectl -n eveys-ocpp delete pod <pod-name>
+```
+
+Kubernetes recreates it; the readiness probe brings the new pod into rotation when it's ready. Existing connections on other pods are unaffected.
+
+### 4.2 Rolling restart of every pod
+
+```bash
+kubectl -n eveys-ocpp rollout restart deployment/eveys-ocpp-gateway
+```
+
+Pods drain one at a time. Watch `kubectl rollout status`.
+
+### 4.3 Drain a single pod for investigation
+
+```bash
+kubectl -n eveys-ocpp cordon <node-name>     # if the issue is a noisy node
+# OR
+kubectl -n eveys-ocpp delete pod <pod>       # gentler — just rotates one
+```
+
+The graceful drain mechanism keeps charging sessions intact: sockets stay on the pod for up to `EVEYS_OCPP_SHUTDOWN_GRACE_PERIOD_SECONDS` while readiness goes red so Envoy stops sending new connections.
+
+### 4.4 Force-evict a stuck charger
+
+A charger that's misbehaving — keeps disconnecting, keeps re-sending bad payloads — can be forcibly evicted by deleting the credential row and waiting for it to disconnect:
+
+```bash
+# Strict mode (EVEYS_OCPP_WS_BASIC_AUTH_REQUIRED=true) only.
+psql "$DSN" -c "DELETE FROM charge_point_credentials \
+                 WHERE charge_point_id = (SELECT id FROM charge_points \
+                                          WHERE cp_id = 'CP_X')"
+# Charger will fail its next WebSocket upgrade.
+```
+
+Re-provision the credential when whatever's wrong with the charger is fixed.
+
+### 4.5 Replay a webhook
+
+If a backend was down when an event was delivered and you need to re-send, the cleanest motion is to use the operator-queue endpoints (where available) or tail Kafka from a chosen offset. Kafka offsets are the source of truth for replay; webhooks are best-effort and not individually replayable through an API today.
+
+---
+
+## 5. Rolling back
+
+A bad release is the day-2 hazard you'll actually face.
+
+### 5.1 The fast path
+
+```bash
+helm rollback eveys-ocpp <previous-revision> --namespace eveys-ocpp
+```
+
+`<previous-revision>` is the revision number from `helm history eveys-ocpp -n eveys-ocpp` — typically the one immediately before the current.
+
+This re-creates pods from the previous revision's manifests. Drain semantics apply just like a normal rolling update.
+
+### 5.2 When the schema moved
+
+If the bad release ran a forward-only Alembic migration, rolling the pods back without rolling the schema back is *unsafe*. Two options in order of preference:
+
+1. **Roll forward** with a fix — fastest, lowest-risk for production data.
+2. **Roll back the schema** if you absolutely must. Each migration has a `downgrade()` function; review it before running. `alembic downgrade -1` against the production DSN. Note this may discard data added by the new schema.
+
+The release notes for each version call out whether the migration is reversible.
+
+### 5.3 The damage-control playbook
+
+If charger traffic is being impacted *right now*:
+
+1. **Stop the bleed.** Roll the chart back to the previous revision.
+2. **Get visibility.** Pull `kubectl logs` from the last 10 minutes, get a recent `/metrics` snapshot, write down what you saw. Future-you needs the artefacts.
+3. **Confirm chargers recovered.** Watch `eveys_ocpp_ws_connections_active` climb back to the baseline.
+4. **File against the gateway** with the artefacts from step 2.
+
+Steps 1–3 take ≤ 5 minutes when rehearsed; step 4 is post-mortem material.
+
+---
+
+## 6. When things go wrong — symptom → likely cause
+
+| Symptom | Look at | Likely cause |
+|---|---|---|
+| `503` from `/api/v1/ready` on every pod | Postgres reachability | DB outage. |
+| `503` from `/api/v1/ready` on one pod | That pod's logs | Pod is draining (intentional) or it lost Redis. |
+| Charger sockets dropping in waves | `eveys_ocpp_ws_connections_active` over time | Network blip; node restart; or a bad release rolling out. |
+| REST returns `CHARGER_OFFLINE` for a charger you can ping | Online registry in Redis | Heartbeat staleness; the charger is connected but to a different process than you think. |
+| `tx.stopped` not landing in Kafka | `eveys_ocpp_kafka_publish_total{outcome="failed"}` | Broker dropped the message; the synchronous REST close still happened. |
+| Latency p99 climbed on `MeterValues` | `eveys_ocpp_db_query_latency_seconds` | Postgres slow; check pool saturation. |
+| Webhook deliveries failing | Backend logs + `eveys_ocpp_webhook_attempts_total` by `outcome` | Backend rejecting or timing out; signature mismatch. |
+
+When you don't recognise the symptom, the right first step is one minute of `kubectl logs` and one minute of `curl /metrics` — most causes show up immediately.
+
+---
+
+## Where to go from here
+
+- Metric definitions: [`../reference/metrics.md`](../reference/metrics.md).
+- Configuration knobs: [`../reference/configuration.md`](../reference/configuration.md).
+- Version bumps: [`upgrade.md`](./upgrade.md).

--- a/userdocs/guides/upgrade.md
+++ b/userdocs/guides/upgrade.md
@@ -1,0 +1,147 @@
+# Upgrade
+
+**Audience.** Operators planning a version bump.
+
+**What this answers.** Versioning policy, supported upgrade paths, what's stable across releases, and how to roll forward without dropping charger connections.
+
+> Rollback motions live in [`operate.md`](./operate.md) §5. This page is about going *forward*.
+
+---
+
+## 1. Versioning policy
+
+The gateway uses **semantic versioning** for its Helm chart and Docker image: `MAJOR.MINOR.PATCH`.
+
+- **MAJOR** — breaking changes to a stable surface (REST API, gRPC API, event envelope, Kafka topic names). Read the release notes carefully. Coordinate with backend / consumer teams before deploying.
+- **MINOR** — additive changes. New endpoints, new event fields, new configuration knobs with safe defaults. Backward-compatible with the previous MINOR.
+- **PATCH** — bug fixes, performance fixes, doc fixes. Always safe to apply.
+
+The chart's `appVersion` matches the gateway's Docker image tag. The chart's own `version` increments independently — chart-only changes don't bump the app.
+
+---
+
+## 2. What's stable across releases
+
+These surfaces follow the semver contract above. Treat them as the platform's contract with the rest of your stack.
+
+| Surface | Stability rule |
+|---|---|
+| **REST API** | Existing endpoints, request shapes, and response shapes don't change inside a MAJOR. New fields may appear on responses; consumers must ignore unknown fields. New endpoints may be added at any time. |
+| **gRPC API** | Existing RPCs, request and response messages, and proto field numbers don't change inside a MAJOR. New fields and RPCs are additive. Removing a field requires a MAJOR. |
+| **Kafka event envelope** | `EventEnvelope` and every payload type follow proto3 evolution rules: adding fields is fine; renumbering or removing fields is forbidden until a MAJOR. Topic names don't change inside a MAJOR. |
+| **Webhook payloads** | Same as the Kafka envelope (JSON serialisation of the same proto). Adding fields is fine; the headers (`X-Eveys-Signature`, `X-Eveys-Event-Type`, `X-Eveys-Event-Id`) are stable. |
+| **OCPP wire format** | Defined by the OCPP standard, not by this project. The gateway never alters charger-facing payloads. |
+| **`error_code` strings** | Stable enum-like surface. New codes may appear; existing codes never change meaning or get removed inside a MAJOR. |
+| **Configuration env vars** | `EVEYS_OCPP_*` variables and their accepted values are stable inside a MAJOR. Deprecations are announced one MINOR in advance. |
+| **Metric names** | `eveys_ocpp_*` series are stable. Adding new series is always allowed. Renaming or removing requires a MAJOR. |
+
+What's **explicitly not** part of the contract: internal log fields beyond `level`, `event`, `request_id`, `cp_id`; trace span names; database schema (you should never query the DB directly — use REST); the proto field tag numbers inside the generated `*_pb2.py` (but the wire format they encode is stable).
+
+---
+
+## 3. The upgrade motion
+
+### 3.1 Read the release notes
+
+Every release ships with a `CHANGELOG.md` entry. Look for:
+
+- **Schema changes.** Listed as `### Migration` in the changelog. A new Alembic revision means Postgres will be altered when the new pod starts.
+- **Configuration changes.** Listed as `### Changed` or `### Removed`. New defaults can be surprising; review them.
+- **Deprecations.** Listed as `### Deprecated`. Time to act before the next MAJOR.
+
+### 3.2 Plan the order
+
+For PATCH and most MINOR upgrades, the order is:
+
+1. Update the chart values (image tag, new options).
+2. `helm upgrade` against staging.
+3. Watch metrics and logs for the soak period your platform standards require.
+4. `helm upgrade` against production.
+
+For a MAJOR upgrade, add two more steps:
+
+0. **Coordinate with consumer teams** that any client-side changes are deployed first.
+0. **Bench-test in a non-production cluster** end-to-end.
+
+5. **Plan the rollback** ahead of time. Have the previous image tag and a known-good values file ready.
+
+### 3.3 Run it
+
+```bash
+helm upgrade eveys-ocpp ./deploy/helm/eveys-ocpp \
+  --namespace eveys-ocpp \
+  --values eveys-ocpp.values.yaml \
+  --version <chart-version>
+```
+
+What happens inside the chart:
+
+1. The new gateway image rolls out one pod at a time, respecting `maxUnavailable: 0`.
+2. Each new pod runs Alembic migrations on start (idempotent — no-op if already at HEAD).
+3. The new pod fails its liveness probe until everything's wired; Kubernetes holds off until ready.
+4. Old pods drain on `SIGTERM` per [`operate.md`](./operate.md) §4.3.
+
+Watch:
+
+```bash
+kubectl -n eveys-ocpp rollout status deployment/eveys-ocpp-gateway --timeout=10m
+```
+
+---
+
+## 4. Zero-downtime rules of thumb
+
+- **`maxUnavailable: 0`** in the rolling-update strategy. Never below replica count.
+- **`terminationGracePeriodSeconds`** ≥ `EVEYS_OCPP_SHUTDOWN_GRACE_PERIOD_SECONDS` + 5 s.
+- **Postgres pool capacity** = `(2 × pod count × per-pod pool size)` during the rollout window — enough for both old and new pods to be checked out simultaneously.
+- **Kafka producer backpressure** is built in; you don't need to size around the rollout.
+- **Redis** sees a brief blip in registry traffic; this is normal and handled by the gateway's reconnect logic.
+
+If you can't satisfy any of these, the upgrade will still work — it just won't be zero-downtime.
+
+---
+
+## 5. Schema migrations specifically
+
+Migrations live in `alembic/versions/`. The gateway runs them automatically on pod start; you can also run them out-of-band with `make pg-migrate` against the DSN.
+
+Migrations in this project are:
+
+- **Additive by default.** New columns, new tables, new indexes — applied without downtime.
+- **Backfill-safe.** When a migration backfills data, it's chunked so it doesn't lock the table for long.
+- **Downward-compatible within a MINOR.** A new MINOR's schema works for the previous MINOR's code, so the rolling-update overlap is safe.
+- **Reversible when reasonable.** Most have `downgrade()` paths; destructive migrations are called out in release notes.
+
+If a migration takes longer than your `terminationGracePeriodSeconds`, the new pod fails its liveness probe. Two options:
+
+1. Run the migration out-of-band first (`make pg-migrate`), then deploy the new image.
+2. Raise the liveness probe's `initialDelaySeconds` and `failureThreshold` to give the migration time to finish on pod start.
+
+---
+
+## 6. Skipping versions
+
+The gateway supports upgrading from any MINOR `X.Y.Z` to any MINOR `X.Y'.Z'` where `Y' >= Y` (and `X` matches). I.e., MINOR-to-MINOR upgrades inside one MAJOR are always safe.
+
+You **cannot** skip a MAJOR. Going from `1.x` to `3.x` means stepping through `2.x` — usually because schema migrations or event envelope changes weren't designed to skip an intermediate MAJOR.
+
+Downgrades are not supported across MINORs that introduced schema changes. See [`operate.md`](./operate.md) §5.2.
+
+---
+
+## 7. When NOT to upgrade
+
+- During fleet peak hours. Even with zero-downtime rollouts, an upgrade is a perturbation. Off-peak is better.
+- Inside a **freeze window** declared by your release process.
+- While an incident is open. Upgrades during incidents add a variable to the post-mortem.
+- When the release notes flag a known issue your environment matches.
+
+For genuine **security patches**, treat the upgrade as part of incident response rather than scheduled work — different rules apply.
+
+---
+
+## Where to go from here
+
+- Day-2 operations and rollback: [`operate.md`](./operate.md).
+- What changed between versions: the project's `CHANGELOG.md` at the repo root.
+- Configuration knobs: [`../reference/configuration.md`](../reference/configuration.md).

--- a/userdocs/guides/use-the-rest-api.md
+++ b/userdocs/guides/use-the-rest-api.md
@@ -1,0 +1,262 @@
+# Use the REST API
+
+**Audience.** A backend developer driving the gateway from their service.
+
+**What this answers.** Auth, errors, pagination, request IDs, cursors. The patterns you'll repeat across every endpoint, with worked examples for the calls a backend hits most.
+
+> If you want the per-endpoint payload reference, that's [`../reference/rest-api.md`](../reference/rest-api.md). This page is the integration *layer* — how to talk to the API, not what every endpoint looks like.
+
+---
+
+## 1. The shape of every call
+
+Every REST call has the same skeleton:
+
+```http
+<METHOD> /api/v1/<path> HTTP/1.1
+Host: <gateway-host>
+Authorization: Bearer <token>
+Content-Type: application/json
+X-Request-ID: <uuid>           # optional but recommended
+
+<json body, when applicable>
+```
+
+A successful response carries raw JSON — no envelope:
+
+```json
+{
+  "field": "value",
+  "request_id": "8a3f2c40-3b8e-4d0a-9b62-7a3d5d1e9fa1"
+}
+```
+
+A failed response carries a small, stable envelope:
+
+```json
+{
+  "error": "human-readable description",
+  "error_code": "STABLE_CODE_FOR_PROGRAMMATIC_USE",
+  "request_id": "8a3f2c40-3b8e-4d0a-9b62-7a3d5d1e9fa1"
+}
+```
+
+The asymmetry is deliberate. Success bodies are domain data; the envelope would be noise. Error bodies are predictable; the envelope is essential.
+
+---
+
+## 2. Authentication
+
+Bearer-token auth. The gateway accepts a CSV of valid tokens in `EVEYS_OCPP_REST_INBOUND_TOKENS`. Any one of them works.
+
+```bash
+curl -s http://<gateway>/api/v1/charge-points \
+  -H "Authorization: Bearer <token>"
+```
+
+Missing header → `401 UNAUTHORIZED`. Wrong token → `403 FORBIDDEN`. The mapping is intentional — the gateway tells callers whether they forgot to send credentials or sent the wrong ones, because the remediation is different.
+
+Token rotation is "issue a new one, deploy it everywhere, remove the old one from the CSV, deploy again". Two tokens can be valid simultaneously which makes overlapping rollouts safe.
+
+---
+
+## 3. Errors — the canonical codes
+
+When the gateway answers an HTTP non-2xx, the `error_code` is one of:
+
+| HTTP | `error_code` | What it means | What you do |
+|---|---|---|---|
+| 400 | `BAD_REQUEST` | Malformed payload, missing required field, invalid value. | Fix the client. |
+| 401 | `UNAUTHORIZED` | No `Authorization` header (or empty). | Send a token. |
+| 403 | `FORBIDDEN` | Token didn't match. | Refresh / re-issue. |
+| 404 | `UNKNOWN_CP_ID` | No charger with this `cp_id`. | Re-check or register the charger. |
+| 404 | `UNKNOWN_TRANSACTION_ID` | No transaction with this id. | Re-check or accept it's gone. |
+| 404 | `UNKNOWN_RESERVATION_ID` | No reservation with this id. | Same. |
+| 409 | `CHARGER_OFFLINE` | Charger isn't currently connected; nothing to dispatch to. | Wait / retry; surface to operator. |
+| 429 | `RATE_LIMITED` | You exceeded the inbound rate limit. | Back off; retry with jitter. |
+| 504 | `CHARGER_TIMEOUT` | Charger took longer than the 30 s OCPP ceiling to reply. | Retry, idempotent commands are safe. |
+| 400 | `WINDOW_TOO_LARGE` | A range query asked for too many points. | Narrow the window. |
+| 500 | `INTERNAL_ERROR` | Unexpected — a bug or a downstream went sick. | File against the gateway. |
+
+These codes are **stable**. Treat them as a programmatic enum. The `error` string is human prose and may change without notice.
+
+---
+
+## 4. Request IDs (for tracing)
+
+Every response carries `request_id` — a UUID the gateway assigns to every request. If you send `X-Request-ID` in, the gateway adopts it; if you don't, it generates one.
+
+Log the `request_id` on your side too. When something goes wrong, you and the gateway operator both grep the same string across all systems — your logs, the gateway's logs, your distributed traces.
+
+```bash
+REQ=$(uuidgen)
+curl -s http://<gateway>/api/v1/charge-points/CP_X \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Request-ID: $REQ"
+# ... and ...
+echo "asked the gateway about CP_X, request_id=$REQ"
+```
+
+---
+
+## 5. Pagination — opaque cursors
+
+List endpoints (`/charge-points`, `/transactions`, `/charge-points/{cp_id}/transactions`, `/charge-points/{cp_id}/reservations`, …) all paginate the same way:
+
+```bash
+curl -s "http://<gateway>/api/v1/transactions?limit=100" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Response:
+
+```json
+{
+  "transactions": [ ... up to 100 rows ... ],
+  "next_cursor": "eyJpZCI6MTIzNDV9",
+  "request_id": "..."
+}
+```
+
+`next_cursor` is an opaque base64 string. Pass it back to get the next page:
+
+```bash
+curl -s "http://<gateway>/api/v1/transactions?limit=100&cursor=eyJpZCI6MTIzNDV9" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+When you reach the end, `next_cursor` is `null`. Don't try to decode the cursor — its internal shape may change between releases. Treat it as a string the gateway gave you to hand back.
+
+`limit` is bounded; the gateway clamps it to a maximum (default 1000) and uses a sensible default if you don't pass one. The defaults are in [`../reference/configuration.md`](../reference/configuration.md) under `rest_default_page_size` / `rest_max_page_size`.
+
+---
+
+## 6. Idempotency (for the calls that need it)
+
+Most operations on the gateway are naturally idempotent — list, fetch, query. The mutating ones split into two groups:
+
+- **OCPP dispatch commands** (`RemoteStart`, `RemoteStop`, `Reset`, `UnlockConnector`, `ChangeAvailability`, the rest). These have OCPP-level semantics. `RemoteStart` twice in a row is allowed; the charger answers `Rejected` the second time. Safe to retry.
+- **State mutations** (`SendLocalList`, `ReserveNow`, `SetChargingProfile`). These write Postgres after the charger acks. Retries are still safe — they go through the same charger-side check — but be aware they may re-emit Kafka envelopes.
+
+The gateway does not require an `Idempotency-Key` header. On the OCPP side it dedupes replays of charger-initiated messages via the message ID; on your side, treat your call IDs (`X-Request-ID`) as the de-facto idempotency anchor for log correlation.
+
+---
+
+## 7. Worked examples — the calls you'll write most
+
+### 7.1 "Is this charger connected?"
+
+```bash
+curl -s http://<gateway>/api/v1/charge-points/CP_X \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Look at `last_heartbeat_at`. Recent (within a couple of intervals) → online. Stale → likely offline; check the registry's online flag in the same payload.
+
+### 7.2 "Start a session"
+
+```bash
+curl -s -X POST http://<gateway>/api/v1/charge-points/CP_X/commands/remote-start \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"id_tag": "USER_RFID_123", "connector_id": 1}'
+```
+
+Response: `{"status": "Accepted", ...}`. Reminder: **`Accepted` here means the charger acknowledged the command**, not that a session is running. Watch for the `tx.started` event to confirm a `StartTransaction` actually landed.
+
+### 7.3 "Stop a session"
+
+```bash
+curl -s -X POST http://<gateway>/api/v1/charge-points/CP_X/commands/remote-stop \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"transaction_id": 12345}'
+```
+
+The `transaction_id` is the one you saw in `tx.started`. The charger replies; a subsequent `StopTransaction` arrives from the charger and produces the `tx.stopped` event.
+
+### 7.4 "List recent transactions for one charger"
+
+```bash
+curl -s "http://<gateway>/api/v1/charge-points/CP_X/transactions?limit=20" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+`page-through with next_cursor` for older rows. Filter by `id_tag` or `status` as query params; see the reference for the full set.
+
+### 7.5 "Get meter-value time series for a session"
+
+```bash
+curl -s "http://<gateway>/api/v1/charge-points/CP_X/meter-values?transaction_id=12345" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Time-series come from ClickHouse. Bound your window or page the result with cursors — the gateway will refuse very wide queries with `WINDOW_TOO_LARGE`.
+
+### 7.6 "Read fresh state for a UI"
+
+For dashboards and operations screens, lean on these read endpoints (all cacheable for a few seconds without compromising freshness):
+
+- `GET /charge-points` — fleet listing with pagination.
+- `GET /charge-points/{cp_id}` — single charger detail with active reservations and profiles inlined.
+- `GET /transactions` — global transaction list across the fleet.
+- `GET /transactions/{transaction_id}` — single transaction including the per-phase + SoC telemetry block.
+- `GET /charge-points/{cp_id}/status-history` — connector state transitions.
+
+For *commands*, post to `/charge-points/{cp_id}/commands/<verb>`.
+
+### 7.7 "Approve a pending CSR"
+
+```bash
+# List pending CSRs for one charger
+curl -s "http://<gateway>/api/v1/charge-points/CP_X/pending-certificate-signings?status=pending" \
+  -H "Authorization: Bearer $TOKEN"
+
+# Approve one
+curl -s -X POST http://<gateway>/api/v1/charge-points/CP_X/pending-certificate-signings/42/approve \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"signed_chain": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----", "approved_by": "ops@example.com"}'
+```
+
+Response includes the charger's reply (`charger_status`) so you can tell whether the chain landed.
+
+---
+
+## 8. OpenAPI / Swagger UI
+
+The gateway publishes its full OpenAPI schema at `/api/v1/openapi.json` and a Swagger UI at `/api/v1/docs`. Useful both for browsing the API interactively and for generating client stubs in your language:
+
+```bash
+# Browse interactively
+open http://<gateway>/api/v1/docs
+
+# Generate a TypeScript client (example)
+curl -s http://<gateway>/api/v1/openapi.json -o openapi.json
+npx openapi-typescript openapi.json --output gateway-client.d.ts
+```
+
+The schema covers every endpoint, every request body, every response, every error envelope.
+
+> The OpenAPI surface and Swagger UI ship enabled by default. For internet-exposed deployments, set `EVEYS_OCPP_REST_OPENAPI_ENABLED=false` so the schema isn't a free reconnaissance tool. Keep it enabled behind a VPN, in dev, and in staging.
+
+---
+
+## 9. Rate limiting and retries
+
+The gateway has a per-token bucket. You'll see `429 RATE_LIMITED` if you exceed it. Back off with exponential jitter (e.g., 250 ms, 500 ms, 1 s, 2 s, capped).
+
+For `CHARGER_TIMEOUT` (504) and `CHARGER_OFFLINE` (409), retry policy depends on the operation:
+
+- Read operations — retry freely.
+- `RemoteStart` / `RemoteStop` — retry only if you can verify the side-effect didn't already happen (consume `tx.started` / `tx.stopped` to confirm).
+- `Reset`, `UnlockConnector` — physical state changes; retry only after you've confirmed with the charger's own state via `GET /charge-points/{cp_id}` or a fresh `StatusNotification`.
+
+For all retries, attach the **same** `X-Request-ID` so logs collate cleanly across attempts.
+
+---
+
+## Where to go from here
+
+- Full endpoint payloads: [`../reference/rest-api.md`](../reference/rest-api.md).
+- Asynchronous events that follow REST commands: [`consume-events.md`](./consume-events.md).
+- Why some calls feel weird (`Accepted ≠ done`): [`../concepts/how-ocpp-flows-work.md`](../concepts/how-ocpp-flows-work.md).

--- a/userdocs/reference/configuration.md
+++ b/userdocs/reference/configuration.md
@@ -1,0 +1,202 @@
+# Configuration reference
+
+**Use this if you** are tuning the gateway, debugging a misconfiguration, or building a Helm values file.
+
+**Audience.** Operators and platform engineers.
+
+**What this answers.** What environment variables exist, organised by what they control. Defaults, stability, and the variables you'll actually touch.
+
+> The gateway exposes the live config under `GET /api/v1/admin/config` and the JSON schema under `GET /api/v1/sys/config/schema`. Both are auth-gated and useful when you want to introspect a running pod instead of reading docs.
+
+---
+
+## How configuration works
+
+- Every setting is read from an environment variable prefixed `EVEYS_OCPP_`. Example: `EVEYS_OCPP_LOG_LEVEL=INFO`.
+- The defaults are production-shaped where it doesn't cost anything; defaults that depend on the platform (DSNs, ports, secrets) require operator input.
+- Settings are validated at startup. A misspelled value or an out-of-range integer fails the pod immediately with a clear error rather than starting in a confused state.
+- Some settings are also **runtime-overridable** via `PATCH /api/v1/admin/config`. The allow-list lives in code; if you can't override a value at runtime, it's structural.
+
+**Stability tiers** (what changing this does):
+
+- **tunable** — safe to change at runtime; no wire-format or schema consequences. Restart the pod to pick up env-var changes (or use the admin endpoint for the runtime-overridable subset).
+- **structural** — changes how the service binds to the world. Coordinate with whoever else uses the affected port / topic / DSN.
+- **dev-only** — local stacks and tests. Do not set in production.
+
+---
+
+## Categories at a glance
+
+| Category | What it controls | Examples |
+|---|---|---|
+| `identity` | What this pod calls itself. | `pod_id`, `service_name` |
+| `logging` | Log level, format, where logs go. | `log_level`, `log_json` |
+| `ws_server` | Charger-facing WebSocket binding and limits. | `ws_port`, `ws_basic_auth_required`, `ws_mtls_*` |
+| `rest_server` | Backend-facing REST binding, auth, pagination. | `rest_port`, `rest_inbound_tokens`, `rest_default_page_size` |
+| `grpc_server` | gRPC binding. | `grpc_port` |
+| `auth` | Inbound bearer-token validation. | `rest_inbound_tokens` |
+| `postgres` | Relational store. | `db_url`, pool sizes |
+| `redis` | Online registry, command bus, caches. | `redis_url` |
+| `kafka_producer` | Event firehose producer. | `kafka_brokers`, batch sizes, retries |
+| `kafka_topics` | Topic names per event type. | `kafka_topic_tx_started`, etc. |
+| `webhooks` | Webhook URLs, enable flags, signing secret, retry budget. | `webhook_url_tx_stopped`, `webhook_signing_secret` |
+| `ocpp_defaults` | Charger-facing defaults (heartbeat interval, etc.). | `heartbeat_interval_seconds` |
+| `backend_integration` | Hot-path REST calls to your backend. | `backend_base_url`, `backend_token`, fallback policy |
+| `authorize_cache` | Redis-backed `Authorize` cache. | `authorize_cache_ttl_seconds` |
+| `idempotency` | OCPP-replay dedup. | `idempotency_ttl_seconds` |
+| `cross_pod_bus` | Redis pub/sub for command routing. | `bus_request_timeout_seconds` |
+| `clickhouse_ingest` | Sidecar that tails Kafka to ClickHouse. | `clickhouse_url`, `clickhouse_batch_*` |
+| `shutdown` | Graceful drain. | `shutdown_grace_period_seconds` |
+| `metrics` | Prometheus surface. | `metrics_port` |
+| `tracing` | OpenTelemetry. | `otlp_endpoint`, `tracing_sample_rate` |
+| `sentry` | Exception capture. | `sentry_dsn` |
+
+---
+
+## The handful you'll actually touch
+
+### Logging
+
+| Variable | Default | Notes |
+|---|---|---|
+| `EVEYS_OCPP_LOG_LEVEL` | `INFO` | `DEBUG` / `INFO` / `WARNING` / `ERROR`. Runtime-overridable. |
+| `EVEYS_OCPP_LOG_JSON` | `true` | Set `false` for human-readable logs in dev. |
+
+### REST and gRPC binding
+
+| Variable | Default | Stability |
+|---|---|---|
+| `EVEYS_OCPP_REST_PORT` | `8080` | structural |
+| `EVEYS_OCPP_GRPC_PORT` | `50051` | structural |
+| `EVEYS_OCPP_METRICS_PORT` | `9100` | structural |
+| `EVEYS_OCPP_REST_OPENAPI_ENABLED` | `true` | Disable for internet-exposed deployments. |
+| `EVEYS_OCPP_REST_DEFAULT_PAGE_SIZE` | `100` | tunable |
+| `EVEYS_OCPP_REST_MAX_PAGE_SIZE` | `1000` | tunable |
+| `EVEYS_OCPP_REST_INBOUND_TOKENS` | — | **Required in prod.** CSV of bearer tokens. Secret. |
+
+### WS / charger edge
+
+| Variable | Default | Notes |
+|---|---|---|
+| `EVEYS_OCPP_WS_PORT` | `9000` | structural |
+| `EVEYS_OCPP_WS_BASIC_AUTH_REQUIRED` | `false` | **Set `true` in production** once every charger has a credential row. |
+| `EVEYS_OCPP_WS_MTLS_ENABLED` | `false` | Enable for Envoy ↔ gateway mTLS. |
+| `EVEYS_OCPP_WS_MTLS_CERT_PATH` | — | Path to the server cert when mTLS is on. |
+| `EVEYS_OCPP_WS_MTLS_KEY_PATH` | — | Path to the server key. |
+| `EVEYS_OCPP_WS_MTLS_CA_PATH` | — | Path to the CA used to verify Envoy's client cert. |
+
+### OCPP defaults
+
+| Variable | Default | Notes |
+|---|---|---|
+| `EVEYS_OCPP_HEARTBEAT_INTERVAL_SECONDS` | `60` | Returned to the charger in the `BootNotification` reply. |
+
+### Backend integration
+
+| Variable | Default | Notes |
+|---|---|---|
+| `EVEYS_OCPP_BACKEND_BASE_URL` | — | Empty disables the hot path (gateway falls back to local behaviour). |
+| `EVEYS_OCPP_BACKEND_TOKEN` | — | Bearer token your backend accepts. Secret. |
+| `EVEYS_OCPP_BACKEND_AUTHORIZE_FALLBACK` | `reject` | What `Authorize` returns when the backend is unreachable: `reject` (deny) or `accept_offline` (allow). |
+
+### Postgres
+
+| Variable | Default | Notes |
+|---|---|---|
+| `EVEYS_OCPP_DB_URL` | — | **Required.** `postgresql+asyncpg://...`. Secret. |
+| `EVEYS_OCPP_DB_POOL_SIZE` | `10` | tunable |
+| `EVEYS_OCPP_DB_MAX_OVERFLOW` | `10` | tunable |
+
+### Redis
+
+| Variable | Default | Notes |
+|---|---|---|
+| `EVEYS_OCPP_REDIS_URL` | — | **Required.** `redis://...`. |
+
+### Kafka
+
+| Variable | Default | Notes |
+|---|---|---|
+| `EVEYS_OCPP_KAFKA_BROKERS` | — | CSV of bootstrap brokers. |
+| `EVEYS_OCPP_KAFKA_TOPIC_*` | per-event default | See [`events.md`](./events.md). Renaming detaches every consumer. |
+
+### Webhooks
+
+| Variable | Default | Notes |
+|---|---|---|
+| `EVEYS_OCPP_WEBHOOK_SECRET` | — | **Required if any webhook is enabled.** Secret. |
+| `EVEYS_OCPP_WEBHOOK_URL_*` | — | One per event (e.g. `WEBHOOK_URL_TX_STOPPED`). |
+| `EVEYS_OCPP_WEBHOOK_ENABLE_*` | varies | Boolean toggle per event. Disabled = no deliveries. |
+
+### Shutdown
+
+| Variable | Default | Notes |
+|---|---|---|
+| `EVEYS_OCPP_SHUTDOWN_GRACE_PERIOD_SECONDS` | `25` | Must be < your `terminationGracePeriodSeconds` by ≥ 5 s. |
+
+### Observability
+
+| Variable | Default | Notes |
+|---|---|---|
+| `EVEYS_OCPP_TRACING_OTLP_ENDPOINT` | — | Empty disables OpenTelemetry. |
+| `EVEYS_OCPP_TRACING_SAMPLE_RATE` | `0.01` | 1% by default; raise in dev/staging. |
+| `EVEYS_OCPP_SENTRY_DSN` | — | Empty disables Sentry. |
+
+---
+
+## Secrets, not env vars
+
+Five values are sensitive and **should never appear in plaintext** in a values file:
+
+- `EVEYS_OCPP_REST_INBOUND_TOKENS`
+- `EVEYS_OCPP_BACKEND_TOKEN`
+- `EVEYS_OCPP_WEBHOOK_SECRET`
+- `EVEYS_OCPP_DB_URL` (carries the DB password)
+- `EVEYS_OCPP_SENTRY_DSN`
+
+The Helm chart references them by Secret name; your secrets manager (Vault, external-secrets, sealed-secrets, AWS Secrets Manager, etc.) is responsible for getting them onto the cluster.
+
+---
+
+## Runtime overrides via the admin API
+
+A bounded set of `tunable` settings can be changed without restarting the pod. The allow-list is small on purpose — anything that affects wire formats, ports, or persistence is *not* in it.
+
+Typical safe overrides:
+
+- `EVEYS_OCPP_LOG_LEVEL` (drop to `DEBUG` for an investigation, raise back to `INFO`)
+- `EVEYS_OCPP_TRACING_SAMPLE_RATE`
+- `EVEYS_OCPP_BACKEND_AUTHORIZE_FALLBACK`
+- `EVEYS_OCPP_WEBHOOK_URL_*` / `EVEYS_OCPP_WEBHOOK_ENABLE_*`
+
+```bash
+# Drop to DEBUG on one pod for ten minutes
+curl -s -X PATCH http://<pod>:8080/api/v1/admin/config \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"key":"EVEYS_OCPP_LOG_LEVEL","value":"DEBUG"}'
+
+# Restore default
+curl -s -X DELETE http://<pod>:8080/api/v1/admin/config/overrides/EVEYS_OCPP_LOG_LEVEL \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+The override persists in Redis so a new pod inherits it; remove the override to revert. Pods broadcast override changes to each other via the cross-pod bus.
+
+---
+
+## Looking up the live config
+
+```bash
+curl -s http://<gateway>/api/v1/admin/config \
+  -H "Authorization: Bearer $TOKEN" | python3 -m json.tool
+```
+
+Secrets are redacted in the response (shown as `***`). The full JSON schema for the config model is at `GET /api/v1/sys/config/schema` — useful for building admin UIs.
+
+---
+
+## Where to go from here
+
+- The metrics surface: [`metrics.md`](./metrics.md).
+- Operational use of these knobs: [`../guides/operate.md`](../guides/operate.md).
+- Production hardening: [`../guides/deploy-to-production.md`](../guides/deploy-to-production.md).

--- a/userdocs/reference/events.md
+++ b/userdocs/reference/events.md
@@ -1,0 +1,242 @@
+# Events reference
+
+**Use this if you** are subscribing to charger events over Kafka, webhooks, or both.
+
+**Audience.** A backend or data developer wiring up consumers.
+
+**What this answers.** Every event type, its envelope shape, partitioning, idempotency guarantees, and which transports it lands on.
+
+> Integration patterns (when to pick Kafka vs webhooks, how to verify HMAC signatures, how to be idempotent) are in [`../guides/consume-events.md`](../guides/consume-events.md). This page is the catalogue.
+
+---
+
+## The envelope
+
+Every event — over Kafka or webhooks — uses the same protobuf envelope. The proto file lives at `proto/events/v1/events.proto`:
+
+```protobuf
+message EventEnvelope {
+  string event_id      = 1;   // UUID, unique per event
+  string occurred_at   = 2;   // ISO-8601 server-receive timestamp (UTC)
+  string cp_id         = 3;   // charger the event is about
+  string schema_version = 4;  // "v1"
+  string trace_id      = 5;   // optional, for distributed tracing
+
+  oneof payload {
+    CpConnected             cp_connected             = 100;
+    CpBoot                  cp_boot                  = 101;
+    CpStatus                cp_status                = 102;
+    CpMeter                 cp_meter                 = 103;
+    TxStarted               tx_started               = 104;
+    CpSecurityEvent         cp_security_event        = 105;
+    TxStopped               tx_stopped               = 106;
+    CpDisconnected          cp_disconnected          = 107;
+    CpFirmwareStatusChanged cp_firmware_status_changed = 108;
+    CpDiagnosticsStatusChanged cp_diagnostics_status_changed = 109;
+    CpCsrSubmitted          cp_csr_submitted         = 110;
+  }
+}
+```
+
+Generate consumer bindings from the proto file in your language. The `WhichOneof("payload")` discriminator tells you which payload variant is set.
+
+---
+
+## Topic / event catalogue
+
+| Topic (default) | Payload | Direction | Volume | Webhook URL setting |
+|---|---|---|---|---|
+| `cp.connected` | `CpConnected` | WS established | per connect | `EVEYS_OCPP_WEBHOOK_URL_CP_ONLINE` |
+| `cp.disconnected` | `CpDisconnected` | WS ended | per disconnect | `EVEYS_OCPP_WEBHOOK_URL_CP_OFFLINE` |
+| `cp.boot` | `CpBoot` | `BootNotification` arrived | rare; on charger boot | `EVEYS_OCPP_WEBHOOK_URL_CP_BOOT` |
+| `cp.status` | `CpStatus` | `StatusNotification` arrived | bursts on state change | `EVEYS_OCPP_WEBHOOK_URL_CP_STATUS` |
+| `cp.meter` | `CpMeter` | `MeterValues` arrived | high; per sample per active session | `EVEYS_OCPP_WEBHOOK_URL_CP_METER` (disabled by default; use Kafka) |
+| `cp.firmware_status` | `CpFirmwareStatusChanged` | `FirmwareStatusNotification` arrived | low; firmware lifecycle | `EVEYS_OCPP_WEBHOOK_URL_CP_FIRMWARE_STATUS` |
+| `cp.diagnostics_status` | `CpDiagnosticsStatusChanged` | `DiagnosticsStatusNotification` arrived | low; diagnostics lifecycle | `EVEYS_OCPP_WEBHOOK_URL_CP_DIAGNOSTICS_STATUS` |
+| `cp.security_event` | `CpSecurityEvent` | `SecurityEventNotification` arrived | sparse; audit-grade | (Kafka only; SIEM pipeline) |
+| `cp.csr_submitted` | `CpCsrSubmitted` | `SignCertificate` arrived | sparse; cert-rotation cycles | (Kafka only; operator queue) |
+| `tx.started` | `TxStarted` | `StartTransaction` persisted | one per session start | `EVEYS_OCPP_WEBHOOK_URL_TX_STARTED` |
+| `tx.stopped` | `TxStopped` | `StopTransaction` persisted | one per session end | `EVEYS_OCPP_WEBHOOK_URL_TX_STOPPED` |
+
+Topic names are configurable; the table shows defaults. Rename only when your platform's naming convention demands it — every consumer detaches.
+
+---
+
+## Per-payload reference
+
+### `CpConnected` — WebSocket opened
+
+```protobuf
+message CpConnected {
+  string subprotocol = 1;   // negotiated: "ocpp1.6" or "ocpp2.0.1"
+  string pod_id      = 2;   // gateway pod that accepted the connection
+}
+```
+
+Published right after the gateway marks the charger online in the registry. **Webhook-equivalent: `cp.online`** (the historical name).
+
+### `CpDisconnected` — WebSocket closed
+
+```protobuf
+message CpDisconnected {
+  string pod_id = 1;
+  string reason = 2;   // "clean" or "error"
+}
+```
+
+Published only when the registry's compare-and-delete confirms this pod still owned the key — a reconnect-to-different-pod race does **not** produce a spurious offline event.
+
+### `CpBoot` — `BootNotification` arrived
+
+```protobuf
+message CpBoot {
+  string vendor           = 1;
+  string model            = 2;
+  string firmware_version = 3;
+  string serial_number    = 4;
+  CpBootStatus status     = 5;   // ACCEPTED / PENDING / REJECTED
+}
+```
+
+### `CpStatus` — `StatusNotification` arrived
+
+```protobuf
+message CpStatus {
+  int32  connector_id        = 1;
+  string status              = 2;   // OCPP-spec string: Available, Charging, ...
+  string error_code          = 3;   // OCPP-spec string: NoError, ConnectorLockFailure, ...
+  string info                = 4;
+  string vendor_id           = 5;
+  string vendor_error_code   = 6;
+  string charger_reported_at = 7;   // charger's own clock; untrusted
+}
+```
+
+### `CpMeter` — `MeterValues` arrived
+
+```protobuf
+message CpMeter {
+  int32  connector_id        = 1;
+  int64  transaction_id      = 2;
+  repeated SampledValue sampled_values = 3;
+  string charger_reported_at = 4;
+}
+
+message SampledValue {
+  string    value     = 1;
+  Context   context   = 2;   // enum
+  Format    format    = 3;   // enum
+  Measurand measurand = 4;   // enum
+  Phase     phase     = 5;   // enum
+  Location  location  = 6;   // enum
+  Unit      unit      = 7;   // enum
+}
+```
+
+The enums encode the OCPP-spec wire strings (`MEASURAND_ENERGY_ACTIVE_IMPORT_REGISTER`, `MEASURAND_SOC`, etc.). High volume — every active session emits these on the sampling interval.
+
+### `TxStarted` — `StartTransaction` persisted
+
+```protobuf
+message TxStarted {
+  int64  transaction_id      = 1;
+  int32  connector_id        = 2;
+  string id_tag              = 3;
+  int64  meter_start_wh      = 4;
+  string charger_reported_at = 5;
+}
+```
+
+Published **after** the gateway commits to Postgres. Replays of the same `StartTransaction` (which OCPP allows) do not re-emit.
+
+### `TxStopped` — `StopTransaction` persisted
+
+```protobuf
+message TxStopped {
+  int64  transaction_id      = 1;
+  string id_tag              = 2;
+  int64  meter_stop_wh       = 3;
+  int64  consumed_wh         = 4;   // pre-computed: meter_stop - meter_start
+  string stop_reason         = 5;
+  string charger_reported_at = 6;
+}
+```
+
+`consumed_wh` is computed from the matching `TxStarted` so consumers don't have to join. Replays don't re-emit.
+
+### `CpSecurityEvent` — `SecurityEventNotification` arrived
+
+```protobuf
+message CpSecurityEvent {
+  string type                = 1;   // OCPP type: InvalidSignature, TamperDetectionActivated, ...
+  string charger_reported_at = 2;
+  string tech_info           = 3;
+}
+```
+
+Audit-grade. SIEM pipelines tail this.
+
+### `CpFirmwareStatusChanged` / `CpDiagnosticsStatusChanged`
+
+```protobuf
+message CpFirmwareStatusChanged   { string status = 1; }
+message CpDiagnosticsStatusChanged { string status = 1; }
+```
+
+Status is the charger-reported state-machine string — `Downloading`, `Installed`, `UploadFailed`, etc. Kept as a string for forward-compat with vendor extensions.
+
+### `CpCsrSubmitted` — charger asked us to sign a CSR
+
+```protobuf
+message CpCsrSubmitted {
+  string csr        = 1;   // PEM-encoded CSR
+  int64  pending_id = 2;   // row id in pending_certificate_signings
+}
+```
+
+The operator queue uses this to route a freshly-arrived CSR into a review UI.
+
+---
+
+## Kafka delivery semantics
+
+- **Producer config.** `acks=all` + `enable.idempotence=true`. The gateway will not silently drop messages under broker churn.
+- **Partition key.** `cp_id` on every record. Per-charger ordering is preserved.
+- **Schema evolution.** Adding fields is allowed; renumbering or removing fields is forbidden until v2 of the envelope. Consumers **must** ignore unknown fields.
+- **At-least-once.** Consumers should idempotent-handle on `event_id`.
+
+---
+
+## Webhook delivery semantics
+
+- **Payload.** The same envelope, JSON-encoded. The `payload` `oneof` becomes a JSON object with a single key naming the variant (e.g. `{"payload": {"tx_started": {...}}}`).
+- **Headers.**
+  - `Content-Type: application/json`
+  - `X-Eveys-Signature: sha256=<lowercase-hex-hmac>` — HMAC-SHA256 of the raw body using `EVEYS_OCPP_WEBHOOK_SECRET`.
+  - `X-Eveys-Event-Type: cp.boot` — for routing.
+  - `X-Eveys-Event-Id: <uuid>` — same value as the envelope's `event_id`.
+  - `X-Eveys-Delivery-Attempt: <n>` — incremented on retries.
+- **Success.** Any 2xx. The gateway gives up retrying on 4xx (the body is malformed in your view); retries non-2xx with exponential backoff up to a configurable cap.
+- **At-least-once.** Be idempotent on `event_id`.
+
+---
+
+## What's *not* an event
+
+- **Heartbeats.** Absorbed by the online registry; surfaced via REST (`last_heartbeat_at`), not as a Kafka topic.
+- **Authorize.** Synchronous; the gateway forwards to your backend's hot-path REST endpoint.
+- **Outbound command results** (RemoteStart's reply, Reset's reply). Returned synchronously to the REST/gRPC caller; not re-published.
+
+---
+
+## Version compatibility
+
+`schema_version` is the load-bearing version field on the envelope. `v1` is the current schema; future schema breaks will increment this. Consumers should check the version on every message and refuse to process unknown versions rather than silently mis-interpret.
+
+---
+
+## Where to go from here
+
+- Picking Kafka vs webhooks, verifying HMAC, designing idempotent consumers: [`../guides/consume-events.md`](../guides/consume-events.md).
+- Why some events sometimes arrive twice: [`../concepts/idempotency-and-replay.md`](../concepts/idempotency-and-replay.md).
+- The synchronous side of the same flow: [`rest-api.md`](./rest-api.md), [`grpc-api.md`](./grpc-api.md).

--- a/userdocs/reference/grpc-api.md
+++ b/userdocs/reference/grpc-api.md
@@ -1,0 +1,194 @@
+# gRPC API reference
+
+**Use this if you** need lower overhead than REST or you're generating client stubs from `.proto` files.
+
+**Audience.** A developer comfortable with protobuf and gRPC clients.
+
+**What this answers.** Every RPC, request and response messages, the proto enum surface, deadlines and errors.
+
+> The REST API mirrors every gRPC RPC and shares the same OCPP semantics. If you're integrating once from a thin client and won't generate stubs, REST is usually simpler. gRPC is the right choice for high-fanout services that benefit from HTTP/2 multiplexing and binary framing.
+
+---
+
+## Service definition
+
+```protobuf
+syntax = "proto3";
+package eveys.ocpp_gw.v1;
+
+service OcppGateway { ... }
+```
+
+- **Proto file**: `proto/ocpp_gw/v1/gateway.proto` in the repository.
+- **Default port**: `50051` (`EVEYS_OCPP_GRPC_PORT`).
+- **Transport**: HTTP/2; TLS optional (configure via env vars).
+
+Generate stubs in your language with whichever tooling you prefer:
+
+```bash
+# Python
+python -m grpc_tools.protoc \
+  --proto_path=proto \
+  --python_out=. --grpc_python_out=. \
+  proto/ocpp_gw/v1/gateway.proto
+
+# Go
+protoc --go_out=. --go-grpc_out=. \
+  -I proto proto/ocpp_gw/v1/gateway.proto
+
+# TypeScript
+buf generate --template buf.gen.yaml proto
+```
+
+---
+
+## Authentication
+
+The gateway accepts a bearer token in the gRPC metadata field `authorization`, same shape as the REST header:
+
+```python
+# Python (grpclib)
+from grpclib.client import Channel
+from grpclib.metadata import Deadline
+
+ch = Channel(host="gateway.example.com", port=50051)
+md = [("authorization", f"Bearer {TOKEN}")]
+deadline = Deadline.from_timeout(35.0)  # OCPP CALL ceiling is 30s; allow margin
+```
+
+Same CSV-of-tokens config (`EVEYS_OCPP_REST_INBOUND_TOKENS`) covers both transports.
+
+---
+
+## Every RPC
+
+The OCPP semantics are identical to the REST surface — the only differences are the framing and the strongly-typed enums.
+
+| RPC | OCPP equivalent | Notes |
+|---|---|---|
+| `RemoteStart` | `RemoteStartTransaction.req` | Returns `RemoteStartResponse{status}`. |
+| `RemoteStop` | `RemoteStopTransaction.req` | |
+| `Reset` | `Reset.req` | `type ∈ Soft / Hard`. |
+| `ChangeConfiguration` | `ChangeConfiguration.req` | Status: `Accepted / Rejected / RebootRequired / NotSupported`. |
+| `GetConfiguration` | `GetConfiguration.req` | Returns `configuration_key[]` + `unknown_key[]`. |
+| `ClearCache` | `ClearCache.req` | |
+| `TriggerMessage` | `TriggerMessage.req` | Core 6 message types. |
+| `ExtendedTriggerMessage` | Security Whitepaper §4.7 | Superset of Core types (adds `LogStatusNotification`, `SignChargePointCertificate`). |
+| `UnlockConnector` | `UnlockConnector.req` | |
+| `ChangeAvailability` | `ChangeAvailability.req` | `connector_id = 0` → whole charger. |
+| `DataTransfer` | `DataTransfer.req` (outbound) | Vendor extension hatch. |
+| `GetLocalListVersion` | `GetLocalListVersion.req` | |
+| `SendLocalList` | `SendLocalList.req` | Full or differential. |
+| `ReserveNow` | `ReserveNow.req` | |
+| `CancelReservation` | `CancelReservation.req` | |
+| `GetDiagnostics` | `GetDiagnostics.req` | Followed asynchronously by `DiagnosticsStatusNotification`. |
+| `UpdateFirmware` | `UpdateFirmware.req` | Followed by `FirmwareStatusNotification`. |
+| `SetChargingProfile` | `SetChargingProfile.req` | |
+| `ClearChargingProfile` | `ClearChargingProfile.req` | |
+| `GetCompositeSchedule` | `GetCompositeSchedule.req` | |
+| `GetLog` | Security Whitepaper §4.6 | `log_type ∈ DiagnosticsLog / SecurityLog`. |
+| `InstallCertificate` | Security Whitepaper §4.5 | Returns the SHA-256 the operator uses to address the cert later. |
+| `DeleteCertificate` | Security Whitepaper §4.10 | By SHA-256. |
+| `GetInstalledCertificateIds` | Security Whitepaper §4.8 | Returns hash_data per installed cert. |
+| `CertificateSigned` | Security Whitepaper §4.2 | Operator pushes a signed chain in response to a charger CSR. |
+| `SignedUpdateFirmware` | Security Whitepaper §4.4 | Signed firmware update. |
+| `GetChargerStatus` | (synchronous read, no OCPP CALL) | Returns the gateway's cached state for one charger. |
+
+---
+
+## Request/response shapes
+
+Rather than restating every message, the protobuf file is the source of truth. A representative example:
+
+```protobuf
+message RemoteStartRequest {
+  string cp_id = 1;            // required
+  string id_tag = 2;           // required
+  int32 connector_id = 3;      // 0 = whichever; >0 = specific
+  ChargingProfile profile = 4; // optional
+}
+
+message RemoteStartResponse {
+  RemoteStartStatus status = 1;   // ACCEPTED / REJECTED
+}
+
+enum RemoteStartStatus {
+  REMOTE_START_STATUS_UNSPECIFIED = 0;
+  REMOTE_START_STATUS_ACCEPTED = 1;
+  REMOTE_START_STATUS_REJECTED = 2;
+}
+```
+
+**Important about enums.** Every proto enum has an `_UNSPECIFIED = 0` zero value. The gateway rejects requests that leave required enums unset (the proto3 default would otherwise look like a valid "missing" — see [`../guides/use-the-rest-api.md`](../guides/use-the-rest-api.md) for why this matters). Always set the enum field explicitly.
+
+For the full payload tree, generate the stubs and let your IDE walk the types.
+
+---
+
+## Error model
+
+gRPC errors follow standard status codes:
+
+| gRPC code | When |
+|---|---|
+| `OK` | Charger replied; result is in the response message. |
+| `INVALID_ARGUMENT` | Malformed request (empty `cp_id`, unset enum, negative `connector_id`, etc.). |
+| `UNAUTHENTICATED` | No bearer token. |
+| `PERMISSION_DENIED` | Bearer token didn't match. |
+| `NOT_FOUND` | Unknown `cp_id`, `transaction_id`, `reservation_id`. |
+| `FAILED_PRECONDITION` | Charger is offline; nothing to dispatch to. |
+| `DEADLINE_EXCEEDED` | Charger didn't reply within the OCPP 30-second ceiling. |
+| `RESOURCE_EXHAUSTED` | Rate-limited. |
+| `INTERNAL` | Unexpected; file against the gateway. |
+
+The error `details` carry a stable `error_code` string matching the REST envelope's `error_code`.
+
+---
+
+## Deadlines
+
+OCPP CALLs have a hard 30-second ceiling on the wire. Set your client-side deadline above that — 35 seconds is a sensible default — to give the gateway room to translate the timeout into `DEADLINE_EXCEEDED` cleanly.
+
+```python
+async with ch:
+    stub = gateway_grpc.OcppGatewayStub(ch)
+    response = await stub.RemoteStart(
+        gateway_pb2.RemoteStartRequest(cp_id="CP_X", id_tag="USER_RFID_123", connector_id=1),
+        timeout=35.0,
+    )
+```
+
+---
+
+## Streaming
+
+The current API is **unary** only — every RPC is request/response. There are no server-streaming or bidirectional-streaming endpoints. If you want a feed of events, subscribe to the Kafka topics; see [`events.md`](./events.md).
+
+---
+
+## Cross-pod dispatch is transparent
+
+When you call a command on the gateway, the pod that handles your call doesn't necessarily own the charger's WebSocket. The gateway looks up the owning pod in Redis and forwards the call internally. Your client never sees this — same RPC, same deadline, same response shape — but you may see a few extra milliseconds of latency on cross-pod hops.
+
+The internals are in [`../concepts/multi-pod-and-routing.md`](../concepts/multi-pod-and-routing.md).
+
+---
+
+## Reflection
+
+The gateway does not enable gRPC reflection by default. To explore the service interactively, point [`grpcurl`](https://github.com/fullstorydev/grpcurl) at your local stack with the proto file:
+
+```bash
+grpcurl -import-path proto -proto proto/ocpp_gw/v1/gateway.proto \
+  -H "authorization: Bearer $TOKEN" \
+  -d '{"cp_id":"CP_X","id_tag":"USER","connector_id":1}' \
+  localhost:50051 eveys.ocpp_gw.v1.OcppGateway/RemoteStart
+```
+
+---
+
+## Where to go from here
+
+- REST equivalents (with full payload shapes): [`rest-api.md`](./rest-api.md).
+- Event consumption (push side of the API): [`events.md`](./events.md).
+- Why some calls return `DEADLINE_EXCEEDED` and how to retry safely: [`../guides/use-the-rest-api.md`](../guides/use-the-rest-api.md).

--- a/userdocs/reference/metrics.md
+++ b/userdocs/reference/metrics.md
@@ -1,0 +1,214 @@
+# Metrics reference
+
+**Use this if you** are building dashboards, writing alerts, or investigating latency or error spikes.
+
+**Audience.** SREs and observability engineers.
+
+**What this answers.** Every Prometheus series the gateway exposes, what its labels mean, what "normal" looks like, and what a sudden change implies.
+
+> The metrics surface is `/metrics` on port `9100`. Scrape it with Prometheus, build dashboards with Grafana. Sample dashboards are shipped under `deploy/grafana/dashboards/` in the repo.
+
+---
+
+## Naming
+
+All gateway metrics are prefixed `eveys_ocpp_`. Histograms produce three series per name (`_bucket`, `_count`, `_sum`); counters produce `<name>_total`; gauges produce `<name>` directly.
+
+---
+
+## The signals that matter most
+
+If you build only four panels, build these.
+
+### `eveys_ocpp_ws_connections_active` (gauge)
+
+How many charger WebSocket sockets are open on this pod right now.
+
+- **Labels**: none.
+- **Sum it across pods** for fleet total.
+- **Watch for**: cliffs (network event), sudden growth (reconnect storm — usually after the gateway itself was unhealthy).
+
+### `eveys_ocpp_ocpp_handler_latency_seconds` (histogram)
+
+Inbound OCPP CALL handling latency, per action.
+
+- **Labels**: `action` (`BootNotification`, `Authorize`, `StartTransaction`, ...).
+- **p99 spikes**: usually Postgres slowness. Check `eveys_ocpp_db_query_latency_seconds` next.
+- **p50 + p99 widening**: handler doing more work — recent change?
+
+### `eveys_ocpp_grpc_request_latency_seconds` (histogram)
+
+Outbound dispatch latency. The full round-trip from "your REST call landed" to "the charger answered".
+
+- **Labels**: `rpc` (`RemoteStart`, etc.).
+- **p99 dominated by**: the WS round-trip + the charger's own latency. Cross-pod hops add a few milliseconds.
+
+### `eveys_ocpp_ocpp_handler_errors_total` (counter)
+
+Per-action error count.
+
+- **Labels**: `action`.
+- **Trend matters more than absolute.** A handful per day is normal at fleet scale; rate climbing is the signal.
+
+---
+
+## Full catalogue (by area)
+
+### WebSocket
+
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `eveys_ocpp_ws_connections_active` | gauge | — | Sockets open right now. |
+| `eveys_ocpp_ws_connects_total` | counter | — | Cumulative connect count. |
+| `eveys_ocpp_ws_disconnects_total` | counter | `reason` | Cumulative disconnect count. |
+| `eveys_ocpp_ws_handshake_failures_total` | counter | `reason` | TLS / subprotocol / auth handshake failures. |
+| `eveys_ocpp_ws_messages_in_total` | counter | `action` | OCPP CALLs received from chargers. |
+| `eveys_ocpp_ws_messages_out_total` | counter | `action` | OCPP CALLs sent to chargers. |
+| `eveys_ocpp_ws_basic_auth_total` | counter | `outcome` | Basic Auth pass/fail counts. |
+
+### OCPP handlers (inbound)
+
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `eveys_ocpp_ocpp_handler_latency_seconds` | histogram | `action` | End-to-end handler time. |
+| `eveys_ocpp_ocpp_handler_errors_total` | counter | `action`, `exception` | Handler raised. |
+| `eveys_ocpp_boot_notifications_total` | counter | `status` | BootNotification by reply status (Accepted / Pending / Rejected). |
+| `eveys_ocpp_boot_replays_total` | counter | — | Replays of a prior BootNotification deduped by the idempotency cache. |
+| `eveys_ocpp_authorize_total` | counter | `outcome` | Authorize results (Accepted/Blocked/Expired/Invalid/ConcurrentTx). |
+| `eveys_ocpp_authorize_cache_hits_total` | counter | — | Redis Authorize cache hits. |
+| `eveys_ocpp_authorize_cache_misses_total` | counter | — | Cache misses (fell through to backend). |
+| `eveys_ocpp_start_transactions_total` | counter | — | StartTransaction persisted. |
+| `eveys_ocpp_stop_transactions_received_total` | counter | — | StopTransaction received (denominator for SLO 4). |
+| `eveys_ocpp_stop_transactions_total` | counter | — | StopTransaction persisted (numerator). |
+| `eveys_ocpp_stop_transaction_replays_total` | counter | — | Deduped replays. |
+| `eveys_ocpp_heartbeats_total` | counter | — | Heartbeats. |
+| `eveys_ocpp_heartbeat_registry_reclaims_total` | counter | — | Charger heartbeat seen on a different pod than the registry said. |
+| `eveys_ocpp_status_notifications_total` | counter | `status`, `error_code` | Charger state changes. |
+| `eveys_ocpp_meter_values_total` | counter | — | MeterValues messages received. |
+| `eveys_ocpp_meter_value_samples_total` | counter | `measurand` | Individual samples within messages. |
+| `eveys_ocpp_meter_value_quarantined_total` | counter | `reason` | Samples rejected by sanity checks. |
+| `eveys_ocpp_rate_limit_throttled_total` | counter | `surface` | Throttled requests (WS / REST). |
+| `eveys_ocpp_data_transfers_total` | counter | `vendor_id`, `status` | DataTransfer counts. |
+| `eveys_ocpp_firmware_status_total` | counter | `status` | FirmwareStatusNotification. |
+| `eveys_ocpp_diagnostics_status_total` | counter | `status` | DiagnosticsStatusNotification. |
+| `eveys_ocpp_sign_certificate_received_total` | counter | `outcome` | SignCertificate (CSRs from chargers). |
+| `eveys_ocpp_security_events_total` | counter | `type` | SecurityEventNotification. |
+| `eveys_ocpp_log_status_total` | counter | `status` | LogStatusNotification. |
+
+### Outbound dispatch (gRPC + REST → charger)
+
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `eveys_ocpp_grpc_requests_total` | counter | `rpc`, `outcome` | gRPC request count. |
+| `eveys_ocpp_grpc_request_latency_seconds` | histogram | `rpc` | gRPC end-to-end latency. |
+| `eveys_ocpp_grpc_dispatch_route_total` | counter | `route` | Same-pod vs cross-pod dispatch counts. |
+| `eveys_ocpp_grpc_charger_offline_total` | counter | `rpc` | Dispatches that found the charger offline. |
+| `eveys_ocpp_bus_requests_total` | counter | `outcome` | Cross-pod bus requests. |
+| `eveys_ocpp_bus_request_latency_seconds` | histogram | — | Cross-pod hop latency. |
+| `eveys_ocpp_bus_inflight` | gauge | — | Currently waiting on bus responses. |
+
+### Kafka producer
+
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `eveys_ocpp_kafka_publish_total` | counter | `topic`, `outcome` | Publish attempts. |
+| `eveys_ocpp_kafka_publish_latency_seconds` | histogram | `topic` | Publish latency. |
+| `eveys_ocpp_kafka_publish_bytes_total` | counter | `topic` | Bytes published. |
+
+### Webhooks
+
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `eveys_ocpp_webhook_deliveries_total` | counter | `event`, `outcome` | Final delivery outcomes (`success`, `failed`). |
+| `eveys_ocpp_webhook_delivery_latency_seconds` | histogram | `event` | End-to-end delivery latency. |
+| `eveys_ocpp_webhook_attempts_total` | counter | `event`, `outcome` | All delivery attempts including retries. |
+| `eveys_ocpp_webhook_consumer_lag_messages` | gauge | `topic` | Backlog in the internal webhook consumer. |
+
+### Backend integration
+
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `eveys_ocpp_backend_requests_total` | counter | `endpoint`, `outcome` | Calls to your backend. |
+| `eveys_ocpp_backend_request_latency_seconds` | histogram | `endpoint` | Backend latency from the gateway's view. |
+| `eveys_ocpp_backend_retries_total` | counter | `endpoint` | Backend retries. |
+| `eveys_ocpp_backend_circuit_state` | gauge | `endpoint` | Circuit breaker state (0=closed, 1=half-open, 2=open). |
+| `eveys_ocpp_backend_circuit_transitions_total` | counter | `endpoint`, `from`, `to` | State transitions. |
+
+### Persistence
+
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `eveys_ocpp_db_query_latency_seconds` | histogram | `query` | Postgres query time. |
+| `eveys_ocpp_db_pool_in_use` | gauge | — | Connections currently checked out. |
+| `eveys_ocpp_db_pool_overflow` | gauge | — | Overflow connections in use. |
+| `eveys_ocpp_redis_command_latency_seconds` | histogram | `command` | Redis command latency. |
+| `eveys_ocpp_registry_online_chargers` | gauge | — | Chargers the gateway thinks are online. |
+
+### Idempotency
+
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `eveys_ocpp_idempotency_lookups_total` | counter | `outcome` | `hit` (deduped) vs `miss` (new). |
+
+### REST surface
+
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `eveys_ocpp_rest_requests_total` | counter | `path`, `method`, `status` | Inbound REST requests. |
+| `eveys_ocpp_rest_request_latency_seconds` | histogram | `path`, `method` | Inbound REST latency. |
+
+### Build info
+
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `eveys_ocpp_build_info` | gauge (value=1) | `version`, `commit`, `python_version` | Released version metadata. |
+
+---
+
+## Reading histograms
+
+Every histogram exposes a default bucket layout sized to the surface it covers (sub-millisecond to multi-second). To get a percentile in PromQL:
+
+```promql
+histogram_quantile(0.99,
+  sum by (le, rpc) (
+    rate(eveys_ocpp_grpc_request_latency_seconds_bucket[5m])
+  )
+)
+```
+
+p99 is the most actionable percentile for the gateway — p50 hides the long tail that matters when chargers think a command failed.
+
+---
+
+## SLOs the project tracks internally
+
+The dashboards in `deploy/grafana/dashboards/06-slos.json` include the SLOs the gateway is engineered against. The four you'll care about:
+
+| SLO | Definition | What breaks it |
+|---|---|---|
+| **1. WS availability** | (connects + maintained) / (connects + maintained + failed handshakes) | TLS, auth, capacity issues. |
+| **2. Command success** | `RemoteStart` Accepted / total RemoteStart attempts | Charger offline, charger rejecting valid commands. |
+| **3. Event delivery** | Successful Kafka publish / total publish attempts | Broker outage, partition leader churn. |
+| **4. Transaction durability** | `StopTransaction` persisted / received | Postgres outage or handler bug. |
+
+---
+
+## Alert ideas (no specific thresholds; these are starting points)
+
+- 5xx rate on REST sustained > 1% for 5 minutes.
+- `eveys_ocpp_ws_connections_active` drops > 20% over 1 minute (sudden disconnect).
+- `eveys_ocpp_handler_errors_total{action="StopTransaction"}` rate > 0 for 1 minute.
+- p99 of `eveys_ocpp_ocpp_handler_latency_seconds{action="MeterValues"}` > 500 ms.
+- `eveys_ocpp_db_pool_in_use / db_pool_max` > 0.9 for 5 minutes.
+- `eveys_ocpp_backend_circuit_state > 0` for any backend endpoint.
+
+Tune to your fleet's baseline — the right thresholds depend on traffic shape.
+
+---
+
+## Where to go from here
+
+- Operating from these metrics: [`../guides/operate.md`](../guides/operate.md).
+- The events these metrics count: [`events.md`](./events.md).
+- Configuration that affects what gets emitted: [`configuration.md`](./configuration.md).

--- a/userdocs/reference/rest-api.md
+++ b/userdocs/reference/rest-api.md
@@ -1,0 +1,344 @@
+# REST API reference
+
+**Use this if you** are calling the gateway over HTTP from a backend, dashboard, or scripts.
+
+**Audience.** A developer who already knows REST and wants the exact endpoint surface.
+
+**What this answers.** Every path, request body, response body, error code, and pagination rule.
+
+> Integration patterns (auth, errors, retries, cursors) are explained in [`../guides/use-the-rest-api.md`](../guides/use-the-rest-api.md). This page is the catalogue.
+
+---
+
+## Conventions in this page
+
+- Every path is prefixed with `/api/v1`.
+- Every request carries `Authorization: Bearer <token>` unless explicitly noted.
+- Success responses are raw JSON (no envelope). Field names are `snake_case`.
+- Error responses match the envelope in [§Error envelope](#error-envelope).
+- `cp_id` is always a path parameter; `transaction_id`, `reservation_id`, etc. are integers.
+- The complete OpenAPI schema is at `GET /api/v1/openapi.json`; Swagger UI at `GET /api/v1/docs`.
+
+---
+
+## Probes
+
+### `GET /health` — liveness
+
+Auth-exempt. Returns `200 OK` whenever the process is up. The body's `status` field reports downstream component health (`ok` / `degraded` / `unavailable`); HTTP status itself does not change.
+
+```json
+{
+  "status": "ok",
+  "components": { "postgres": "ok", "redis": "ok" },
+  "version": "0.1.0",
+  "build": { ... }
+}
+```
+
+### `GET /ready` — readiness / drain signal
+
+Auth-exempt. Returns `200 OK` normally. Returns `503 Service Unavailable` once the pod is draining (after `SIGTERM`). Load balancers and Envoy probe this; do not use it for application logic.
+
+---
+
+## Charge points
+
+### `GET /charge-points` — list the fleet
+
+Cursor-paginated.
+
+Query params:
+
+| Param | Type | Default | Notes |
+|---|---|---|---|
+| `cursor` | string | — | Opaque; pass `next_cursor` from the previous page. |
+| `limit` | int | `rest_default_page_size` | Capped by `rest_max_page_size`. |
+| `vendor` | string | — | Filter by `BootNotification`-reported vendor. |
+| `model` | string | — | Filter by model. |
+
+Response:
+
+```json
+{
+  "charge_points": [
+    {
+      "cp_id": "CP_ACME_42",
+      "vendor": "ACME",
+      "model": "CV2",
+      "firmware_version": "1.4.2",
+      "serial_number": "SN-001",
+      "last_boot_at": "2026-05-11T08:00:00Z",
+      "last_heartbeat_at": "2026-05-11T10:00:00Z",
+      "last_status": "Available",
+      "connectors": [ { "connector_id": 1, "status": "Available" } ]
+    }
+  ],
+  "next_cursor": "eyJpZCI6MTIzfQ",
+  "request_id": "..."
+}
+```
+
+### `GET /charge-points/{cp_id}` — single charger detail
+
+Inlines active reservations and active charging profiles.
+
+```json
+{
+  "cp_id": "CP_ACME_42",
+  "vendor": "ACME",
+  "model": "CV2",
+  "firmware_version": "1.4.2",
+  "serial_number": "SN-001",
+  "last_boot_at": "...",
+  "last_heartbeat_at": "...",
+  "last_firmware_status": "Installed",
+  "last_diagnostics_status": null,
+  "last_log_status": null,
+  "connectors": [ ... ],
+  "active_reservations": [ ... ],
+  "active_charging_profiles": [ ... ],
+  "request_id": "..."
+}
+```
+
+Errors: `404 UNKNOWN_CP_ID`.
+
+---
+
+## Transactions
+
+### `GET /transactions` — global transaction list
+
+Cursor-paginated. Query params:
+
+| Param | Type | Notes |
+|---|---|---|
+| `cursor`, `limit` | | Standard pagination. |
+| `cp_id` | string | Narrow to one charger. |
+| `id_tag` | string | Narrow to one user identifier. |
+| `status` | string | `running` / `completed`. |
+| `started_after` / `started_before` | ISO-8601 | Time window. |
+
+### `GET /charge-points/{cp_id}/transactions` — per-charger list
+
+Same query params; `cp_id` comes from the path instead of a filter.
+
+### `GET /transactions/{transaction_id}` — single transaction with telemetry
+
+Response carries a bounded `telemetry` block (state-of-charge + per-phase voltage/current/power snapshot when reported by the charger).
+
+```json
+{
+  "transaction_id": 12345,
+  "cp_id": "CP_ACME_42",
+  "connector_id": 1,
+  "id_tag": "USER_RFID_123",
+  "meter_start_wh": 12000,
+  "meter_stop_wh": 18500,
+  "started_reported_at": "...",
+  "started_received_at": "...",
+  "stopped_reported_at": "...",
+  "stopped_received_at": "...",
+  "stop_reason": "Local",
+  "telemetry": {
+    "soc": { "start_pct": 32, "last_pct": 78, "last_at": "..." },
+    "phases": {
+      "L1": { "voltage_v": 230, "current_a": 16, "power_w": 3680 },
+      "L2": { ... },
+      "L3": { ... }
+    }
+  },
+  "request_id": "..."
+}
+```
+
+Errors: `404 UNKNOWN_TRANSACTION_ID`.
+
+---
+
+## Reservations and charging profiles
+
+### `GET /charge-points/{cp_id}/reservations`
+
+Cursor-paginated. Query params include `status` and `active=true|false` (active = `status=Active AND expiry_date > now()`).
+
+### `GET /charge-points/{cp_id}/charging-profiles`
+
+Cursor-paginated. Lists every profile currently installed on the charger from the gateway's mirror.
+
+---
+
+## Time-series
+
+### `GET /charge-points/{cp_id}/meter-values`
+
+Query params:
+
+| Param | Notes |
+|---|---|
+| `transaction_id` | Narrow to one session. |
+| `from`, `to` | ISO-8601 window bounds. |
+| `measurand` | `Energy.Active.Import.Register`, `Voltage`, etc. |
+| `cursor`, `limit` | Standard. |
+
+Errors: `400 WINDOW_TOO_LARGE` when the window is too wide.
+
+### `GET /charge-points/{cp_id}/status-history`
+
+Connector state transitions. Same query shape as `meter-values`.
+
+---
+
+## Commands (POST … under `/charge-points/{cp_id}/commands/`)
+
+Every command dispatches an OCPP CALL to the charger and returns its reply. Status mappings come straight from the OCPP enums.
+
+| Path | Body | Response `status` values |
+|---|---|---|
+| `/remote-start` | `{"id_tag":"...","connector_id":1,"charging_profile":{...?}}` | `Accepted` / `Rejected` |
+| `/remote-stop` | `{"transaction_id":N}` | `Accepted` / `Rejected` |
+| `/reset` | `{"type":"Soft"\|"Hard"}` | `Accepted` / `Rejected` |
+| `/change-configuration` | `{"key":"...","value":"..."}` | `Accepted` / `Rejected` / `RebootRequired` / `NotSupported` |
+| `/get-configuration` | `{"keys":["..."]}` (empty/absent = all) | `{"configuration_key":[{key, readonly, value}], "unknown_key":["..."]}` |
+| `/clear-cache` | `{}` | `Accepted` / `Rejected` |
+| `/trigger-message` | `{"requested_message":"BootNotification","connector_id":0}` | `Accepted` / `Rejected` / `NotImplemented` |
+| `/extended-trigger-message` | `{"requested_message":"LogStatusNotification"\|"SignChargePointCertificate"\|...Core6}` | `Accepted` / `Rejected` / `NotImplemented` |
+| `/unlock-connector` | `{"connector_id":1}` | `Unlocked` / `UnlockFailed` / `NotSupported` |
+| `/change-availability` | `{"connector_id":1,"type":"Operative"\|"Inoperative"}` (`connector_id:0` = whole charger) | `Accepted` / `Rejected` / `Scheduled` |
+| `/data-transfer` | `{"vendor_id":"...","message_id":"...","data":"..."}` | `{"status":"Accepted"\|...,"data":"..."}` |
+| `/get-local-list-version` | `{}` | `{"list_version":N}` (`-1` if no list) |
+| `/send-local-list` | `{"list_version":N,"update_type":"Full"\|"Differential","local_authorization_list":[...]}` | `Accepted` / `Failed` / `NotSupported` / `VersionMismatch` |
+| `/reserve-now` | `{"connector_id":1,"id_tag":"...","expiry_date":"ISO-8601","parent_id_tag":"...?","reservation_id":N?}` | `Accepted` / `Faulted` / `Occupied` / `Rejected` / `Unavailable` |
+| `/cancel-reservation` | `{"reservation_id":N}` | `Accepted` / `Rejected` |
+| `/get-diagnostics` | `{"location":"ftp://...","retries":N?,"retry_interval":N?,"start_time":"...?","stop_time":"...?"}` | `{"file_name":"..."}` |
+| `/get-log` | `{"log_type":"DiagnosticsLog"\|"SecurityLog","request_id":N,"log":{"remote_location":"...","oldest_timestamp":"...?","latest_timestamp":"...?"},"retries":N?,"retry_interval":N?}` | `{"status":"Accepted"\|"Rejected"\|"AcceptedCanceled","filename":"...?"}` |
+| `/install-certificate` | `{"certificate_type":"CentralSystemRootCertificate"\|"ManufacturerRootCertificate","certificate":"<PEM>"}` | `{"status":"Accepted"\|"Failed"\|"Rejected","sha256_hash":"..."}` |
+| `/delete-certificate` | `{"sha256_hash":"..."}` | `Accepted` / `Failed` / `NotFound` |
+| `/get-installed-certificate-ids` | `{"certificate_type":"CentralSystemRootCertificate"\|"ManufacturerRootCertificate"}` | `{"status":"Accepted"\|"NotFound","certificate_hash_data":[{hash_algorithm,issuer_name_hash,issuer_key_hash,serial_number}]}` |
+| `/certificate-signed` | `{"certificate_chain":"-----BEGIN CERTIFICATE-----\\n..."}` | `Accepted` / `Rejected` |
+| `/update-firmware` | `{"location":"ftp://...","retrieve_date":"...","retries":N?,"retry_interval":N?}` | `{}` (charger acks; status follows via `FirmwareStatusNotification`) |
+| `/signed-update-firmware` | `{"request_id":N,"retries":N?,"retry_interval":N?,"firmware":{"location":"...","retrieve_date_time":"...","signing_certificate":"<PEM>","signature":"<base64>","install_date_time":"...?"}}` | `Accepted` / `Rejected` / `AcceptedCanceled` / `InvalidCertificate` / `RevokedCertificate` |
+| `/set-charging-profile` | `{"connector_id":N,"cs_charging_profiles":{...}}` | `Accepted` / `Rejected` / `NotSupported` |
+| `/clear-charging-profile` | `{"id":N?,"connector_id":N?,"charging_profile_purpose":"...?","stack_level":N?}` | `Accepted` / `Unknown` |
+| `/get-composite-schedule` | `{"connector_id":N,"duration":N,"charging_rate_unit":"A"\|"W"?}` | `{"status":"Accepted"\|"Rejected","connector_id":N?,"schedule_start":"...?","charging_schedule":{...?}}` |
+
+All responses include `request_id`. Common errors: `404 UNKNOWN_CP_ID`, `409 CHARGER_OFFLINE`, `504 CHARGER_TIMEOUT`.
+
+### `GET /charge-points/{cp_id}/commands/get-charger-status` — cached state, no OCPP round-trip
+
+Returns the gateway's cached view of the charger (`last_boot`, `last_status`, online flag). Use for dashboards where a sub-second answer matters more than absolute freshness.
+
+---
+
+## Pending certificate signings (operator queue)
+
+Operator review surface for charger-initiated CSRs.
+
+### `GET /charge-points/{cp_id}/pending-certificate-signings`
+
+Cursor-paginated. Query param `status` ∈ `pending` / `signed` / `rejected`. Each row carries `id`, `cp_id`, `csr` (PEM), `received_at`, `status`, `signed_at`, `approved_by`, `rejected_at`, `rejected_reason`.
+
+### `GET /charge-points/{cp_id}/pending-certificate-signings/{id}`
+
+Single row, same shape.
+
+### `POST /charge-points/{cp_id}/pending-certificate-signings/{id}/approve`
+
+Body:
+
+```json
+{ "signed_chain": "-----BEGIN CERTIFICATE-----\n...", "approved_by": "ops@example.com" }
+```
+
+Marks the row `signed`, dispatches `CertificateSigned.req` to the charger, returns the charger's reply:
+
+```json
+{ "id": 42, "cp_id": "CP_X", "status": "signed", "charger_status": "Accepted", "request_id": "..." }
+```
+
+Concurrent approvals collapse to one dispatch + one 404 (the SQL row-state guard makes this atomic).
+
+### `POST /charge-points/{cp_id}/pending-certificate-signings/{id}/reject`
+
+Body:
+
+```json
+{ "reason": "CN does not match charger serial" }
+```
+
+Marks the row `rejected`; no charger interaction.
+
+---
+
+## Admin (runtime config)
+
+### `GET /admin/config`
+
+Returns the live `Settings` (with secrets redacted) and any operator overrides currently in place.
+
+### `PATCH /admin/config`
+
+Apply a runtime override to an allow-listed setting. Body:
+
+```json
+{ "key": "EVEYS_OCPP_LOG_LEVEL", "value": "DEBUG" }
+```
+
+Only fields explicitly flagged as runtime-overridable are accepted; others return `400 BAD_REQUEST`.
+
+### `DELETE /admin/config/overrides/{key}`
+
+Remove a runtime override; the field reverts to its environment/defaults.
+
+### `GET /sys/config/schema`
+
+Returns the JSON schema of the runtime `Settings` model — useful for building admin UIs.
+
+---
+
+## OpenAPI / Swagger
+
+- `GET /openapi.json` — full schema.
+- `GET /docs` — Swagger UI.
+- `GET /redoc` — ReDoc.
+
+All three are auth-exempt. Disable via `EVEYS_OCPP_REST_OPENAPI_ENABLED=false` for internet-exposed deployments.
+
+---
+
+## Error envelope
+
+Every non-2xx response has the shape:
+
+```json
+{
+  "error":      "human-readable description",
+  "error_code": "STABLE_CODE",
+  "request_id": "..."
+}
+```
+
+| HTTP | `error_code` | Meaning |
+|---|---|---|
+| 400 | `BAD_REQUEST` | Malformed payload, missing/invalid field. |
+| 400 | `WINDOW_TOO_LARGE` | Time-series query window exceeded the cap. |
+| 401 | `UNAUTHORIZED` | No bearer token. |
+| 403 | `FORBIDDEN` | Wrong bearer token. |
+| 404 | `UNKNOWN_CP_ID` | No charger with this id (or no matching subresource). |
+| 404 | `UNKNOWN_TRANSACTION_ID` | No transaction with this id. |
+| 404 | `UNKNOWN_RESERVATION_ID` | No reservation with this id. |
+| 409 | `CHARGER_OFFLINE` | Charger isn't connected; nothing to dispatch to. |
+| 429 | `RATE_LIMITED` | Exceeded per-token rate. |
+| 504 | `CHARGER_TIMEOUT` | Charger didn't reply within the 30-second OCPP ceiling. |
+| 500 | `INTERNAL_ERROR` | Unexpected. File against the gateway. |
+
+`error_code` is a stable enum-like surface. `error` is human prose and may change between releases.
+
+---
+
+## Where to go from here
+
+- Patterns for using these endpoints from a backend: [`../guides/use-the-rest-api.md`](../guides/use-the-rest-api.md).
+- gRPC equivalent of every command: [`grpc-api.md`](./grpc-api.md).
+- Event consumption: [`events.md`](./events.md).


### PR DESCRIPTION
## Summary

Fresh, self-contained user-facing documentation set under `userdocs/` for developers and operators new to the gateway. 18 pages + an entry README + an in-tree plan file. Closes #194.

The audience is comfortable with Python 3.13, Docker, Kubernetes, REST, and Kafka — but new to OCPP and to this gateway. The existing `docs/` tree stays as the implementation/internal documentation.

## What's in it

- **Top level** (4) — what-is-this (with a 60-second OCPP primer), quickstart (10-minute Compose walkthrough), architecture (one diagram, four surfaces), glossary.
- **Guides** (7) — install, connect-a-charger, use-the-rest-api, consume-events, deploy-to-production (with sign-off checklist), operate, upgrade.
- **Reference** (5) — rest-api, grpc-api, events, configuration, metrics.
- **Concepts** (4) — how-ocpp-flows-work, security-model, multi-pod-and-routing, idempotency-and-replay.

## Conventions

- Every page opens with bold **Audience** + **What this answers**.
- Every reference page opens with a "use this if you…" line.
- First mention of any OCPP term links to the glossary.
- No prose cross-links to `docs/` or ADRs. Source-file references appear only where a reader may want to open the file directly.

## Verified before commit

- Every internal `.md` link resolves (Python pass over the whole directory).
- Every cited env-var name matches the real Settings class (fixed `WEBHOOK_SECRET`, `TRACING_OTLP_ENDPOINT`, `DB_MAX_OVERFLOW`; removed a fictional `BACKEND_CA_PATH`).
- Every cited metric name matches the registry (fixed `ws_active_connections` → `ws_connections_active`; replaced a non-existent `kafka_publish_failures_total` with the real labelled form).
- Zero hits for `docs/`, `adr/`, `ADR-` anywhere in `userdocs/`.

## Test plan

- [x] Eyeball every page in the GitHub diff to confirm Markdown renders cleanly.
- [x] Click through every link in the rendered README; confirm each target loads.
- [x] Walk the Quickstart on a clean checkout (Docker Compose → simulator → RemoteStart → tx.started in Kafka).
- [ ] CI green.