### PR TITLE
feature(api): persist + expose ocpp_version on the charger row

### DIFF
--- a/alembic/versions/2026_05_12_0012-0012_charge_points_ocpp_version.py
+++ b/alembic/versions/2026_05_12_0012-0012_charge_points_ocpp_version.py
@@ -1,0 +1,49 @@
+"""charge_points.ocpp_version.
+
+Revision ID: 0012
+Revises: 0011
+Create Date: 2026-05-12
+
+Records which OCPP subprotocol the charger negotiated on its
+WebSocket handshake. Today the gateway only accepts ``ocpp1.6`` so
+the column is effectively constant — but exposing it now lets the
+Console show "OCPP 1.6" on the charger detail page without guessing,
+and gives us the seam to flip to ``ocpp2.0.1`` per-row when the 2.0.1
+profile lands.
+
+Set by the BootNotification handler (which runs after the WS
+upgrade, so the subprotocol is known). Backfilled to ``ocpp1.6`` on
+upgrade for the existing rows — that's the only protocol any of them
+have ever spoken.
+
+``String(16)`` fits both 1.6 and 2.0.1 plus headroom for future
+suffixes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0012"
+down_revision: str | None = "0011"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "charge_points",
+        sa.Column("ocpp_version", sa.String(length=16), nullable=True),
+    )
+    # Backfill: every row already in the DB was created by a charger
+    # that connected on ocpp1.6 (the only subprotocol the gateway has
+    # ever accepted). New rows get the value written by the
+    # BootNotification handler.
+    op.execute("UPDATE charge_points SET ocpp_version = 'ocpp1.6' WHERE ocpp_version IS NULL")
+
+
+def downgrade() -> None:
+    op.drop_column("charge_points", "ocpp_version")

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -175,6 +175,18 @@
             ],
             "title": "Model"
           },
+          "ocpp_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "OCPP subprotocol the charger negotiated on its WS upgrade. ``ocpp1.6`` today; will be ``ocpp2.0.1`` per-row when the 2.0.1 profile lands. Null for rows that pre-date this field and haven't booted since the column was added.",
+            "title": "Ocpp Version"
+          },
           "online": {
             "description": "True iff some pod currently holds the charger's WS.",
             "title": "Online",
@@ -369,6 +381,18 @@
               }
             ],
             "title": "Model"
+          },
+          "ocpp_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "OCPP subprotocol the charger negotiated on its WS upgrade. ``ocpp1.6`` today; will be ``ocpp2.0.1`` per-row when the 2.0.1 profile lands. Null for rows that pre-date this field and haven't booted since the column was added.",
+            "title": "Ocpp Version"
           },
           "online": {
             "description": "True iff some pod currently holds the charger's WS.",

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -118,6 +118,15 @@ components:
           - type: string
           - type: 'null'
           title: Model
+        ocpp_version:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: OCPP subprotocol the charger negotiated on its WS upgrade.
+            ``ocpp1.6`` today; will be ``ocpp2.0.1`` per-row when the 2.0.1 profile
+            lands. Null for rows that pre-date this field and haven't booted since
+            the column was added.
+          title: Ocpp Version
         online:
           description: True iff some pod currently holds the charger's WS.
           title: Online
@@ -234,6 +243,15 @@ components:
           - type: string
           - type: 'null'
           title: Model
+        ocpp_version:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: OCPP subprotocol the charger negotiated on its WS upgrade.
+            ``ocpp1.6`` today; will be ``ocpp2.0.1`` per-row when the 2.0.1 profile
+            lands. Null for rows that pre-date this field and haven't booted since
+            the column was added.
+          title: Ocpp Version
         online:
           description: True iff some pod currently holds the charger's WS.
           title: Online

--- a/src/eveys_ocpp/api/_schemas.py
+++ b/src/eveys_ocpp/api/_schemas.py
@@ -147,6 +147,15 @@ class ChargePoint(BaseModel):
     model: str | None = None
     firmware_version: str | None = None
     serial_number: str | None = None
+    ocpp_version: str | None = Field(
+        default=None,
+        description=(
+            "OCPP subprotocol the charger negotiated on its WS upgrade. "
+            "``ocpp1.6`` today; will be ``ocpp2.0.1`` per-row when the "
+            "2.0.1 profile lands. Null for rows that pre-date this "
+            "field and haven't booted since the column was added."
+        ),
+    )
     last_status: str | None = Field(
         default=None,
         description=(

--- a/src/eveys_ocpp/api/charge_points.py
+++ b/src/eveys_ocpp/api/charge_points.py
@@ -88,6 +88,7 @@ def _to_response(cp: dict[str, Any]) -> dict[str, Any]:
         "model": cp["model"],
         "firmware_version": cp["firmware_version"],
         "serial_number": cp["serial_number"],
+        "ocpp_version": cp.get("ocpp_version"),
         "last_boot_at": _isoformat(cp["last_boot_at"]),
         "last_heartbeat_at": _isoformat(cp["last_heartbeat_at"]),
         "last_status": cp["last_status"],

--- a/src/eveys_ocpp/connection.py
+++ b/src/eveys_ocpp/connection.py
@@ -85,6 +85,17 @@ class EveysChargePoint(Cpv16):
         self.authorize_cache = authorize_cache
         self.rate_limiter = rate_limiter
 
+    @property
+    def ocpp_version(self) -> str:
+        """Subprotocol the charger negotiated on the WS handshake
+        (``ocpp1.6`` today). Read by the BootNotification handler to
+        persist the value on the charger row so the Console can show
+        it without guessing. Falls back to ``ocpp1.6`` if the
+        websocket lib didn't surface a subprotocol — only happens in
+        unit tests with a fake connection."""
+        sub = getattr(self._connection, "subprotocol", None)
+        return str(sub) if sub else "ocpp1.6"
+
     # ---- handler delegation -------------------------------------------------
     # Each handler module exports a `handle(...)` coroutine. We thin-wrap
     # them here so the decorator metadata sits on this class (where the

--- a/src/eveys_ocpp/handlers/v16/boot_notification.py
+++ b/src/eveys_ocpp/handlers/v16/boot_notification.py
@@ -190,6 +190,7 @@ async def _handle_inner(
             firmware_version=firmware_version,
             serial_number=charge_point_serial_number,
             boot_at=received_at,
+            ocpp_version=cp.ocpp_version,
         )
 
     # Backend round-trip (E3-5). If no backend is wired (W1/dev), accept

--- a/src/eveys_ocpp/persistence/models.py
+++ b/src/eveys_ocpp/persistence/models.py
@@ -44,6 +44,13 @@ class ChargePoint(Base):
     model: Mapped[str | None] = mapped_column(String(128))
     firmware_version: Mapped[str | None] = mapped_column(String(64))
     serial_number: Mapped[str | None] = mapped_column(String(64))
+    # OCPP subprotocol the charger negotiated on its WS handshake
+    # (`ocpp1.6` today, `ocpp2.0.1` when that profile lands). Set by
+    # the BootNotification handler — the WS upgrade has already
+    # succeeded by then so the subprotocol is known. Operators read
+    # this on the Console detail page so they don't have to guess
+    # which OCPP surface a charger speaks.
+    ocpp_version: Mapped[str | None] = mapped_column(String(16))
 
     last_boot_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     last_heartbeat_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))

--- a/src/eveys_ocpp/persistence/repositories.py
+++ b/src/eveys_ocpp/persistence/repositories.py
@@ -40,32 +40,44 @@ async def upsert_charge_point_boot(
     firmware_version: str | None,
     serial_number: str | None,
     boot_at: datetime,
+    ocpp_version: str | None = None,
 ) -> ChargePoint:
     """Insert-or-update a charger row on BootNotification.
 
     Implements upsert via Postgres `ON CONFLICT (cp_id) DO UPDATE`. This is
     the idempotency anchor for BootNotification (AGENTS rule 3): replays
     update the row instead of inserting duplicates.
+
+    ``ocpp_version`` is the subprotocol the charger negotiated on its
+    WS upgrade — captured here because BootNotification is the first
+    handler we run after the upgrade. Optional for back-compat with
+    callers (older tests) that don't pass it; the existing value is
+    preserved when None.
     """
+    insert_values: dict[str, object] = {
+        "cp_id": cp_id,
+        "vendor": vendor,
+        "model": model,
+        "firmware_version": firmware_version,
+        "serial_number": serial_number,
+        "last_boot_at": boot_at,
+    }
+    update_values: dict[str, object] = {
+        "vendor": vendor,
+        "model": model,
+        "firmware_version": firmware_version,
+        "serial_number": serial_number,
+        "last_boot_at": boot_at,
+    }
+    if ocpp_version is not None:
+        insert_values["ocpp_version"] = ocpp_version
+        update_values["ocpp_version"] = ocpp_version
     stmt = (
         pg_insert(ChargePoint)
-        .values(
-            cp_id=cp_id,
-            vendor=vendor,
-            model=model,
-            firmware_version=firmware_version,
-            serial_number=serial_number,
-            last_boot_at=boot_at,
-        )
+        .values(**insert_values)
         .on_conflict_do_update(
             index_elements=[ChargePoint.cp_id],
-            set_={
-                "vendor": vendor,
-                "model": model,
-                "firmware_version": firmware_version,
-                "serial_number": serial_number,
-                "last_boot_at": boot_at,
-            },
+            set_=update_values,
         )
         .returning(ChargePoint)
     )
@@ -886,6 +898,7 @@ def _charge_point_to_dict(cp: ChargePoint) -> dict[str, Any]:
         "model": cp.model,
         "firmware_version": cp.firmware_version,
         "serial_number": cp.serial_number,
+        "ocpp_version": cp.ocpp_version,
         "last_boot_at": cp.last_boot_at,
         "last_heartbeat_at": cp.last_heartbeat_at,
         "last_status": cp.last_status,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -148,4 +148,9 @@ def fake_cp(settings: Settings, fake_session_factory: Any) -> MagicMock:
     cp.event_producer = None
     cp.backend_client = None
     cp.authorize_cache = None
+    # Match the real EveysChargePoint.ocpp_version property — the
+    # OCPP library only accepts ocpp1.6 today, so every fake_cp
+    # carries that. Tests that exercise 2.0.1-specific paths set
+    # this attribute explicitly.
+    cp.ocpp_version = "ocpp1.6"
     return cp

--- a/tests/unit/handlers/v16/test_boot_notification.py
+++ b/tests/unit/handlers/v16/test_boot_notification.py
@@ -54,6 +54,12 @@ async def test_persists_charger_metadata(fake_cp: Any, monkeypatch: pytest.Monke
     assert kwargs["model"] == "X1"
     assert kwargs["firmware_version"] == "1.0.0"
     assert kwargs["serial_number"] == "SN001"
+    # The OCPP subprotocol negotiated on the WS upgrade is captured
+    # here too so the Console can show "OCPP 1.6 / 2.0.1" on the
+    # detail page without guessing. fake_cp's connection reports
+    # 1.6 (the only subprotocol the gateway accepts today); when
+    # 2.0.1 lands the same field flips per-row.
+    assert kwargs["ocpp_version"] == "ocpp1.6"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- New ``charge_points.ocpp_version`` column captures the OCPP subprotocol negotiated on the WS upgrade (``ocpp1.6`` today; ``ocpp2.0.1`` per-row when that profile lands).
- Written by the BootNotification handler through the existing upsert.
- Surfaced via ``GET /api/v1/charge-points`` (list) and ``GET /charge-points/{id}`` (detail).
- Migration 0012 backfills existing rows to ``ocpp1.6`` — every row in the DB was created by a 1.6 connection because that's the only subprotocol the gateway has ever accepted.

## Why
The Console can't show operators which OCPP version a charger speaks. Today every connection is 1.6 so it's effectively constant; exposing it now means the Console renders "OCPP 1.6" without guessing, and the seam to flip per-row exists for the day 2.0.1 ships.

## Out of scope
Security-Extensions detection (no protocol-level handshake for it in 1.6). The Console gates Security-profile commands (e.g. GetLog) on a separate UI disclosure rather than auto-detection.

## Tests
- Updated ``test_persists_charger_metadata`` asserts ``ocpp_version`` flows through the upsert.
- ``fake_cp`` fixture defaults to ``ocpp1.6`` so handler tests that touch ``cp.ocpp_version`` get a real string, not a MagicMock.
- Workspace: 950 unit tests pass, 80.46% coverage.
- OpenAPI snapshot regenerated.

## Test plan
- [ ] Migrate to 0012 → existing ``charge_points`` rows get ``ocpp_version='ocpp1.6'``.
- [ ] Reboot a charger → ``GET /api/v1/charge-points/<cp_id>`` shows ``"ocpp_version": "ocpp1.6"``.
- [ ] Old chargers that haven't booted since the migration still return ``"ocpp1.6"`` from the backfill.

Closes #216