### PR TITLE
feature(api): cp_id_contains filter on /charge-points

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1836,6 +1836,22 @@
               ],
               "title": "Cp Id Prefix"
             }
+          },
+          {
+            "in": "query",
+            "name": "cp_id_contains",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cp Id Contains"
+            }
           }
         ],
         "responses": {

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1201,6 +1201,14 @@ paths:
           - type: string
           - type: 'null'
           title: Cp Id Prefix
+      - in: query
+        name: cp_id_contains
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Cp Id Contains
       responses:
         '200':
           content:

--- a/src/eveys_ocpp/api/charge_points.py
+++ b/src/eveys_ocpp/api/charge_points.py
@@ -174,6 +174,7 @@ async def list_charge_points_route(
     created_after: str | None = Query(default=None),
     created_before: str | None = Query(default=None),
     cp_id_prefix: str | None = Query(default=None),
+    cp_id_contains: str | None = Query(default=None),
 ) -> dict[str, Any]:
     settings = request.app.state.settings
     reject_mixed_pagination(cursor=cursor, page=page)
@@ -198,6 +199,7 @@ async def list_charge_points_route(
         "created_after": _parse_iso8601_or_400(created_after, field_name="created_after"),
         "created_before": _parse_iso8601_or_400(created_before, field_name="created_before"),
         "cp_id_prefix": cp_id_prefix,
+        "cp_id_contains": cp_id_contains,
     }
 
     # Two pagination paths, never both.

--- a/src/eveys_ocpp/persistence/repositories.py
+++ b/src/eveys_ocpp/persistence/repositories.py
@@ -910,6 +910,7 @@ def _charge_points_filter_conditions(
     created_after: datetime | None = None,
     created_before: datetime | None = None,
     cp_id_prefix: str | None = None,
+    cp_id_contains: str | None = None,
 ) -> list[Any]:
     """Shared WHERE clauses for `list_charge_points` and
     `count_charge_points`. Excludes the cursor/offset boundary."""
@@ -946,6 +947,12 @@ def _charge_points_filter_conditions(
         # is treated as a literal, not a wildcard.
         safe = cp_id_prefix.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
         conditions.append(ChargePoint.cp_id.like(f"{safe}%", escape="\\"))
+    if cp_id_contains:
+        # Free-text substring match for the operator search box. ILIKE
+        # so a user typing "617B" matches "cp_617b…" without caring
+        # about case. Same `%` / `_` escaping as `cp_id_prefix`.
+        safe = cp_id_contains.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        conditions.append(ChargePoint.cp_id.ilike(f"%{safe}%", escape="\\"))
     return conditions
 
 
@@ -968,6 +975,7 @@ async def list_charge_points(
     created_after: datetime | None = None,
     created_before: datetime | None = None,
     cp_id_prefix: str | None = None,
+    cp_id_contains: str | None = None,
     offset: int | None = None,
 ) -> list[dict[str, Any]]:
     """List chargers, ordered by surrogate `id`.
@@ -1005,6 +1013,7 @@ async def list_charge_points(
         created_after=created_after,
         created_before=created_before,
         cp_id_prefix=cp_id_prefix,
+        cp_id_contains=cp_id_contains,
     ):
         stmt = stmt.where(cond)
     if offset is not None:
@@ -1034,6 +1043,7 @@ async def count_charge_points(
     created_after: datetime | None = None,
     created_before: datetime | None = None,
     cp_id_prefix: str | None = None,
+    cp_id_contains: str | None = None,
 ) -> int:
     """`SELECT COUNT(*)` over the same filter chain as
     `list_charge_points`. Used by the offset-pagination path to
@@ -1054,6 +1064,7 @@ async def count_charge_points(
         created_after=created_after,
         created_before=created_before,
         cp_id_prefix=cp_id_prefix,
+        cp_id_contains=cp_id_contains,
     ):
         stmt = stmt.where(cond)
     result = await session.execute(stmt)

--- a/tests/unit/api/test_list_filters.py
+++ b/tests/unit/api/test_list_filters.py
@@ -77,6 +77,7 @@ async def test_charge_points_filters_forwarded_to_repo(
         "&created_after=2026-01-01T00:00:00Z"
         "&created_before=2026-12-31T00:00:00Z"
         "&cp_id_prefix=CP_ACME_"
+        "&cp_id_contains=617b"
     )
     assert response.status_code == 200, response.json()
 
@@ -94,6 +95,7 @@ async def test_charge_points_filters_forwarded_to_repo(
     assert kwargs["created_after"] == datetime(2026, 1, 1, tzinfo=UTC)
     assert kwargs["created_before"] == datetime(2026, 12, 31, tzinfo=UTC)
     assert kwargs["cp_id_prefix"] == "CP_ACME_"
+    assert kwargs["cp_id_contains"] == "617b"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Adds `cp_id_contains` query param to `GET /api/v1/charge-points`. `ILIKE '%escaped%'`, same `%` / `_` escaping as `cp_id_prefix`.
- Console can now pass a substring from the search box (e.g. paste `617b5675` from a support ticket) and find the matching charger.
- Refreshed `docs/api/openapi.{json,yaml}` snapshot.

Closes #202

## Test plan
- [x] `tests/unit/api/test_list_filters.py` extended — the forwarder test passes the new param and asserts it lands in repo kwargs.
- [x] Full `tests/unit/api/` suite green (223 passed).
- [x] `make openapi-export` re-run; committed spec matches.