### PR TITLE
feature(audit): OCPP frame audit table + ingestor + read routes (PR 2 of 3 for #218)

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1028,6 +1028,130 @@
         "title": "MeterValuesResponse",
         "type": "object"
       },
+      "OcppFrame": {
+        "description": "One row of the `cp_ocpp_frames` audit table \u2014 a single OCPP\nframe in either direction, captured verbatim. ``raw_payload`` is\nthe JSON the gateway received or wrote on the wire.",
+        "properties": {
+          "action": {
+            "description": "OCPP action name. Empty for CALLRESULT / CALLERROR.",
+            "title": "Action",
+            "type": "string"
+          },
+          "cp_id": {
+            "title": "Cp Id",
+            "type": "string"
+          },
+          "direction": {
+            "description": "\"inbound\" (CP\u2192gateway) or \"outbound\" (gateway\u2192CP).",
+            "title": "Direction",
+            "type": "string"
+          },
+          "event_id": {
+            "title": "Event Id",
+            "type": "string"
+          },
+          "message_id": {
+            "title": "Message Id",
+            "type": "string"
+          },
+          "message_type": {
+            "description": "2 = CALL, 3 = CALLRESULT, 4 = CALLERROR.",
+            "title": "Message Type",
+            "type": "integer"
+          },
+          "occurred_at": {
+            "title": "Occurred At",
+            "type": "string"
+          },
+          "ocpp_version": {
+            "title": "Ocpp Version",
+            "type": "string"
+          },
+          "raw_payload": {
+            "description": "The exact JSON bytes on the wire.",
+            "title": "Raw Payload",
+            "type": "string"
+          },
+          "transaction_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Extracted from the frame payload when present (Start/Stop Transaction, MeterValues, \u2026). Null for frames that don't carry a transactionId.",
+            "title": "Transaction Id"
+          }
+        },
+        "required": [
+          "event_id",
+          "occurred_at",
+          "cp_id",
+          "direction",
+          "action",
+          "message_type",
+          "message_id",
+          "ocpp_version",
+          "raw_payload"
+        ],
+        "title": "OcppFrame",
+        "type": "object"
+      },
+      "OcppFramesByCpResponse": {
+        "description": "`GET /api/v1/charge-points/{cp_id}/frames?from=\u2026&to=\u2026`.",
+        "properties": {
+          "cp_id": {
+            "title": "Cp Id",
+            "type": "string"
+          },
+          "frames": {
+            "items": {
+              "$ref": "#/components/schemas/OcppFrame"
+            },
+            "title": "Frames",
+            "type": "array"
+          },
+          "request_id": {
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "cp_id",
+          "frames",
+          "request_id"
+        ],
+        "title": "OcppFramesByCpResponse",
+        "type": "object"
+      },
+      "OcppFramesByTransactionResponse": {
+        "description": "`GET /api/v1/transactions/{transaction_id}/frames`. No window\nrequired \u2014 transactions are already bounded.",
+        "properties": {
+          "frames": {
+            "items": {
+              "$ref": "#/components/schemas/OcppFrame"
+            },
+            "title": "Frames",
+            "type": "array"
+          },
+          "request_id": {
+            "title": "Request Id",
+            "type": "string"
+          },
+          "transaction_id": {
+            "title": "Transaction Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "transaction_id",
+          "frames",
+          "request_id"
+        ],
+        "title": "OcppFramesByTransactionResponse",
+        "type": "object"
+      },
       "OfflineDurationEvent": {
         "description": "One observed offline window for a charger.\n\nAnchored on `came_online_at` (the reconnect that closed the\nwindow). `offline_seconds` is precomputed gateway-side.",
         "properties": {
@@ -4001,6 +4125,140 @@
         ]
       }
     },
+    "/api/v1/charge-points/{cp_id}/frames": {
+      "get": {
+        "description": "Verbatim OCPP frame trail for one charger. Each row is the\nexact JSON the gateway received (``direction=inbound``) or wrote\non the wire (``direction=outbound``).\n\nOptional ``direction`` scopes to one side; optional ``action``\nfilters on the OCPP action name (``BootNotification``,\n``MeterValues``, \u2026). Same 7-day window cap as the meter +\nstatus routes.",
+        "operationId": "list_frames_by_cp_api_v1_charge_points__cp_id__frames_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "cp_id",
+            "required": true,
+            "schema": {
+              "title": "Cp Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "from",
+            "required": true,
+            "schema": {
+              "title": "From",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "to",
+            "required": true,
+            "schema": {
+              "title": "To",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "direction",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Direction"
+            }
+          },
+          {
+            "in": "query",
+            "name": "action",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Action"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maximum": 10000,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OcppFramesByCpResponse",
+                  "additionalProperties": true,
+                  "title": "Response List Frames By Cp Api V1 Charge Points  Cp Id  Frames Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Bad from/to or window too large."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unknown cp_id."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "ClickHouse-backed OCPP frame audit for a charge point (both directions)",
+        "tags": [
+          "timeseries"
+        ]
+      }
+    },
     "/api/v1/charge-points/{cp_id}/meter-values": {
       "get": {
         "operationId": "list_meter_values_api_v1_charge_points__cp_id__meter_values_get",
@@ -5640,6 +5898,80 @@
           }
         },
         "summary": "Single-transaction detail",
+        "tags": [
+          "transactions"
+        ]
+      }
+    },
+    "/api/v1/transactions/{transaction_id}/frames": {
+      "get": {
+        "description": "Every OCPP frame stamped with the given ``transaction_id`` \u2014\nboth directions, ordered by ``occurred_at``. No time window\nrequired: transactions are already bounded.\n\n404 when the transaction_id doesn't exist in the OLTP store. An\nexisting transaction with zero frames returns ``frames: []`` (a\nfresh tx that hasn't received MeterValues yet).",
+        "operationId": "get_transaction_frames_route_api_v1_transactions__transaction_id__frames_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "transaction_id",
+            "required": true,
+            "schema": {
+              "title": "Transaction Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maximum": 10000,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OcppFramesByTransactionResponse",
+                  "additionalProperties": true,
+                  "title": "Response Get Transaction Frames Route Api V1 Transactions  Transaction Id  Frames Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unknown transaction_id."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "OCPP frame audit trail for one transaction",
         "tags": [
           "transactions"
         ]

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -702,6 +702,105 @@ components:
       - request_id
       title: MeterValuesResponse
       type: object
+    OcppFrame:
+      description: 'One row of the `cp_ocpp_frames` audit table — a single OCPP
+
+        frame in either direction, captured verbatim. ``raw_payload`` is
+
+        the JSON the gateway received or wrote on the wire.'
+      properties:
+        action:
+          description: OCPP action name. Empty for CALLRESULT / CALLERROR.
+          title: Action
+          type: string
+        cp_id:
+          title: Cp Id
+          type: string
+        direction:
+          description: '"inbound" (CP→gateway) or "outbound" (gateway→CP).'
+          title: Direction
+          type: string
+        event_id:
+          title: Event Id
+          type: string
+        message_id:
+          title: Message Id
+          type: string
+        message_type:
+          description: 2 = CALL, 3 = CALLRESULT, 4 = CALLERROR.
+          title: Message Type
+          type: integer
+        occurred_at:
+          title: Occurred At
+          type: string
+        ocpp_version:
+          title: Ocpp Version
+          type: string
+        raw_payload:
+          description: The exact JSON bytes on the wire.
+          title: Raw Payload
+          type: string
+        transaction_id:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          description: Extracted from the frame payload when present (Start/Stop Transaction,
+            MeterValues, …). Null for frames that don't carry a transactionId.
+          title: Transaction Id
+      required:
+      - event_id
+      - occurred_at
+      - cp_id
+      - direction
+      - action
+      - message_type
+      - message_id
+      - ocpp_version
+      - raw_payload
+      title: OcppFrame
+      type: object
+    OcppFramesByCpResponse:
+      description: '`GET /api/v1/charge-points/{cp_id}/frames?from=…&to=…`.'
+      properties:
+        cp_id:
+          title: Cp Id
+          type: string
+        frames:
+          items:
+            $ref: '#/components/schemas/OcppFrame'
+          title: Frames
+          type: array
+        request_id:
+          title: Request Id
+          type: string
+      required:
+      - cp_id
+      - frames
+      - request_id
+      title: OcppFramesByCpResponse
+      type: object
+    OcppFramesByTransactionResponse:
+      description: '`GET /api/v1/transactions/{transaction_id}/frames`. No window
+
+        required — transactions are already bounded.'
+      properties:
+        frames:
+          items:
+            $ref: '#/components/schemas/OcppFrame'
+          title: Frames
+          type: array
+        request_id:
+          title: Request Id
+          type: string
+        transaction_id:
+          title: Transaction Id
+          type: integer
+      required:
+      - transaction_id
+      - frames
+      - request_id
+      title: OcppFramesByTransactionResponse
+      type: object
     OfflineDurationEvent:
       description: 'One observed offline window for a charger.
 
@@ -2755,6 +2854,100 @@ paths:
       summary: Server-Sent Events stream of per-CP lifecycle events
       tags:
       - sse
+  /api/v1/charge-points/{cp_id}/frames:
+    get:
+      description: 'Verbatim OCPP frame trail for one charger. Each row is the
+
+        exact JSON the gateway received (``direction=inbound``) or wrote
+
+        on the wire (``direction=outbound``).
+
+
+        Optional ``direction`` scopes to one side; optional ``action``
+
+        filters on the OCPP action name (``BootNotification``,
+
+        ``MeterValues``, …). Same 7-day window cap as the meter +
+
+        status routes.'
+      operationId: list_frames_by_cp_api_v1_charge_points__cp_id__frames_get
+      parameters:
+      - in: path
+        name: cp_id
+        required: true
+        schema:
+          title: Cp Id
+          type: string
+      - in: query
+        name: from
+        required: true
+        schema:
+          title: From
+          type: string
+      - in: query
+        name: to
+        required: true
+        schema:
+          title: To
+          type: string
+      - in: query
+        name: direction
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Direction
+      - in: query
+        name: action
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Action
+      - in: query
+        name: limit
+        required: false
+        schema:
+          anyOf:
+          - maximum: 10000
+            minimum: 1
+            type: integer
+          - type: 'null'
+          title: Limit
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OcppFramesByCpResponse'
+                additionalProperties: true
+                title: Response List Frames By Cp Api V1 Charge Points  Cp Id  Frames
+                  Get
+                type: object
+          description: Successful Response
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+          description: Bad from/to or window too large.
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+          description: Unknown cp_id.
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: ClickHouse-backed OCPP frame audit for a charge point (both directions)
+      tags:
+      - timeseries
   /api/v1/charge-points/{cp_id}/meter-values:
     get:
       operationId: list_meter_values_api_v1_charge_points__cp_id__meter_values_get
@@ -3737,6 +3930,64 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
       summary: Single-transaction detail
+      tags:
+      - transactions
+  /api/v1/transactions/{transaction_id}/frames:
+    get:
+      description: 'Every OCPP frame stamped with the given ``transaction_id`` —
+
+        both directions, ordered by ``occurred_at``. No time window
+
+        required: transactions are already bounded.
+
+
+        404 when the transaction_id doesn''t exist in the OLTP store. An
+
+        existing transaction with zero frames returns ``frames: []`` (a
+
+        fresh tx that hasn''t received MeterValues yet).'
+      operationId: get_transaction_frames_route_api_v1_transactions__transaction_id__frames_get
+      parameters:
+      - in: path
+        name: transaction_id
+        required: true
+        schema:
+          title: Transaction Id
+          type: integer
+      - in: query
+        name: limit
+        required: false
+        schema:
+          anyOf:
+          - maximum: 10000
+            minimum: 1
+            type: integer
+          - type: 'null'
+          title: Limit
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OcppFramesByTransactionResponse'
+                additionalProperties: true
+                title: Response Get Transaction Frames Route Api V1 Transactions  Transaction
+                  Id  Frames Get
+                type: object
+          description: Successful Response
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+          description: Unknown transaction_id.
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: OCPP frame audit trail for one transaction
       tags:
       - transactions
 security:

--- a/src/eveys_ocpp/api/_schemas.py
+++ b/src/eveys_ocpp/api/_schemas.py
@@ -568,6 +568,47 @@ class FleetStatusResponse(BaseModel):
     request_id: str
 
 
+class OcppFrame(BaseModel):
+    """One row of the `cp_ocpp_frames` audit table — a single OCPP
+    frame in either direction, captured verbatim. ``raw_payload`` is
+    the JSON the gateway received or wrote on the wire."""
+
+    event_id: str
+    occurred_at: str
+    cp_id: str
+    direction: str = Field(description='"inbound" (CP→gateway) or "outbound" (gateway→CP).')
+    action: str = Field(description="OCPP action name. Empty for CALLRESULT / CALLERROR.")
+    message_type: int = Field(description="2 = CALL, 3 = CALLRESULT, 4 = CALLERROR.")
+    message_id: str
+    ocpp_version: str
+    transaction_id: int | None = Field(
+        default=None,
+        description=(
+            "Extracted from the frame payload when present (Start/Stop"
+            " Transaction, MeterValues, …). Null for frames that don't"
+            " carry a transactionId."
+        ),
+    )
+    raw_payload: str = Field(description="The exact JSON bytes on the wire.")
+
+
+class OcppFramesByCpResponse(BaseModel):
+    """`GET /api/v1/charge-points/{cp_id}/frames?from=…&to=…`."""
+
+    cp_id: str
+    frames: list[OcppFrame]
+    request_id: str
+
+
+class OcppFramesByTransactionResponse(BaseModel):
+    """`GET /api/v1/transactions/{transaction_id}/frames`. No window
+    required — transactions are already bounded."""
+
+    transaction_id: int
+    frames: list[OcppFrame]
+    request_id: str
+
+
 class OfflineDurationEvent(BaseModel):
     """One observed offline window for a charger.
 
@@ -670,6 +711,9 @@ __all__ = [
     "LatestMeter",
     "MeterValueSample",
     "MeterValuesResponse",
+    "OcppFrame",
+    "OcppFramesByCpResponse",
+    "OcppFramesByTransactionResponse",
     "OfflineDurationEvent",
     "OfflineHistoryResponse",
     "PaginationBlock",

--- a/src/eveys_ocpp/api/timeseries.py
+++ b/src/eveys_ocpp/api/timeseries.py
@@ -46,6 +46,7 @@ from eveys_ocpp.api._schemas import (
     ErrorEnvelope,
     FleetStatusResponse,
     MeterValuesResponse,
+    OcppFramesByCpResponse,
     OfflineHistoryResponse,
     StatusHistoryResponse,
 )
@@ -266,6 +267,79 @@ async def list_fleet_status_history(
     return {
         "events": [_status_to_response(r) for r in rows],
         "request_id": request.state.request_id,
+    }
+
+
+@router.get(
+    "/charge-points/{cp_id}/frames",
+    summary="ClickHouse-backed OCPP frame audit for a charge point (both directions)",
+    responses={
+        200: {"model": OcppFramesByCpResponse},
+        400: {"model": ErrorEnvelope, "description": "Bad from/to or window too large."},
+        404: {"model": ErrorEnvelope, "description": "Unknown cp_id."},
+    },
+)
+async def list_frames_by_cp(
+    request: Request,
+    cp_id: str,
+    from_: str = Query(alias="from"),
+    to: str = Query(...),
+    direction: str | None = Query(default=None),
+    action: str | None = Query(default=None),
+    limit: int | None = Query(default=None, ge=1, le=10_000),
+) -> dict[str, Any]:
+    """Verbatim OCPP frame trail for one charger. Each row is the
+    exact JSON the gateway received (``direction=inbound``) or wrote
+    on the wire (``direction=outbound``).
+
+    Optional ``direction`` scopes to one side; optional ``action``
+    filters on the OCPP action name (``BootNotification``,
+    ``MeterValues``, …). Same 7-day window cap as the meter +
+    status routes."""
+    settings = request.app.state.settings
+    page_size = clamp_limit(
+        limit,
+        default=settings.rest_default_page_size,
+        maximum=settings.rest_max_page_size,
+    )
+
+    started_from = _parse_iso8601(from_, field_name="from")
+    started_to = _parse_iso8601(to, field_name="to")
+    _validate_window(started_from, started_to)
+
+    await _ensure_cp_exists(request, cp_id)
+
+    rows = await _ch_client(request).fetch_frames_by_cp(
+        cp_id=cp_id,
+        started_from=started_from,
+        started_to=started_to,
+        direction=direction,
+        action=action,
+        limit=page_size,
+    )
+
+    return {
+        "cp_id": cp_id,
+        "frames": [_frame_to_response(r) for r in rows],
+        "request_id": request.state.request_id,
+    }
+
+
+def _frame_to_response(row: dict[str, Any]) -> dict[str, Any]:
+    """Project a ClickHouse `cp_ocpp_frames` row into the API shape.
+    Empty strings normalised to None for nullable-feeling fields so
+    consumers don't have to special-case both forms."""
+    return {
+        "event_id": row["event_id"],
+        "occurred_at": _isoformat(row["occurred_at"]),
+        "cp_id": row["cp_id"],
+        "direction": row["direction"],
+        "action": row["action"] or "",
+        "message_type": row["message_type"],
+        "message_id": row["message_id"] or "",
+        "ocpp_version": row["ocpp_version"] or "",
+        "transaction_id": row.get("transaction_id"),
+        "raw_payload": row["raw_payload"],
     }
 
 

--- a/src/eveys_ocpp/api/transactions.py
+++ b/src/eveys_ocpp/api/transactions.py
@@ -35,6 +35,7 @@ from eveys_ocpp.api._pagination import (
 )
 from eveys_ocpp.api._schemas import (
     ErrorEnvelope,
+    OcppFramesByTransactionResponse,
     TransactionDetail,
     TransactionListResponse,
 )
@@ -338,6 +339,80 @@ async def get_transaction_route(request: Request, transaction_id: int) -> dict[s
     response["telemetry"] = await _telemetry_for(request, tx)
     response["request_id"] = request.state.request_id
     return response
+
+
+@router.get(
+    "/transactions/{transaction_id}/frames",
+    summary="OCPP frame audit trail for one transaction",
+    responses={
+        200: {"model": OcppFramesByTransactionResponse},
+        404: {"model": ErrorEnvelope, "description": "Unknown transaction_id."},
+    },
+)
+async def get_transaction_frames_route(
+    request: Request,
+    transaction_id: int,
+    limit: int | None = Query(default=None, ge=1, le=10_000),
+) -> dict[str, Any]:
+    """Every OCPP frame stamped with the given ``transaction_id`` —
+    both directions, ordered by ``occurred_at``. No time window
+    required: transactions are already bounded.
+
+    404 when the transaction_id doesn't exist in the OLTP store. An
+    existing transaction with zero frames returns ``frames: []`` (a
+    fresh tx that hasn't received MeterValues yet)."""
+    async with session_scope(request.app.state.session_factory) as session:
+        tx = await get_transaction_by_id(session, transaction_id=transaction_id)
+    if tx is None:
+        raise ApiError(
+            status_code=404,
+            error_code=ERR_UNKNOWN_TRANSACTION_ID,
+            message=f"unknown transaction_id: {transaction_id}",
+        )
+
+    settings = request.app.state.settings
+    page_size = clamp_limit(
+        limit,
+        default=settings.rest_default_page_size,
+        maximum=settings.rest_max_page_size,
+    )
+
+    ch_client = getattr(request.app.state, "ch_client", None)
+    if ch_client is None:
+        # Same posture as get_transaction_route's telemetry: tests and
+        # compose-smoke run without ClickHouse — surface frames=[]
+        # instead of 500ing.
+        rows: list[dict[str, Any]] = []
+    else:
+        rows = await ch_client.fetch_frames_by_transaction(
+            transaction_id=transaction_id,
+            limit=page_size,
+        )
+
+    return {
+        "transaction_id": transaction_id,
+        "frames": [_frame_to_response(r) for r in rows],
+        "request_id": request.state.request_id,
+    }
+
+
+def _frame_to_response(row: dict[str, Any]) -> dict[str, Any]:
+    """Project a `cp_ocpp_frames` row into the API shape. Mirrors the
+    same helper in `api/timeseries.py`; duplicated here so the two
+    routers stay independent (the import direction would otherwise
+    be backwards)."""
+    return {
+        "event_id": row["event_id"],
+        "occurred_at": _isoformat(row["occurred_at"]),
+        "cp_id": row["cp_id"],
+        "direction": row["direction"],
+        "action": row["action"] or "",
+        "message_type": row["message_type"],
+        "message_id": row["message_id"] or "",
+        "ocpp_version": row["ocpp_version"] or "",
+        "transaction_id": row.get("transaction_id"),
+        "raw_payload": row["raw_payload"],
+    }
 
 
 async def _telemetry_for(request: Request, tx: dict[str, Any]) -> dict[str, Any] | None:

--- a/src/eveys_ocpp/clickhouse/ddl/0007_create_cp_ocpp_frames.sql
+++ b/src/eveys_ocpp/clickhouse/ddl/0007_create_cp_ocpp_frames.sql
@@ -1,0 +1,47 @@
+-- cp.ocpp_frames — bidirectional OCPP frame audit.
+--
+-- Mirrors `proto/events/v1/events.proto` `CpOcppFrame`. One row per
+-- OCPP frame, both directions: `direction='inbound'` is CP→gateway,
+-- `direction='outbound'` is gateway→CP. The frame's raw JSON is
+-- stored verbatim in `raw_payload` so disputes and fraud
+-- investigations can replay the exact bytes that were on the wire.
+--
+-- `transaction_id` is extracted by the ingestor when present in the
+-- frame body (StartTransaction.conf, MeterValues, StopTransaction)
+-- and stored alongside; null for frames that don't carry a tx
+-- (BootNotification, Heartbeat, StatusNotification, etc). A
+-- skip-index on the column makes "all frames for tx 12345" cheap
+-- even though most rows have null in that column.
+--
+-- Order key matches sibling tables. The skip-index on
+-- `transaction_id` keeps tx lookups partition-scoped — operators
+-- almost always know which cp_id the tx is on (it's in the
+-- transactions table; the API joins them), so cp_id stays the
+-- primary access path. The skip-index is a belt-and-braces speedup
+-- for the cross-cp "find by tx alone" case.
+
+CREATE TABLE IF NOT EXISTS cp_ocpp_frames
+(
+    event_id            String,
+    occurred_at         DateTime64(3, 'UTC'),
+    cp_id               String,
+    schema_version      String,
+    trace_id            String,
+
+    direction           String,
+    raw_payload         String,
+    message_id          String,
+    action              String,
+    -- 2 = CALL, 3 = CALLRESULT, 4 = CALLERROR, 0 = unparseable.
+    message_type        Int32,
+    ocpp_version        String,
+    -- Extracted by the ingestor from the OCPP payload when present.
+    -- Nullable because most frame kinds don't carry a transaction.
+    transaction_id      Nullable(Int64),
+
+    INDEX idx_tx (transaction_id) TYPE minmax GRANULARITY 4,
+    INDEX idx_action (action) TYPE bloom_filter GRANULARITY 4
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(occurred_at)
+ORDER BY (cp_id, occurred_at);

--- a/src/eveys_ocpp/clickhouse/ingestor.py
+++ b/src/eveys_ocpp/clickhouse/ingestor.py
@@ -38,6 +38,7 @@ Entrypoint: ``python -m eveys_ocpp.clickhouse.ingestor``.
 from __future__ import annotations
 
 import asyncio
+import json
 import signal
 import sys
 from collections.abc import Iterable
@@ -172,6 +173,60 @@ def _row_cp_offline_duration(env: events_pb2.EventEnvelope) -> dict[str, Any]:
     }
 
 
+def _extract_transaction_id(raw_payload: str) -> int | None:
+    """Pull ``transactionId`` out of an OCPP frame's JSON when present.
+
+    OCPP-J frames are a 4-element JSON array:
+        [messageTypeId, messageId, action, payload]   # CALL
+        [messageTypeId, messageId, payload]           # CALLRESULT / CALLERROR
+
+    The ``transactionId`` field shows up inside the payload object on
+    a small set of message types (StartTransaction.conf,
+    StopTransaction.req, MeterValues.req, RemoteStartTransaction.req
+    when the central system pins the id, …). It's the same key name
+    everywhere it appears, so a shallow dict lookup suffices — no
+    need to know which action we're parsing.
+
+    Returns ``None`` for: unparseable JSON, unexpected frame shape, no
+    ``transactionId`` key, or a value that isn't coercible to int.
+    Built to never raise; the ingestor must not crash on a malformed
+    frame, just store the row without the tx index hint.
+    """
+    if not raw_payload:
+        return None
+    try:
+        frame = json.loads(raw_payload)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(frame, list) or len(frame) < 3:
+        return None
+    # Payload is the last element regardless of CALL vs RESULT/ERROR.
+    body = frame[-1]
+    if not isinstance(body, dict):
+        return None
+    value = body.get("transactionId")
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _row_cp_ocpp_frame(env: events_pb2.EventEnvelope) -> dict[str, Any]:
+    payload = env.cp_ocpp_frame
+    return {
+        **_envelope_meta(env),
+        "direction": payload.direction,
+        "raw_payload": payload.raw_payload,
+        "message_id": payload.message_id,
+        "action": payload.action,
+        "message_type": payload.message_type,
+        "ocpp_version": payload.ocpp_version,
+        "transaction_id": _extract_transaction_id(payload.raw_payload),
+    }
+
+
 # `oneof` field name → (table, extractor). The protobuf-generated
 # `WhichOneof("payload")` returns the field name of the set variant.
 _DISPATCH: dict[str, tuple[str, Any]] = {
@@ -180,6 +235,7 @@ _DISPATCH: dict[str, tuple[str, Any]] = {
     "cp_boot": ("cp_boot", _row_cp_boot),
     "tx_started": ("tx_started", _row_tx_started),
     "cp_offline_duration": ("cp_offline_duration", _row_cp_offline_duration),
+    "cp_ocpp_frame": ("cp_ocpp_frames", _row_cp_ocpp_frame),
     # Note: cp_connected is intentionally not ingested — that variant
     # is a registry-presence event, not telemetry. If a future ADR
     # decides we want it in CH, add a row here.
@@ -221,6 +277,7 @@ class ClickHouseIngestor:
             self._settings.kafka_topic_cp_boot,
             self._settings.kafka_topic_tx_started,
             self._settings.kafka_topic_cp_offline_duration,
+            self._settings.kafka_topic_cp_ocpp_frames,
         )
         consumer = AIOKafkaConsumer(
             *topics,

--- a/src/eveys_ocpp/clickhouse/read_client.py
+++ b/src/eveys_ocpp/clickhouse/read_client.py
@@ -593,3 +593,96 @@ class ClickHouseReadClient:
             cols = [d[0] for d in cursor.description]
             rows = await cursor.fetchall()
         return [dict(zip(cols, row, strict=True)) for row in rows]
+
+    async def fetch_frames_by_cp(
+        self,
+        *,
+        cp_id: str,
+        started_from: datetime,
+        started_to: datetime,
+        direction: str | None,
+        action: str | None,
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        """Per-cp OCPP frame audit inside [from, to]. Both
+        directions by default; pass ``direction`` to scope to
+        ``inbound`` (CP→gateway) or ``outbound`` (gateway→CP)."""
+        assert self._conn is not None
+
+        sql = """
+            SELECT
+                event_id,
+                occurred_at,
+                cp_id,
+                direction,
+                action,
+                message_type,
+                message_id,
+                ocpp_version,
+                transaction_id,
+                raw_payload
+            FROM cp_ocpp_frames
+            WHERE cp_id = {cp_id}
+              AND occurred_at >= {from_ts}
+              AND occurred_at <= {to_ts}
+        """
+        params: dict[str, Any] = {
+            "cp_id": cp_id,
+            "from_ts": started_from,
+            "to_ts": started_to,
+        }
+        if direction is not None:
+            sql += " AND direction = {direction}"
+            params["direction"] = direction
+        if action is not None:
+            sql += " AND action = {action}"
+            params["action"] = action
+        sql += " ORDER BY occurred_at, event_id LIMIT {limit}"
+        params["limit"] = limit
+
+        async with self._conn.cursor() as cursor:
+            await cursor.execute(sql, params)
+            cols = [d[0] for d in cursor.description]
+            rows = await cursor.fetchall()
+        return [dict(zip(cols, row, strict=True)) for row in rows]
+
+    async def fetch_frames_by_transaction(
+        self,
+        *,
+        transaction_id: int,
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        """All frames tagged with ``transaction_id``. No time window —
+        transactions are already bounded (typically minutes to hours),
+        so the lookup is cheap if the skip-index on transaction_id
+        prunes most parts. Used by "show me the frame trace for tx
+        12345" workflows."""
+        assert self._conn is not None
+
+        sql = """
+            SELECT
+                event_id,
+                occurred_at,
+                cp_id,
+                direction,
+                action,
+                message_type,
+                message_id,
+                ocpp_version,
+                transaction_id,
+                raw_payload
+            FROM cp_ocpp_frames
+            WHERE transaction_id = {transaction_id}
+            ORDER BY occurred_at, event_id
+            LIMIT {limit}
+        """
+        params: dict[str, Any] = {
+            "transaction_id": transaction_id,
+            "limit": limit,
+        }
+
+        async with self._conn.cursor() as cursor:
+            await cursor.execute(sql, params)
+            cols = [d[0] for d in cursor.description]
+            rows = await cursor.fetchall()
+        return [dict(zip(cols, row, strict=True)) for row in rows]

--- a/tests/unit/api/test_timeseries.py
+++ b/tests/unit/api/test_timeseries.py
@@ -419,3 +419,103 @@ async def test_fleet_status_bad_window_orientation(client: httpx.AsyncClient) ->
         "/api/v1/status-history?from=2026-05-06T23:59:59%2B00:00&to=2026-05-06T00:00:00%2B00:00"
     )
     assert response.status_code == 400
+
+
+# ---- frames-by-cp ----------------------------------------------------------
+
+
+def _frame_row(
+    cp_id: str = "CP_001",
+    direction: str = "inbound",
+    action: str = "MeterValues",
+    transaction_id: int | None = 12345,
+) -> dict[str, Any]:
+    return {
+        "event_id": "evt-0003",
+        "occurred_at": datetime(2026, 5, 6, 14, 0, tzinfo=UTC),
+        "cp_id": cp_id,
+        "direction": direction,
+        "action": action,
+        "message_type": 2,
+        "message_id": "call-abc",
+        "ocpp_version": "ocpp1.6",
+        "transaction_id": transaction_id,
+        "raw_payload": '[2,"call-abc","MeterValues",{"transactionId":12345}]',
+    }
+
+
+@pytest.mark.asyncio
+async def test_frames_by_cp_returns_full_shape(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    fake_ch_client: MagicMock,
+) -> None:
+    from eveys_ocpp.api import timeseries as ts_module
+
+    monkeypatch.setattr(ts_module, "get_charge_point_pk", AsyncMock(return_value=1))
+    fake_ch_client.fetch_frames_by_cp = AsyncMock(return_value=[_frame_row()])
+
+    response = await client.get(
+        "/api/v1/charge-points/CP_001/frames"
+        "?from=2026-05-06T00:00:00%2B00:00&to=2026-05-06T23:59:59%2B00:00"
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["cp_id"] == "CP_001"
+    row = body["frames"][0]
+    assert row["direction"] == "inbound"
+    assert row["action"] == "MeterValues"
+    assert row["transaction_id"] == 12345
+    assert row["raw_payload"].startswith("[2,")
+
+
+@pytest.mark.asyncio
+async def test_frames_by_cp_passes_optional_filters_through(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    fake_ch_client: MagicMock,
+) -> None:
+    from eveys_ocpp.api import timeseries as ts_module
+
+    monkeypatch.setattr(ts_module, "get_charge_point_pk", AsyncMock(return_value=1))
+    spy = AsyncMock(return_value=[])
+    fake_ch_client.fetch_frames_by_cp = spy
+
+    await client.get(
+        "/api/v1/charge-points/CP_001/frames"
+        "?from=2026-05-06T00:00:00%2B00:00&to=2026-05-06T23:59:59%2B00:00"
+        "&direction=outbound&action=BootNotification&limit=50"
+    )
+
+    kwargs = spy.await_args.kwargs
+    assert kwargs["direction"] == "outbound"
+    assert kwargs["action"] == "BootNotification"
+    assert kwargs["limit"] == 50
+
+
+@pytest.mark.asyncio
+async def test_frames_by_cp_window_too_large(client: httpx.AsyncClient) -> None:
+    response = await client.get(
+        "/api/v1/charge-points/CP_001/frames"
+        "?from=2026-04-01T00:00:00%2B00:00&to=2026-05-06T00:00:00%2B00:00"
+    )
+    assert response.status_code == 400
+    assert response.json()["error_code"] == "WINDOW_TOO_LARGE"
+
+
+@pytest.mark.asyncio
+async def test_frames_by_cp_unknown_cp_404(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from eveys_ocpp.api import timeseries as ts_module
+
+    monkeypatch.setattr(ts_module, "get_charge_point_pk", AsyncMock(return_value=None))
+
+    response = await client.get(
+        "/api/v1/charge-points/UNKNOWN/frames"
+        "?from=2026-05-06T00:00:00%2B00:00&to=2026-05-06T23:59:59%2B00:00"
+    )
+    assert response.status_code == 404
+    assert response.json()["error_code"] == "UNKNOWN_CP_ID"

--- a/tests/unit/api/test_transactions.py
+++ b/tests/unit/api/test_transactions.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
@@ -354,3 +354,80 @@ async def test_list_responses_have_no_telemetry_field(
     body = response.json()
     for row in body["transactions"]:
         assert "telemetry" not in row
+
+
+# ---- /transactions/{id}/frames --------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_transaction_frames_unknown_tx_404(
+    client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from eveys_ocpp.api import transactions as tx_module
+
+    monkeypatch.setattr(tx_module, "get_transaction_by_id", AsyncMock(return_value=None))
+
+    response = await client.get("/api/v1/transactions/999/frames")
+
+    assert response.status_code == 404
+    assert response.json()["error_code"] == "UNKNOWN_TRANSACTION_ID"
+
+
+@pytest.mark.asyncio
+async def test_get_transaction_frames_returns_frames_for_known_tx(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    fake_ch_client: MagicMock,
+) -> None:
+    """Existing tx + ClickHouse rows → 200 with the projected frames.
+    ``transaction_id`` in the row body is preserved."""
+    from eveys_ocpp.api import transactions as tx_module
+
+    monkeypatch.setattr(
+        tx_module, "get_transaction_by_id", AsyncMock(return_value=_tx_row(transaction_id=42))
+    )
+    fake_ch_client.fetch_frames_by_transaction = AsyncMock(
+        return_value=[
+            {
+                "event_id": "evt-x",
+                "occurred_at": datetime(2026, 5, 6, 14, 0, tzinfo=UTC),
+                "cp_id": "CP_001",
+                "direction": "inbound",
+                "action": "MeterValues",
+                "message_type": 2,
+                "message_id": "call-x",
+                "ocpp_version": "ocpp1.6",
+                "transaction_id": 42,
+                "raw_payload": '[2,"call-x","MeterValues",{"transactionId":42}]',
+            }
+        ]
+    )
+
+    response = await client.get("/api/v1/transactions/42/frames")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["transaction_id"] == 42
+    assert body["frames"][0]["action"] == "MeterValues"
+    assert body["frames"][0]["transaction_id"] == 42
+
+
+@pytest.mark.asyncio
+async def test_get_transaction_frames_passes_limit_through(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    fake_ch_client: MagicMock,
+) -> None:
+    from eveys_ocpp.api import transactions as tx_module
+
+    monkeypatch.setattr(
+        tx_module, "get_transaction_by_id", AsyncMock(return_value=_tx_row(transaction_id=42))
+    )
+    spy = AsyncMock(return_value=[])
+    fake_ch_client.fetch_frames_by_transaction = spy
+
+    await client.get("/api/v1/transactions/42/frames?limit=10")
+
+    kwargs = spy.await_args.kwargs
+    assert kwargs["transaction_id"] == 42
+    assert kwargs["limit"] == 10

--- a/tests/unit/test_clickhouse_ingestor.py
+++ b/tests/unit/test_clickhouse_ingestor.py
@@ -20,9 +20,11 @@ from eveys_ocpp.clickhouse.ingestor import (
     _DISPATCH,
     ClickHouseIngestor,
     _envelope_meta,
+    _extract_transaction_id,
     _parse_occurred_at,
     _row_cp_boot,
     _row_cp_meter,
+    _row_cp_ocpp_frame,
     _row_cp_status,
     _row_tx_started,
 )
@@ -185,16 +187,91 @@ def test_dispatch_table_covers_every_persisted_oneof() -> None:
     """The dispatch table maps every `oneof payload` variant we
     persist. `cp_connected` is intentionally missing (not telemetry —
     see ingestor.py module docstring)."""
-    persisted = {"cp_meter", "cp_status", "cp_boot", "tx_started", "cp_offline_duration"}
+    persisted = {
+        "cp_meter",
+        "cp_status",
+        "cp_boot",
+        "tx_started",
+        "cp_offline_duration",
+        "cp_ocpp_frame",
+    }
     assert set(_DISPATCH.keys()) == persisted
 
 
 def test_dispatch_uses_table_names_matching_ddl() -> None:
     """The (table, extractor) pair points at the table name in
     src/eveys_ocpp/clickhouse/ddl/, not the proto field name."""
-    expected_tables = {"cp_meter", "cp_status", "cp_boot", "tx_started", "cp_offline_duration"}
+    expected_tables = {
+        "cp_meter",
+        "cp_status",
+        "cp_boot",
+        "tx_started",
+        "cp_offline_duration",
+        "cp_ocpp_frames",
+    }
     actual_tables = {table for (table, _extractor) in _DISPATCH.values()}
     assert actual_tables == expected_tables
+
+
+# ---- cp.ocpp_frames row extractor + transaction_id parser ------------------
+
+
+def test_row_cp_ocpp_frame_serializes_envelope_fields() -> None:
+    """Plain pass-through for direction/action/message_type/etc. The
+    only field that requires gateway-side computation is
+    transaction_id, which the parser extracts from raw_payload below."""
+    env = _envelope(
+        cp_ocpp_frame=events_pb2.CpOcppFrame(
+            direction="inbound",
+            raw_payload='[2,"abc","Heartbeat",{}]',
+            message_id="abc",
+            action="Heartbeat",
+            message_type=2,
+            ocpp_version="ocpp1.6",
+        )
+    )
+    row = _row_cp_ocpp_frame(env)
+    assert row["direction"] == "inbound"
+    assert row["action"] == "Heartbeat"
+    assert row["message_type"] == 2
+    assert row["ocpp_version"] == "ocpp1.6"
+    # Heartbeat carries no transactionId, so the parser yields None.
+    assert row["transaction_id"] is None
+
+
+def test_extract_transaction_id_from_call_with_transaction_id() -> None:
+    """MeterValues.req carries `transactionId` at the top of the
+    payload object. Tx audit queries hinge on this extraction."""
+    raw = '[2,"call-id","MeterValues",{"connectorId":1,"transactionId":12345,"meterValue":[]}]'
+    assert _extract_transaction_id(raw) == 12345
+
+
+def test_extract_transaction_id_from_callresult() -> None:
+    """StartTransaction.conf is the canonical 'we just got a tx_id'
+    frame — outbound, MessageTypeId=3, transactionId in the payload."""
+    raw = '[3,"call-id",{"transactionId":42,"idTagInfo":{"status":"Accepted"}}]'
+    assert _extract_transaction_id(raw) == 42
+
+
+def test_extract_transaction_id_absent_returns_none() -> None:
+    """Most frame kinds (BootNotification, Heartbeat, StatusNotification)
+    don't carry a transactionId. The ingestor must store the row
+    anyway with the column set to NULL."""
+    raw = '[2,"call-id","Heartbeat",{}]'
+    assert _extract_transaction_id(raw) is None
+
+
+def test_extract_transaction_id_handles_unparseable_payload() -> None:
+    """Never raise — a malformed inbound frame must not crash the
+    ingestor. The frame still gets stored; only the tx index hint
+    is lost."""
+    assert _extract_transaction_id("not json at all") is None
+    assert _extract_transaction_id("") is None
+    assert _extract_transaction_id('{"shape":"wrong"}') is None
+    assert _extract_transaction_id('[2,"too","short"]') is None
+    assert _extract_transaction_id('[2,"id","Action","not-a-dict-payload"]') is None
+    # transactionId present but unparseable as int.
+    assert _extract_transaction_id('[2,"id","X",{"transactionId":"not-int"}]') is None
 
 
 # ---- Parse-failure guards in _process_record ------------------------------
@@ -310,6 +387,7 @@ async def test_start_constructs_kafka_consumer_with_at_least_once_kwargs(
         kafka_topic_cp_boot="cp.boot",
         kafka_topic_tx_started="tx.started",
         kafka_topic_cp_offline_duration="cp.offline_duration",
+        kafka_topic_cp_ocpp_frames="cp.ocpp_frames",
         clickhouse_ingestor_group="test-group",
     )
     ingestor = ClickHouseIngestor(settings)
@@ -323,6 +401,7 @@ async def test_start_constructs_kafka_consumer_with_at_least_once_kwargs(
         "cp.boot",
         "tx.started",
         "cp.offline_duration",
+        "cp.ocpp_frames",
     }
     # at-least-once: manual commit only after a successful INSERT.
     assert captured_kwargs["enable_auto_commit"] is False

--- a/tests/unit/test_clickhouse_migrate.py
+++ b/tests/unit/test_clickhouse_migrate.py
@@ -225,12 +225,12 @@ def test_apply_pending_applies_only_unapplied_migrations(
 
     applied = migrate.apply_pending(host="ch", port=8123, db="eveys_ocpp")
 
-    assert applied == [3, 4, 5, 6]
+    assert applied == [3, 4, 5, 6, 7]
 
     # Expected sequence: CREATE DATABASE → SELECT applied → for each
-    # of [3, 4, 5, 6]: CREATE TABLE + INSERT tracking row. Exactly
-    # 2 + (4 * 2) = 10 SQL calls.
-    assert len(sqls_executed) == 10
+    # pending migration: CREATE TABLE + INSERT tracking row. Exactly
+    # 2 + (N * 2) calls where N is the number of pending migrations.
+    assert len(sqls_executed) == 2 + (5 * 2)
 
     # The very first call is the CREATE DATABASE (db=None).
     assert sqls_executed[0][0] is None
@@ -247,13 +247,14 @@ def test_apply_pending_applies_only_unapplied_migrations(
         assert sql_db == "eveys_ocpp"
     create_calls = [s for (_db, s) in sqls_executed[2:] if "CREATE TABLE" in s]
     insert_calls = [s for (_db, s) in sqls_executed[2:] if "INSERT INTO schema_migrations" in s]
-    assert len(create_calls) == 4
-    assert len(insert_calls) == 4
+    assert len(create_calls) == 5
+    assert len(insert_calls) == 5
     # Tracking inserts carry the right (version, name) pairs.
     assert "(3, 'create_cp_status')" in insert_calls[0]
     assert "(4, 'create_cp_boot')" in insert_calls[1]
     assert "(5, 'create_tx_started')" in insert_calls[2]
     assert "(6, 'create_cp_offline_duration')" in insert_calls[3]
+    assert "(7, 'create_cp_ocpp_frames')" in insert_calls[4]
 
 
 def test_apply_pending_is_a_noop_when_everything_already_applied(
@@ -263,8 +264,9 @@ def test_apply_pending_is_a_noop_when_everything_already_applied(
     only does the CREATE DATABASE + SELECT, no new INSERTs or
     CREATE TABLEs."""
     sqls_executed: list[str] = []
-    # All 6 versions already applied.
-    response_body = b"1\n2\n3\n4\n5\n6\n"
+    # All applied versions present — including the new 0007 from
+    # this PR.
+    response_body = b"1\n2\n3\n4\n5\n6\n7\n"
 
     def fake_urlopen(req: object, timeout: int = 0) -> _FakeResponse:
         sql = req.data.decode()  # type: ignore[attr-defined]

--- a/tests/unit/test_clickhouse_read_client.py
+++ b/tests/unit/test_clickhouse_read_client.py
@@ -207,3 +207,67 @@ async def test_fetch_fleet_status_history_cp_ids_in_clause() -> None:
     assert "'CP_B'" in rendered
     assert "AND cp_id IN" in rendered
     assert "%(" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_fetch_frames_by_cp_uses_asynch_placeholder_shape() -> None:
+    """Per-cp frame audit lookup. cp_id + time window required;
+    direction + action are optional filters that expand into extra
+    AND clauses with bound parameters."""
+    client, cursor = _client_with_fake_cursor()
+
+    await client.fetch_frames_by_cp(
+        cp_id="CP_42",
+        started_from=datetime(2026, 5, 1, tzinfo=UTC),
+        started_to=datetime(2026, 5, 8, tzinfo=UTC),
+        direction="inbound",
+        action="MeterValues",
+        limit=500,
+    )
+
+    sql, params = cursor.execute.await_args.args
+    rendered = _substitute(sql, params)
+    assert "'CP_42'" in rendered
+    assert "direction = 'inbound'" in rendered
+    assert "action = 'MeterValues'" in rendered
+    assert "LIMIT 500" in rendered
+    # asynch placeholder shape (`{name}`), not DB-API (`%(name)s`).
+    assert "%(" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_fetch_frames_by_cp_skips_optional_filters_when_none() -> None:
+    """Without direction or action, the SQL has neither extra AND
+    clause — the route handler must not synthesise empty-string
+    filters that would silently match every row."""
+    client, cursor = _client_with_fake_cursor()
+
+    await client.fetch_frames_by_cp(
+        cp_id="CP_42",
+        started_from=datetime(2026, 5, 1, tzinfo=UTC),
+        started_to=datetime(2026, 5, 8, tzinfo=UTC),
+        direction=None,
+        action=None,
+        limit=200,
+    )
+
+    sql, params = cursor.execute.await_args.args
+    rendered = _substitute(sql, params)
+    assert "AND direction =" not in rendered
+    assert "AND action =" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_fetch_frames_by_transaction_uses_asynch_placeholder_shape() -> None:
+    """No time window required — transactions are bounded already.
+    The skip-index on transaction_id prunes parts so the scan stays
+    cheap even across long retention windows."""
+    client, cursor = _client_with_fake_cursor()
+
+    await client.fetch_frames_by_transaction(transaction_id=12345, limit=1000)
+
+    sql, params = cursor.execute.await_args.args
+    rendered = _substitute(sql, params)
+    assert "transaction_id = 12345" in rendered
+    assert "LIMIT 1000" in rendered
+    assert "%(" not in rendered


### PR DESCRIPTION
## Summary

PR 2 of three for #218. Closes the **"which frames belonged to transaction 12345?"** gap by persisting every OCPP frame (both directions) into ClickHouse and exposing two read routes.

\`\`\`
GET /api/v1/charge-points/{cp_id}/frames?from=...&to=...
GET /api/v1/transactions/{transaction_id}/frames
\`\`\`

## Storage

New ClickHouse table \`cp_ocpp_frames\` (DDL 0007). Columns from the \`CpOcppFrame\` proto + a \`transaction_id\` column the ingestor populates by parsing the OCPP-J payload. Order key \`(cp_id, occurred_at)\`; **skip-index on \`transaction_id\`** keeps the cross-cp "find by tx alone" lookup cheap, plus a bloom-filter on \`action\` for action-name filtering.

## Ingestor

- \`_row_cp_ocpp_frame\` mirrors the other row extractors.
- \`_extract_transaction_id\` parses the wire JSON (\`[msgType, msgId, action, payload]\`) and pulls \`transactionId\` from the payload object. Handles StartTransaction.conf, MeterValues.req, StopTransaction.req — all the kinds that carry the field. **Never raises**: malformed JSON, wrong shape, non-numeric values all yield \`None\`, and the frame still gets stored.
- Subscribes to \`kafka_topic_cp_ocpp_frames\` (existing setting from PR #213).

## Read API

| Route | Filters | Window cap |
|---|---|---|
| \`GET /charge-points/{cp_id}/frames\` | \`direction\` (inbound / outbound), \`action\` (BootNotification / MeterValues / …) | 7-day (matches sibling routes) |
| \`GET /transactions/{transaction_id}/frames\` | none | none (transactions are already bounded) |

Both routes return the verbatim \`raw_payload\` JSON so disputes / fraud investigations can replay the exact bytes that were on the wire.

The tx-frames route falls back to \`frames=[]\` when no ClickHouse client is wired — same posture as the existing telemetry block on transaction-detail, so compose-smoke / unit-test apps don't 500.

## Tests

- 5 new ingestor tests (row extractor + transaction_id parser: present, absent, malformed JSON, wrong shape, non-numeric).
- 3 new read-client tests (placeholder shape + optional-filter passthrough + no-window tx lookup).
- 4 new per-cp route tests (full shape, filter passthrough, window cap, 404).
- 3 new tx-frames route tests (404, returns rows, limit passthrough).
- Migration-test counts bumped 4 → 5 to include the new DDL.
- **991 tests pass, 80.22% coverage gate cleared.**
- OpenAPI snapshot regenerated.

## Acceptance

- ✅ \`GET /api/v1/transactions/42/frames\` returns the full frame trace for the tx — both directions, ordered.
- ✅ \`GET /api/v1/charge-points/CP_X/frames?action=MeterValues&from=...&to=...\` scopes to MeterValues only.
- ✅ Malformed inbound frames don't crash the ingestor; the row is stored with \`transaction_id = NULL\`.

## Console-side follow-up

After this lands, the Console gets a small read-only proxy + an "OCPP Log" tab on the detail page reading from \`/charge-points/{cp_id}/frames\`, plus a "frames for this tx" expand on the Transactions list.

Refs #218