### PR TITLE
fix(audit): uptime endpoint 500s on DateTime64 columns under asynch driver

### DIFF
--- a/src/eveys_ocpp/clickhouse/read_client.py
+++ b/src/eveys_ocpp/clickhouse/read_client.py
@@ -718,21 +718,31 @@ class ClickHouseReadClient:
         # matches the returned total exactly. ClickHouse `greatest` /
         # `least` are nullable-safe over the window bounds (both
         # always set on this call path).
+        #
+        # `from_ts` / `to_ts` are explicitly cast to `DateTime64(3, 'UTC')`
+        # at every use site. The asynch driver renders Python `datetime`
+        # objects into the SQL as bare `'YYYY-MM-DD HH:MM:SS'` literals;
+        # against `DateTime64(3, 'UTC')` columns, that mismatch produces
+        # a server-side `Code 386 — no supertype for DateTime64 and String`
+        # error inside `greatest()` / `least()`. The other read methods
+        # (status-history etc.) get away without the cast because they
+        # only use `=` / `>=` / `<=` where ClickHouse coerces; the
+        # `greatest` / `least` paths in this aggregation don't.
         sql = """
             SELECT
-                greatest(went_offline_at, {from_ts}) AS clipped_offline_at,
-                least(came_online_at, {to_ts})       AS clipped_online_at,
+                greatest(went_offline_at, toDateTime64({from_ts}, 3, 'UTC')) AS clipped_offline_at,
+                least(came_online_at, toDateTime64({to_ts}, 3, 'UTC')) AS clipped_online_at,
                 toInt64(dateDiff(
                     'second',
-                    greatest(went_offline_at, {from_ts}),
-                    least(came_online_at, {to_ts})
-                ))                                   AS clipped_seconds,
-                offline_seconds                      AS original_offline_seconds,
+                    greatest(went_offline_at, toDateTime64({from_ts}, 3, 'UTC')),
+                    least(came_online_at, toDateTime64({to_ts}, 3, 'UTC'))
+                )) AS clipped_seconds,
+                offline_seconds AS original_offline_seconds,
                 prior_reason
             FROM cp_offline_duration
             WHERE cp_id = {cp_id}
-              AND came_online_at >= {from_ts}
-              AND went_offline_at <= {to_ts}
+              AND came_online_at >= toDateTime64({from_ts}, 3, 'UTC')
+              AND went_offline_at <= toDateTime64({to_ts}, 3, 'UTC')
             ORDER BY clipped_offline_at
         """
         params: dict[str, Any] = {

--- a/tests/unit/test_clickhouse_read_client.py
+++ b/tests/unit/test_clickhouse_read_client.py
@@ -300,6 +300,14 @@ async def test_fetch_uptime_for_cp_uses_asynch_placeholder_shape() -> None:
     assert "greatest(went_offline_at" in rendered
     assert "least(came_online_at" in rendered
     assert "dateDiff" in rendered
+    # Regression: `cp_offline_duration` columns are `DateTime64(3, 'UTC')`.
+    # asynch renders Python datetimes as bare `'YYYY-MM-DD HH:MM:SS'`
+    # literals; inside `greatest()` / `least()` ClickHouse refuses to
+    # find a supertype between `DateTime64` and `String` and 500s with
+    # Code 386. Every use of `from_ts` / `to_ts` must wrap with
+    # `toDateTime64(..., 3, 'UTC')`.
+    assert "toDateTime64(" in rendered
+    assert "3, 'UTC')" in rendered
     # asynch placeholder shape, not DB-API.
     assert "%(" not in rendered
 


### PR DESCRIPTION
## Summary

- `GET /api/v1/charge-points/{cp_id}/uptime` was returning HTTP 500 in any environment with a real ClickHouse — caught by local smoke-testing once #222 was deployed.
- ClickHouse error 386: no supertype between `DateTime64(3, 'UTC')` and the bare-string literal that `asynch` renders Python datetimes into.
- Mock-based tests passed because they never round-tripped through `escape_params`.

## Fix

Wrap every use of `from_ts` / `to_ts` in `fetch_uptime_for_cp` with `toDateTime64(..., 3, 'UTC')`. Test updated to assert the cast is present.

## Test plan

- [x] Affected unit tests pass (`test_fetch_uptime_for_cp_*`).
- [x] Live smoke-test against local gateway: `GET /api/v1/charge-points/cp_64ae7361/uptime?from=…&to=…` now returns HTTP 200 with `{uptime_pct: 100.0, ...}` (was 500).
- [x] Lint clean.

Refs #224