### PR TITLE
feature(audit): fleet-wide status-history search (PR 1 of 3 for #218)

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -731,6 +731,101 @@
         "title": "ErrorEnvelope",
         "type": "object"
       },
+      "FleetStatusEvent": {
+        "description": "Fleet-wide status event \u2014 same shape as :class:`StatusEvent`\nplus the cp_id, since the fleet endpoint returns rows from\nmultiple chargers in one response.",
+        "properties": {
+          "connector_id": {
+            "title": "Connector Id",
+            "type": "integer"
+          },
+          "cp_id": {
+            "title": "Cp Id",
+            "type": "string"
+          },
+          "error_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Code"
+          },
+          "info": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Info"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "timestamp": {
+            "title": "Timestamp",
+            "type": "string"
+          },
+          "vendor_error_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vendor Error Code"
+          },
+          "vendor_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vendor Id"
+          }
+        },
+        "required": [
+          "timestamp",
+          "connector_id",
+          "status",
+          "cp_id"
+        ],
+        "title": "FleetStatusEvent",
+        "type": "object"
+      },
+      "FleetStatusResponse": {
+        "description": "`GET /api/v1/charge-points/status?from=\u2026&to=\u2026&status=\u2026`.\n\nFleet-wide variant of :class:`StatusHistoryResponse`. Common use:\n\"all Faulted statuses this week\".",
+        "properties": {
+          "events": {
+            "items": {
+              "$ref": "#/components/schemas/FleetStatusEvent"
+            },
+            "title": "Events",
+            "type": "array"
+          },
+          "request_id": {
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "events",
+          "request_id"
+        ],
+        "title": "FleetStatusResponse",
+        "type": "object"
+      },
       "HTTPValidationError": {
         "properties": {
           "detail": {
@@ -5016,6 +5111,127 @@
         "summary": "Readiness probe (auth-exempt)",
         "tags": [
           "health"
+        ]
+      }
+    },
+    "/api/v1/status-history": {
+      "get": {
+        "description": "Cross-charger variant of the per-cp ``status-history`` route.\n\nCommon use: an operator filtering for ``status=Faulted`` over the\nlast week to surface every charger that flipped to a fault state.\n\n``status`` and ``cp_id`` are both repeatable query params: e.g.\n``?status=Faulted&status=Unavailable`` to get either, or\n``?cp_id=A&cp_id=B`` to restrict to two chargers without paying\nthe cost of one round-trip per cp_id.",
+        "operationId": "list_fleet_status_history_api_v1_status_history_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "from",
+            "required": true,
+            "schema": {
+              "title": "From",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "to",
+            "required": true,
+            "schema": {
+              "title": "To",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cp_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cp Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maximum": 10000,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FleetStatusResponse",
+                  "additionalProperties": true,
+                  "title": "Response List Fleet Status History Api V1 Status History Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Bad from/to or window too large."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Fleet-wide StatusNotification history (e.g. all Faulted statuses this week)",
+        "tags": [
+          "timeseries"
         ]
       }
     },

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -492,6 +492,73 @@ components:
       - request_id
       title: ErrorEnvelope
       type: object
+    FleetStatusEvent:
+      description: 'Fleet-wide status event — same shape as :class:`StatusEvent`
+
+        plus the cp_id, since the fleet endpoint returns rows from
+
+        multiple chargers in one response.'
+      properties:
+        connector_id:
+          title: Connector Id
+          type: integer
+        cp_id:
+          title: Cp Id
+          type: string
+        error_code:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Error Code
+        info:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Info
+        status:
+          title: Status
+          type: string
+        timestamp:
+          title: Timestamp
+          type: string
+        vendor_error_code:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Vendor Error Code
+        vendor_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Vendor Id
+      required:
+      - timestamp
+      - connector_id
+      - status
+      - cp_id
+      title: FleetStatusEvent
+      type: object
+    FleetStatusResponse:
+      description: '`GET /api/v1/charge-points/status?from=…&to=…&status=…`.
+
+
+        Fleet-wide variant of :class:`StatusHistoryResponse`. Common use:
+
+        "all Faulted statuses this week".'
+      properties:
+        events:
+          items:
+            $ref: '#/components/schemas/FleetStatusEvent'
+          title: Events
+          type: array
+        request_id:
+          title: Request Id
+          type: string
+      required:
+      - events
+      - request_id
+      title: FleetStatusResponse
+      type: object
     HTTPValidationError:
       properties:
         detail:
@@ -3354,6 +3421,93 @@ paths:
       summary: Readiness probe (auth-exempt)
       tags:
       - health
+  /api/v1/status-history:
+    get:
+      description: 'Cross-charger variant of the per-cp ``status-history`` route.
+
+
+        Common use: an operator filtering for ``status=Faulted`` over the
+
+        last week to surface every charger that flipped to a fault state.
+
+
+        ``status`` and ``cp_id`` are both repeatable query params: e.g.
+
+        ``?status=Faulted&status=Unavailable`` to get either, or
+
+        ``?cp_id=A&cp_id=B`` to restrict to two chargers without paying
+
+        the cost of one round-trip per cp_id.'
+      operationId: list_fleet_status_history_api_v1_status_history_get
+      parameters:
+      - in: query
+        name: from
+        required: true
+        schema:
+          title: From
+          type: string
+      - in: query
+        name: to
+        required: true
+        schema:
+          title: To
+          type: string
+      - in: query
+        name: status
+        required: false
+        schema:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Status
+      - in: query
+        name: cp_id
+        required: false
+        schema:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Cp Id
+      - in: query
+        name: limit
+        required: false
+        schema:
+          anyOf:
+          - maximum: 10000
+            minimum: 1
+            type: integer
+          - type: 'null'
+          title: Limit
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FleetStatusResponse'
+                additionalProperties: true
+                title: Response List Fleet Status History Api V1 Status History Get
+                type: object
+          description: Successful Response
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+          description: Bad from/to or window too large.
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Fleet-wide StatusNotification history (e.g. all Faulted statuses this
+        week)
+      tags:
+      - timeseries
   /api/v1/sys/config:
     get:
       operationId: get_sys_config_api_v1_sys_config_get

--- a/src/eveys_ocpp/api/_schemas.py
+++ b/src/eveys_ocpp/api/_schemas.py
@@ -550,6 +550,24 @@ class StatusHistoryResponse(BaseModel):
     request_id: str
 
 
+class FleetStatusEvent(StatusEvent):
+    """Fleet-wide status event — same shape as :class:`StatusEvent`
+    plus the cp_id, since the fleet endpoint returns rows from
+    multiple chargers in one response."""
+
+    cp_id: str
+
+
+class FleetStatusResponse(BaseModel):
+    """`GET /api/v1/charge-points/status?from=…&to=…&status=…`.
+
+    Fleet-wide variant of :class:`StatusHistoryResponse`. Common use:
+    "all Faulted statuses this week"."""
+
+    events: list[FleetStatusEvent]
+    request_id: str
+
+
 class OfflineDurationEvent(BaseModel):
     """One observed offline window for a charger.
 
@@ -645,6 +663,8 @@ __all__ = [
     "CommandAcceptedResponse",
     "ConnectorStatus",
     "ErrorEnvelope",
+    "FleetStatusEvent",
+    "FleetStatusResponse",
     "HealthComponents",
     "HealthResponse",
     "LatestMeter",

--- a/src/eveys_ocpp/api/timeseries.py
+++ b/src/eveys_ocpp/api/timeseries.py
@@ -19,7 +19,7 @@ lives at `clickhouse/read_client.py`.
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from typing import Any
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Query, Request
 
@@ -44,6 +44,7 @@ from eveys_ocpp.api._pagination import (
 )
 from eveys_ocpp.api._schemas import (
     ErrorEnvelope,
+    FleetStatusResponse,
     MeterValuesResponse,
     OfflineHistoryResponse,
     StatusHistoryResponse,
@@ -214,6 +215,56 @@ async def list_status_history(
 
     return {
         "status_history": [_status_to_response(r) for r in rows],
+        "request_id": request.state.request_id,
+    }
+
+
+@router.get(
+    "/status-history",
+    summary="Fleet-wide StatusNotification history (e.g. all Faulted statuses this week)",
+    responses={
+        200: {"model": FleetStatusResponse},
+        400: {"model": ErrorEnvelope, "description": "Bad from/to or window too large."},
+    },
+)
+async def list_fleet_status_history(
+    request: Request,
+    from_: str = Query(alias="from"),
+    to: str = Query(...),
+    status: Annotated[list[str] | None, Query()] = None,
+    cp_id: Annotated[list[str] | None, Query()] = None,
+    limit: int | None = Query(default=None, ge=1, le=10_000),
+) -> dict[str, Any]:
+    """Cross-charger variant of the per-cp ``status-history`` route.
+
+    Common use: an operator filtering for ``status=Faulted`` over the
+    last week to surface every charger that flipped to a fault state.
+
+    ``status`` and ``cp_id`` are both repeatable query params: e.g.
+    ``?status=Faulted&status=Unavailable`` to get either, or
+    ``?cp_id=A&cp_id=B`` to restrict to two chargers without paying
+    the cost of one round-trip per cp_id."""
+    settings = request.app.state.settings
+    page_size = clamp_limit(
+        limit,
+        default=settings.rest_default_page_size,
+        maximum=settings.rest_max_page_size,
+    )
+
+    started_from = _parse_iso8601(from_, field_name="from")
+    started_to = _parse_iso8601(to, field_name="to")
+    _validate_window(started_from, started_to)
+
+    rows = await _ch_client(request).fetch_fleet_status_history(
+        started_from=started_from,
+        started_to=started_to,
+        statuses=status,
+        cp_ids=cp_id,
+        limit=page_size,
+    )
+
+    return {
+        "events": [_status_to_response(r) for r in rows],
         "request_id": request.state.request_id,
     }
 

--- a/src/eveys_ocpp/clickhouse/read_client.py
+++ b/src/eveys_ocpp/clickhouse/read_client.py
@@ -528,3 +528,68 @@ class ClickHouseReadClient:
             cols = [d[0] for d in cursor.description]
             rows = await cursor.fetchall()
         return [dict(zip(cols, row, strict=True)) for row in rows]
+
+    async def fetch_fleet_status_history(
+        self,
+        *,
+        started_from: datetime,
+        started_to: datetime,
+        statuses: list[str] | None,
+        cp_ids: list[str] | None,
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        """Return StatusNotification transitions across the fleet inside
+        [from, to], optionally filtered by status value and/or a small
+        list of cp_ids.
+
+        Fleet-wide variant of :meth:`fetch_status_history`. Same row
+        shape and ordering; just drops the single-cp filter. The
+        partition prune on ``occurred_at`` keeps the scan bounded to
+        the months that overlap the window.
+
+        Common use: "all Faulted statuses this week" — pass
+        ``statuses=["Faulted"]`` and a 7-day window.
+        """
+        assert self._conn is not None  # narrowed by start()
+
+        sql = """
+            SELECT
+                event_id,
+                occurred_at,
+                cp_id,
+                connector_id,
+                status,
+                error_code,
+                info,
+                vendor_id,
+                vendor_error_code,
+                charger_reported_at
+            FROM cp_status
+            WHERE occurred_at >= {from_ts}
+              AND occurred_at <= {to_ts}
+        """
+        params: dict[str, Any] = {
+            "from_ts": started_from,
+            "to_ts": started_to,
+        }
+        if statuses:
+            # asynch's str.format escaping doesn't handle list literals
+            # natively, so render the IN clause's element placeholders
+            # by name and bind each value individually.
+            placeholders = ", ".join(f"{{status_{i}}}" for i in range(len(statuses)))
+            sql += f" AND status IN ({placeholders})"
+            for i, s in enumerate(statuses):
+                params[f"status_{i}"] = s
+        if cp_ids:
+            placeholders = ", ".join(f"{{cp_{i}}}" for i in range(len(cp_ids)))
+            sql += f" AND cp_id IN ({placeholders})"
+            for i, c in enumerate(cp_ids):
+                params[f"cp_{i}"] = c
+        sql += " ORDER BY occurred_at, event_id LIMIT {limit}"
+        params["limit"] = limit
+
+        async with self._conn.cursor() as cursor:
+            await cursor.execute(sql, params)
+            cols = [d[0] for d in cursor.description]
+            rows = await cursor.fetchall()
+        return [dict(zip(cols, row, strict=True)) for row in rows]

--- a/tests/unit/api/test_timeseries.py
+++ b/tests/unit/api/test_timeseries.py
@@ -334,3 +334,88 @@ async def test_status_history_window_too_large(client: httpx.AsyncClient) -> Non
     )
     assert response.status_code == 400
     assert response.json()["error_code"] == "WINDOW_TOO_LARGE"
+
+
+# ---- fleet status-history --------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fleet_status_returns_events_from_multiple_cps(
+    client: httpx.AsyncClient,
+    fake_ch_client: MagicMock,
+) -> None:
+    row_a = _status_row(status="Faulted") | {"cp_id": "CP_A"}
+    row_b = _status_row(status="Faulted") | {"cp_id": "CP_B"}
+    fake_ch_client.fetch_fleet_status_history = AsyncMock(return_value=[row_a, row_b])
+
+    response = await client.get(
+        "/api/v1/status-history"
+        "?from=2026-05-06T00:00:00%2B00:00&to=2026-05-06T23:59:59%2B00:00"
+        "&status=Faulted"
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert {row["cp_id"] for row in body["events"]} == {"CP_A", "CP_B"}
+    assert all(row["status"] == "Faulted" for row in body["events"])
+
+
+@pytest.mark.asyncio
+async def test_fleet_status_passes_status_and_cp_filters_through(
+    client: httpx.AsyncClient,
+    fake_ch_client: MagicMock,
+) -> None:
+    spy = AsyncMock(return_value=[])
+    fake_ch_client.fetch_fleet_status_history = spy
+
+    response = await client.get(
+        "/api/v1/status-history"
+        "?from=2026-05-06T00:00:00%2B00:00&to=2026-05-06T23:59:59%2B00:00"
+        "&status=Faulted&status=Unavailable"
+        "&cp_id=CP_001&cp_id=CP_002"
+        "&limit=50"
+    )
+
+    assert response.status_code == 200
+    kwargs = spy.await_args.kwargs
+    assert kwargs["statuses"] == ["Faulted", "Unavailable"]
+    assert kwargs["cp_ids"] == ["CP_001", "CP_002"]
+    assert kwargs["limit"] == 50
+
+
+@pytest.mark.asyncio
+async def test_fleet_status_no_filters_returns_all(
+    client: httpx.AsyncClient,
+    fake_ch_client: MagicMock,
+) -> None:
+    """No `status` / `cp_id` means no SQL filter — the client method
+    receives None for both and the route doesn't 400 on missing
+    filters (only `from`/`to` are required)."""
+    spy = AsyncMock(return_value=[_status_row()])
+    fake_ch_client.fetch_fleet_status_history = spy
+
+    response = await client.get(
+        "/api/v1/status-history?from=2026-05-06T00:00:00%2B00:00&to=2026-05-06T23:59:59%2B00:00"
+    )
+
+    assert response.status_code == 200
+    kwargs = spy.await_args.kwargs
+    assert kwargs["statuses"] is None
+    assert kwargs["cp_ids"] is None
+
+
+@pytest.mark.asyncio
+async def test_fleet_status_window_too_large(client: httpx.AsyncClient) -> None:
+    response = await client.get(
+        "/api/v1/status-history?from=2026-04-01T00:00:00%2B00:00&to=2026-05-06T00:00:00%2B00:00"
+    )
+    assert response.status_code == 400
+    assert response.json()["error_code"] == "WINDOW_TOO_LARGE"
+
+
+@pytest.mark.asyncio
+async def test_fleet_status_bad_window_orientation(client: httpx.AsyncClient) -> None:
+    response = await client.get(
+        "/api/v1/status-history?from=2026-05-06T23:59:59%2B00:00&to=2026-05-06T00:00:00%2B00:00"
+    )
+    assert response.status_code == 400

--- a/tests/unit/test_clickhouse_read_client.py
+++ b/tests/unit/test_clickhouse_read_client.py
@@ -141,3 +141,69 @@ async def test_fetch_latest_connector_statuses_uses_asynch_placeholder_shape() -
     assert "'CP_A'" in rendered
     assert "'CP_B'" in rendered
     assert "%(" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_fetch_fleet_status_history_no_optional_filters() -> None:
+    """With status + cp_ids both None the SQL has neither IN clause —
+    a fleet-wide unfiltered scan over the time window."""
+    client, cursor = _client_with_fake_cursor()
+
+    await client.fetch_fleet_status_history(
+        started_from=datetime(2026, 5, 1, tzinfo=UTC),
+        started_to=datetime(2026, 5, 8, tzinfo=UTC),
+        statuses=None,
+        cp_ids=None,
+        limit=500,
+    )
+
+    sql, params = cursor.execute.await_args.args
+    rendered = _substitute(sql, params)
+    assert "AND status IN" not in rendered
+    assert "AND cp_id IN" not in rendered
+    assert "%(" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_fetch_fleet_status_history_status_in_clause() -> None:
+    """`statuses=["Faulted", "Unavailable"]` expands into an `IN`
+    clause with bound parameters — no string concatenation of user
+    input into SQL."""
+    client, cursor = _client_with_fake_cursor()
+
+    await client.fetch_fleet_status_history(
+        started_from=datetime(2026, 5, 1, tzinfo=UTC),
+        started_to=datetime(2026, 5, 8, tzinfo=UTC),
+        statuses=["Faulted", "Unavailable"],
+        cp_ids=None,
+        limit=1000,
+    )
+
+    sql, params = cursor.execute.await_args.args
+    rendered = _substitute(sql, params)
+    assert "'Faulted'" in rendered
+    assert "'Unavailable'" in rendered
+    assert "AND status IN" in rendered
+    assert "AND cp_id IN" not in rendered
+    # asynch's placeholder shape, not DB-API.
+    assert "%(" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_fetch_fleet_status_history_cp_ids_in_clause() -> None:
+    client, cursor = _client_with_fake_cursor()
+
+    await client.fetch_fleet_status_history(
+        started_from=datetime(2026, 5, 1, tzinfo=UTC),
+        started_to=datetime(2026, 5, 8, tzinfo=UTC),
+        statuses=None,
+        cp_ids=["CP_A", "CP_B"],
+        limit=500,
+    )
+
+    sql, params = cursor.execute.await_args.args
+    rendered = _substitute(sql, params)
+    assert "'CP_A'" in rendered
+    assert "'CP_B'" in rendered
+    assert "AND cp_id IN" in rendered
+    assert "%(" not in rendered


### PR DESCRIPTION
## Summary

First PR of three for #218. Adds a fleet-wide variant of the existing per-cp \`status-history\` route so the Console can answer cross-charger queries like **\"all Faulted statuses across the fleet this week\"** without per-cp round-trips.

\`\`\`
GET /api/v1/status-history?from=...&to=...&status=Faulted
\`\`\`

## What's in this PR

- **\`ClickHouseReadClient.fetch_fleet_status_history\`** — drops the per-cp filter from the existing query, adds optional \`statuses\` and \`cp_ids\` IN-clauses with bound parameters. Same partition-pruned scan over \`cp_status\` as the per-cp method.
- **Route**: \`GET /api/v1/status-history\`. Required \`from\`/\`to\`, optional repeatable \`status\` and \`cp_id\` query params, 7-day window cap (\`_MAX_WINDOW\` shared with siblings). Response includes \`cp_id\` per row.
- **Schemas**: \`FleetStatusEvent\` / \`FleetStatusResponse\`.
- **Tests**: 5 new route tests (multi-cp rows, filter passthrough, no-filters, window-too-large, inverted window) + 3 new ClickHouse method tests (no-filters / status IN / cp_id IN).
- **OpenAPI snapshot** regenerated.

## Note on path

The issue spec mentioned \`/api/v1/charge-points/status\` but that's at the per-cp router prefix. Going with \`/api/v1/status-history\` at the top level — it's a fleet endpoint, not per-cp, and reads cleaner.

## Out of scope (deferred per #218)

- ❌ PR 2: OCPP frames table + ingestor + routes
- ❌ PR 3: uptime% aggregator route

## Acceptance

- ✅ \`GET /api/v1/status-history?status=Faulted&from=...&to=...\` returns Faulted rows across all chargers in a single response.
- ✅ Repeatable \`status\` / \`cp_id\` query params expand to safely-bound IN clauses.
- ✅ Window > 7 days returns \`WINDOW_TOO_LARGE\`.
- ✅ 984 unit tests pass; 80% coverage gate cleared.

## Test plan

- [ ] \`GET /api/v1/status-history?status=Faulted&from=2026-05-06T00:00:00Z&to=2026-05-13T00:00:00Z\` returns Faulted rows from any charger
- [ ] \`GET /api/v1/status-history?cp_id=A&cp_id=B&from=...&to=...\` restricts to the two chargers
- [ ] \`GET /api/v1/status-history?status=Faulted&status=Unavailable&from=...&to=...\` returns either status
- [ ] Window > 7d returns 400 WINDOW_TOO_LARGE

Refs #218