### PR TITLE
fix(api): online filter on /charge-points was applied post-page

### DIFF
--- a/src/eveys_ocpp/api/charge_points.py
+++ b/src/eveys_ocpp/api/charge_points.py
@@ -179,6 +179,27 @@ async def list_charge_points_route(
     settings = request.app.state.settings
     reject_mixed_pagination(cursor=cursor, page=page)
 
+    # Resolve the online filter against Redis BEFORE the SQL queries
+    # so the count + page math stay consistent. `online=true` becomes
+    # `cp_id IN (<online_ids>)`; `online=false` becomes the NOT IN.
+    # When the registry isn't wired (tests / no-Redis dev), treat
+    # every charger as offline (mirroring `_enrich_with_presence`).
+    cp_ids_in: list[str] | None = None
+    cp_ids_not_in: list[str] | None = None
+    if online is not None:
+        registry = request.app.state.registry
+        if registry is None:
+            online_ids: list[str] = []
+        else:
+            try:
+                online_ids = await registry.list_online_ids()
+            except Exception:
+                online_ids = []
+        if online:
+            cp_ids_in = online_ids
+        else:
+            cp_ids_not_in = online_ids
+
     # Parse every time-window param once. Each may 400 individually.
     filter_kwargs: dict[str, Any] = {
         "vendor": vendor,
@@ -200,6 +221,8 @@ async def list_charge_points_route(
         "created_before": _parse_iso8601_or_400(created_before, field_name="created_before"),
         "cp_id_prefix": cp_id_prefix,
         "cp_id_contains": cp_id_contains,
+        "cp_ids_in": cp_ids_in,
+        "cp_ids_not_in": cp_ids_not_in,
     }
 
     # Two pagination paths, never both.
@@ -220,8 +243,8 @@ async def list_charge_points_route(
             )
             total = await count_charge_points(session, **filter_kwargs)
         enriched = [await _enrich_with_presence(request, cp) for cp in rows]
-        if online is not None:
-            enriched = [cp for cp in enriched if cp["online"] == online]
+        # `online` was already pushed into the SQL filter above — no
+        # post-page trimming needed.
         enriched = await _enrich_with_connectors(request, enriched)
         return {
             "charge_points": [_to_response(cp) for cp in enriched],
@@ -265,12 +288,9 @@ async def list_charge_points_route(
 
     enriched = [await _enrich_with_presence(request, cp) for cp in page_rows]
 
-    # `online` filter is post-Postgres because presence lives in Redis.
-    # This means the page may shrink below `limit` after filtering — a
-    # known trade-off documented as acceptable in the spec ("limit is
-    # a hint; pages may be shorter").
-    if online is not None:
-        enriched = [cp for cp in enriched if cp["online"] == online]
+    # `online` was pushed into the SQL filter via cp_ids_in /
+    # cp_ids_not_in earlier in this handler, so the page contents
+    # already honour the filter — no post-page trim.
 
     enriched = await _enrich_with_connectors(request, enriched)
 

--- a/src/eveys_ocpp/persistence/repositories.py
+++ b/src/eveys_ocpp/persistence/repositories.py
@@ -911,9 +911,19 @@ def _charge_points_filter_conditions(
     created_before: datetime | None = None,
     cp_id_prefix: str | None = None,
     cp_id_contains: str | None = None,
+    cp_ids_in: list[str] | None = None,
+    cp_ids_not_in: list[str] | None = None,
 ) -> list[Any]:
     """Shared WHERE clauses for `list_charge_points` and
-    `count_charge_points`. Excludes the cursor/offset boundary."""
+    `count_charge_points`. Excludes the cursor/offset boundary.
+
+    `cp_ids_in` / `cp_ids_not_in` are how the route layer pushes the
+    Redis online registry into the SQL filter when the operator
+    selects online / offline. Pre-computed by the route so the
+    count + page math stays consistent. An empty `cp_ids_in` list
+    forces a no-match condition (so the page renders 0 of 0) rather
+    than being silently ignored.
+    """
     conditions: list[Any] = []
     if vendor is not None:
         conditions.append(ChargePoint.vendor == vendor)
@@ -953,6 +963,16 @@ def _charge_points_filter_conditions(
         # about case. Same `%` / `_` escaping as `cp_id_prefix`.
         safe = cp_id_contains.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
         conditions.append(ChargePoint.cp_id.ilike(f"%{safe}%", escape="\\"))
+    if cp_ids_in is not None:
+        # Empty list means "no charger is online" — the IN clause would
+        # be a SQL error, so we synthesise a false predicate that
+        # returns zero rows for both list_ and count_.
+        if not cp_ids_in:
+            conditions.append(ChargePoint.id == -1)
+        else:
+            conditions.append(ChargePoint.cp_id.in_(cp_ids_in))
+    if cp_ids_not_in:
+        conditions.append(ChargePoint.cp_id.not_in(cp_ids_not_in))
     return conditions
 
 
@@ -976,6 +996,8 @@ async def list_charge_points(
     created_before: datetime | None = None,
     cp_id_prefix: str | None = None,
     cp_id_contains: str | None = None,
+    cp_ids_in: list[str] | None = None,
+    cp_ids_not_in: list[str] | None = None,
     offset: int | None = None,
 ) -> list[dict[str, Any]]:
     """List chargers, ordered by surrogate `id`.
@@ -992,10 +1014,11 @@ async def list_charge_points(
       caller is expected to use `count_charge_points` separately for
       the `total`.
 
-    `vendor` filters by exact match. The `online` filter is NOT
-    applied here because presence lives in Redis; the route handler
-    filters the result post-hoc when the client passes `online=true`
-    or `online=false`.
+    `vendor` filters by exact match. Presence lives in Redis, so the
+    route handler resolves `online=true|false` to a set of cp_ids and
+    passes it as `cp_ids_in` / `cp_ids_not_in`. That way count + page
+    math both respect the filter (an unbounded post-page filter would
+    return wrong totals and shrink pages below `limit`).
     """
     stmt = select(ChargePoint).order_by(ChargePoint.id)
     for cond in _charge_points_filter_conditions(
@@ -1014,6 +1037,8 @@ async def list_charge_points(
         created_before=created_before,
         cp_id_prefix=cp_id_prefix,
         cp_id_contains=cp_id_contains,
+        cp_ids_in=cp_ids_in,
+        cp_ids_not_in=cp_ids_not_in,
     ):
         stmt = stmt.where(cond)
     if offset is not None:
@@ -1044,6 +1069,8 @@ async def count_charge_points(
     created_before: datetime | None = None,
     cp_id_prefix: str | None = None,
     cp_id_contains: str | None = None,
+    cp_ids_in: list[str] | None = None,
+    cp_ids_not_in: list[str] | None = None,
 ) -> int:
     """`SELECT COUNT(*)` over the same filter chain as
     `list_charge_points`. Used by the offset-pagination path to
@@ -1065,6 +1092,8 @@ async def count_charge_points(
         created_before=created_before,
         cp_id_prefix=cp_id_prefix,
         cp_id_contains=cp_id_contains,
+        cp_ids_in=cp_ids_in,
+        cp_ids_not_in=cp_ids_not_in,
     ):
         stmt = stmt.where(cond)
     result = await session.execute(stmt)

--- a/src/eveys_ocpp/registry.py
+++ b/src/eveys_ocpp/registry.py
@@ -182,3 +182,22 @@ class Registry:
             async for _ in self._redis.scan_iter(match="cp:online:*", count=500):
                 total += 1
         return total
+
+    async def list_online_ids(self) -> list[str]:
+        """Return every currently-online cp_id.
+
+        Used by the `/charge-points?online=…` filter so the SQL count
+        and page limits can both honour presence. Reads via the same
+        SCAN iterator as count_online, then strips the `cp:online:`
+        prefix off each key. Linear in fleet size but bounded by the
+        list endpoint's 30s poll cadence on the Console side.
+        """
+        prefix = "cp:online:"
+        ids: list[str] = []
+        with _timed_redis("scan"):
+            async for key in self._redis.scan_iter(match=f"{prefix}*", count=500):
+                # decode_responses=True on the client → key is a str.
+                s = key if isinstance(key, str) else str(key)
+                if s.startswith(prefix):
+                    ids.append(s[len(prefix) :])
+        return ids

--- a/tests/unit/api/test_charge_points.py
+++ b/tests/unit/api/test_charge_points.py
@@ -61,32 +61,79 @@ async def test_list_paginates_with_cursor(
 
 
 @pytest.mark.asyncio
-async def test_list_filters_by_online_post_postgres(
+async def test_list_online_true_pushes_cp_ids_in_filter_from_registry(
     client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
     fake_registry: MagicMock,
 ) -> None:
-    """The `online` filter runs against the Redis registry, not Postgres,
-    so it filters AFTER paging — the spec accepts the resulting page may
-    be shorter than `limit`."""
+    """`online=true` resolves to `cp_ids_in=<online_ids>` so the SQL
+    count and page math respect the filter (no post-page trimming)."""
     from eveys_ocpp.api import charge_points as cp_module
 
-    rows = [_cp_row(cp_id="CP_ONLINE", internal_id=1), _cp_row(cp_id="CP_OFFLINE", internal_id=2)]
-    monkeypatch.setattr(cp_module, "list_charge_points", AsyncMock(return_value=rows))
+    fake_registry.list_online_ids = AsyncMock(return_value=["CP_ONLINE_A", "CP_ONLINE_B"])
+    fake_registry.get_pod = AsyncMock(side_effect=lambda cp_id: "pod-1")
 
-    # Registry says CP_ONLINE has a pod, CP_OFFLINE has none.
-    async def _get_pod(cp_id: str) -> str | None:
-        return "pod-1" if cp_id == "CP_ONLINE" else None
-
-    fake_registry.get_pod = AsyncMock(side_effect=_get_pod)
+    list_spy = AsyncMock(return_value=[_cp_row(cp_id="CP_ONLINE_A", internal_id=1)])
+    monkeypatch.setattr(cp_module, "list_charge_points", list_spy)
 
     response = await client.get("/api/v1/charge-points?online=true")
+    assert response.status_code == 200
 
-    body = response.json()
-    assert len(body["charge_points"]) == 1
-    assert body["charge_points"][0]["cp_id"] == "CP_ONLINE"
-    assert body["charge_points"][0]["online"] is True
-    assert body["charge_points"][0]["pod_id"] == "pod-1"
+    kwargs = list_spy.await_args.kwargs
+    assert kwargs["cp_ids_in"] == ["CP_ONLINE_A", "CP_ONLINE_B"]
+    assert kwargs["cp_ids_not_in"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_online_false_pushes_cp_ids_not_in_filter(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    fake_registry: MagicMock,
+) -> None:
+    """`online=false` resolves to `cp_ids_not_in=<online_ids>`."""
+    from eveys_ocpp.api import charge_points as cp_module
+
+    fake_registry.list_online_ids = AsyncMock(return_value=["CP_ONLINE_X"])
+    fake_registry.get_pod = AsyncMock(return_value=None)
+
+    list_spy = AsyncMock(return_value=[_cp_row(cp_id="CP_OFFLINE", internal_id=2)])
+    monkeypatch.setattr(cp_module, "list_charge_points", list_spy)
+
+    response = await client.get("/api/v1/charge-points?online=false")
+    assert response.status_code == 200
+
+    kwargs = list_spy.await_args.kwargs
+    assert kwargs["cp_ids_in"] is None
+    assert kwargs["cp_ids_not_in"] == ["CP_ONLINE_X"]
+
+
+@pytest.mark.asyncio
+async def test_list_online_true_in_page_mode_passes_filter_to_count(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    fake_registry: MagicMock,
+) -> None:
+    """In page-mode the same `cp_ids_in` filter must reach
+    `count_charge_points` — otherwise total reports the unfiltered
+    count and the page footer lies to the operator."""
+    from eveys_ocpp.api import charge_points as cp_module
+
+    fake_registry.list_online_ids = AsyncMock(return_value=["CP_ONLINE_A"])
+    fake_registry.get_pod = AsyncMock(return_value="pod-1")
+
+    monkeypatch.setattr(
+        cp_module,
+        "list_charge_points",
+        AsyncMock(return_value=[_cp_row(cp_id="CP_ONLINE_A", internal_id=1)]),
+    )
+    count_spy = AsyncMock(return_value=1)
+    monkeypatch.setattr(cp_module, "count_charge_points", count_spy)
+
+    response = await client.get("/api/v1/charge-points?page=1&page_size=10&online=true")
+    assert response.status_code == 200
+
+    kwargs = count_spy.await_args.kwargs
+    assert kwargs["cp_ids_in"] == ["CP_ONLINE_A"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
The \`online\` filter on \`GET /charge-points\` only filtered the page that was already loaded, and never reached \`count_charge_points\`. Under page-mode pagination this surfaced as:

- \`pagination.total\` showed the **unfiltered** fleet size.
- Pages shrank below the requested \`page_size\`.
- Page math was off by however many rows happened to be online on the chosen page.

Resolve \`online\` against the Redis registry (new \`Registry.list_online_ids()\`) into a list of cp_ids and pass as \`cp_ids_in\` / \`cp_ids_not_in\` to both list_ and count_. SQL does the filtering; total, limit, and page all stay consistent.

Closes #208

## Test plan
- [x] New tests: \`online=true\` pushes \`cp_ids_in=…\`, \`online=false\` pushes \`cp_ids_not_in=…\`, and page-mode reaches \`count_charge_points\` with the same filter.
- [x] Full \`tests/unit/api\` suite: 230 passed.
- [x] Empty online-list is honoured (rendered as a no-match condition, not an empty IN clause).