### PR TITLE
feature(api): GET /sys/kpis rollup for Console dashboard

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -4532,6 +4532,29 @@
         ]
       }
     },
+    "/api/v1/sys/kpis": {
+      "get": {
+        "operationId": "get_sys_kpis_api_v1_sys_kpis_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Sys Kpis Api V1 Sys Kpis Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Headline counts for the Console dashboard",
+        "tags": [
+          "sys-kpis"
+        ]
+      }
+    },
     "/api/v1/transactions": {
       "get": {
         "operationId": "list_transactions_global_route_api_v1_transactions_get",

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -3019,6 +3019,21 @@ paths:
       summary: GET gateway configuration with per-key metadata (read-only)
       tags:
       - sys-config
+  /api/v1/sys/kpis:
+    get:
+      operationId: get_sys_kpis_api_v1_sys_kpis_get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Get Sys Kpis Api V1 Sys Kpis Get
+                type: object
+          description: Successful Response
+      summary: Headline counts for the Console dashboard
+      tags:
+      - sys-kpis
   /api/v1/transactions:
     get:
       operationId: list_transactions_global_route_api_v1_transactions_get

--- a/src/eveys_ocpp/api/_app.py
+++ b/src/eveys_ocpp/api/_app.py
@@ -48,6 +48,7 @@ from eveys_ocpp.api import (
     ready,
     reservations,
     sys_config,
+    sys_kpis,
     timeseries,
     transactions,
 )
@@ -197,6 +198,7 @@ def make_app(
     app.include_router(timeseries.router, prefix="/api/v1")
     app.include_router(admin.router, prefix="/api/v1")
     app.include_router(sys_config.router, prefix="/api/v1")
+    app.include_router(sys_kpis.router, prefix="/api/v1")
 
     return app
 

--- a/src/eveys_ocpp/api/sys_kpis.py
+++ b/src/eveys_ocpp/api/sys_kpis.py
@@ -1,0 +1,81 @@
+"""`GET /api/v1/sys/kpis` — single-roundtrip rollup for the Console
+dashboard.
+
+Returns the headline counts the index page renders as KPI tiles. One
+endpoint instead of the four separate counts the dashboard would
+otherwise have to fan out across — saves N HTTP round-trips on every
+poll and keeps the page snappy at fleet scale.
+
+Fields (all integers; null means "not yet implemented"):
+- `online_count`         — number of chargers with a live WS (Redis).
+- `total_count`          — number of chargers known to Postgres.
+- `active_tx_count`      — open transactions right now.
+- `tx_today_count`       — transactions started since UTC midnight.
+- `faulted_count`        — chargers whose last_status is "Faulted".
+- `energy_24h_wh`        — total Wh delivered in the trailing 24h.
+                            null until backed by a ClickHouse rollup.
+
+Auth follows the same bearer-token middleware as every other
+`/api/v1/*` route. The Console exposes it as `GET /sys/kpis`,
+proxied to this path.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from fastapi import APIRouter, Request
+
+from eveys_ocpp.observability import get_logger
+from eveys_ocpp.persistence.db import session_scope
+from eveys_ocpp.persistence.repositories import count_charge_points, count_transactions
+
+log = get_logger(__name__)
+
+router = APIRouter(tags=["sys-kpis"])
+
+
+@router.get(
+    "/sys/kpis",
+    summary="Headline counts for the Console dashboard",
+)
+async def get_sys_kpis(request: Request) -> dict[str, Any]:
+    registry = request.app.state.registry
+
+    # Redis online count. Falls back to None when there's no registry
+    # wired (tests / dev-without-Redis) so the UI knows to render `—`
+    # rather than a misleading zero.
+    online_count: int | None
+    if registry is None:
+        online_count = None
+    else:
+        try:
+            online_count = await registry.count_online()
+        except Exception:  # Redis blip must not 500 the dashboard.
+            online_count = None
+
+    now = datetime.now(UTC)
+    midnight = now.replace(hour=0, minute=0, second=0, microsecond=0)
+
+    async with session_scope(request.app.state.session_factory) as session:
+        total_count = await count_charge_points(session)
+        active_tx_count = await count_transactions(session, active=True)
+        tx_today_count = await count_transactions(session, started_from=midnight)
+        faulted_count = await count_charge_points(session, last_status="Faulted")
+
+    # Energy delivered (24h) is a ClickHouse rollup; not implemented
+    # yet. Surface as null so the UI can render an em-dash without
+    # mistaking "no data" for "zero energy".
+    energy_24h_wh: int | None = None
+    _ = now - timedelta(hours=24)  # placeholder anchor for the future rollup
+
+    return {
+        "online_count": online_count,
+        "total_count": total_count,
+        "active_tx_count": active_tx_count,
+        "tx_today_count": tx_today_count,
+        "faulted_count": faulted_count,
+        "energy_24h_wh": energy_24h_wh,
+        "request_id": request.state.request_id,
+    }

--- a/src/eveys_ocpp/registry.py
+++ b/src/eveys_ocpp/registry.py
@@ -166,3 +166,19 @@ class Registry:
         with _timed_redis("exists"):
             count = await self._redis.exists(_key(cp_id))
         return int(count) > 0
+
+    async def count_online(self) -> int:
+        """Fleet-wide online count via SCAN MATCH cp:online:*.
+
+        Used by the `/sys/kpis` rollup. SCAN is non-blocking and runs
+        in a single Redis pool round-trip per batch; for a fleet of N
+        chargers it's O(N) but only the index page polls this (30s),
+        so the load is bounded. Avoids holding any cross-pod gauge
+        state since the per-pod `REGISTRY_ONLINE_CHARGERS` metric
+        doesn't aggregate cleanly when the gateway scales horizontally.
+        """
+        total = 0
+        with _timed_redis("scan"):
+            async for _ in self._redis.scan_iter(match="cp:online:*", count=500):
+                total += 1
+        return total

--- a/tests/unit/api/test_sys_kpis.py
+++ b/tests/unit/api/test_sys_kpis.py
@@ -1,0 +1,123 @@
+"""Tests for `GET /api/v1/sys/kpis` — Console-dashboard rollup."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_returns_the_expected_shape(
+    client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from eveys_ocpp.api import sys_kpis as kpis_module
+
+    monkeypatch.setattr(kpis_module, "count_transactions", AsyncMock(return_value=0))
+    monkeypatch.setattr(kpis_module, "count_charge_points", AsyncMock(return_value=0))
+
+    response = await client.get("/api/v1/sys/kpis")
+    assert response.status_code == 200, response.text
+    body = response.json()
+    for key in (
+        "online_count",
+        "total_count",
+        "active_tx_count",
+        "tx_today_count",
+        "faulted_count",
+        "energy_24h_wh",
+        "request_id",
+    ):
+        assert key in body, f"missing: {key}"
+    # Energy isn't backed by a rollup yet — must be null, not 0.
+    assert body["energy_24h_wh"] is None
+
+
+@pytest.mark.asyncio
+async def test_online_count_is_null_when_registry_count_fails(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    fake_registry: Any,
+) -> None:
+    """A Redis blip on count_online surfaces as null, not 0."""
+    from eveys_ocpp.api import sys_kpis as kpis_module
+
+    fake_registry.count_online = AsyncMock(side_effect=ConnectionError("redis down"))
+    monkeypatch.setattr(kpis_module, "count_transactions", AsyncMock(return_value=0))
+    monkeypatch.setattr(kpis_module, "count_charge_points", AsyncMock(return_value=0))
+
+    response = await client.get("/api/v1/sys/kpis")
+    body = response.json()
+    assert body["online_count"] is None
+
+
+@pytest.mark.asyncio
+async def test_online_count_flows_from_registry(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    fake_registry: Any,
+) -> None:
+    from eveys_ocpp.api import sys_kpis as kpis_module
+
+    fake_registry.count_online = AsyncMock(return_value=42)
+    monkeypatch.setattr(kpis_module, "count_transactions", AsyncMock(return_value=0))
+    monkeypatch.setattr(kpis_module, "count_charge_points", AsyncMock(return_value=0))
+
+    response = await client.get("/api/v1/sys/kpis")
+    body = response.json()
+    assert body["online_count"] == 42
+
+
+@pytest.mark.asyncio
+async def test_forwards_today_filter_to_count_transactions(
+    client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The `tx_today_count` call must pass a UTC-midnight `started_from`."""
+    from eveys_ocpp.api import sys_kpis as kpis_module
+
+    captured_kwargs: list[dict[str, Any]] = []
+
+    async def fake_count_tx(_session: Any, **kwargs: Any) -> int:
+        captured_kwargs.append(kwargs)
+        return 0
+
+    monkeypatch.setattr(kpis_module, "count_transactions", AsyncMock(side_effect=fake_count_tx))
+    monkeypatch.setattr(kpis_module, "count_charge_points", AsyncMock(return_value=0))
+
+    response = await client.get("/api/v1/sys/kpis")
+    assert response.status_code == 200
+
+    assert any(call.get("active") is True for call in captured_kwargs)
+    started_from_calls = [c for c in captured_kwargs if "started_from" in c]
+    assert started_from_calls, "expected a count_transactions call with started_from"
+    midnight = started_from_calls[0]["started_from"]
+    assert midnight.hour == 0
+    assert midnight.minute == 0
+    assert midnight.second == 0
+    assert midnight.microsecond == 0
+
+
+@pytest.mark.asyncio
+async def test_faulted_count_filters_by_last_status(
+    client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from eveys_ocpp.api import sys_kpis as kpis_module
+
+    captured: list[dict[str, Any]] = []
+
+    async def fake_count_cp(_session: Any, **kwargs: Any) -> int:
+        captured.append(kwargs)
+        # The faulted call passes last_status="Faulted"; return 3 for it
+        # and 0 for the total-count call so the test can tell them apart.
+        return 3 if kwargs.get("last_status") == "Faulted" else 0
+
+    monkeypatch.setattr(kpis_module, "count_charge_points", AsyncMock(side_effect=fake_count_cp))
+    monkeypatch.setattr(kpis_module, "count_transactions", AsyncMock(return_value=0))
+
+    response = await client.get("/api/v1/sys/kpis")
+    body = response.json()
+    assert body["faulted_count"] == 3
+    assert body["total_count"] == 0
+    assert any(c.get("last_status") == "Faulted" for c in captured)


### PR DESCRIPTION
## Summary
- New \`GET /api/v1/sys/kpis\` returning headline counts in one round-trip: online_count, total_count, active_tx_count, tx_today_count, faulted_count, energy_24h_wh.
- New \`Registry.count_online()\` (Redis SCAN MATCH) since the existing per-pod \`REGISTRY_ONLINE_CHARGERS\` gauge can't aggregate across a horizontally-scaled gateway.
- \`energy_24h_wh\` is null until a ClickHouse rollup is added; the field is reserved so a future PR can fill it without a schema change on the Console side.

Closes #206

## Test plan
- [x] \`tests/unit/api/test_sys_kpis.py\` covers: response shape, registry-fail surfaces null, registry value flows through, today-filter is UTC midnight, faulted filter passes \`last_status=Faulted\`. 5/5 green.
- [x] Full \`tests/unit/api\` suite: 228 passed.
- [x] OpenAPI spec refreshed.