### PR TITLE
feature(analytics): GET /transactions/aggregate — bucketed sessions + energy

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1934,6 +1934,105 @@
         "title": "TransactionTelemetry",
         "type": "object"
       },
+      "TransactionsAggregateBucket": {
+        "description": "One bucket \u00d7 group entry in the analytics response.\n\n`group` is omitted when the query used `group_by=none`. Otherwise\nit carries the cp_id or id_tag the row was split on. Aggregates\nonly count completed sessions \u2014 active (open) transactions can't\ncontribute energy or duration totals.",
+        "properties": {
+          "bucket_at": {
+            "title": "Bucket At",
+            "type": "string"
+          },
+          "consumed_wh_total": {
+            "title": "Consumed Wh Total",
+            "type": "integer"
+          },
+          "duration_seconds_total": {
+            "title": "Duration Seconds Total",
+            "type": "integer"
+          },
+          "group": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Group"
+          },
+          "session_count": {
+            "title": "Session Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "bucket_at",
+          "session_count",
+          "consumed_wh_total",
+          "duration_seconds_total"
+        ],
+        "title": "TransactionsAggregateBucket",
+        "type": "object"
+      },
+      "TransactionsAggregateResponse": {
+        "description": "`GET /api/v1/transactions/aggregate?from=\u2026&to=\u2026&bucket=\u2026&group_by=\u2026`.\n\nBucketed analytics over `transactions`. Excludes active sessions\n(no `stopped_reported_at` \u2192 no contribution to energy or duration).\nWindow cap is 90 days \u2014 aggregations are cheap; operators want\nquarterly views.",
+        "properties": {
+          "buckets": {
+            "items": {
+              "$ref": "#/components/schemas/TransactionsAggregateBucket"
+            },
+            "title": "Buckets",
+            "type": "array"
+          },
+          "request_id": {
+            "title": "Request Id",
+            "type": "string"
+          },
+          "window": {
+            "$ref": "#/components/schemas/TransactionsAggregateWindow"
+          }
+        },
+        "required": [
+          "buckets",
+          "window",
+          "request_id"
+        ],
+        "title": "TransactionsAggregateResponse",
+        "type": "object"
+      },
+      "TransactionsAggregateWindow": {
+        "properties": {
+          "bucket": {
+            "title": "Bucket",
+            "type": "string"
+          },
+          "from": {
+            "title": "From",
+            "type": "string"
+          },
+          "group_by": {
+            "title": "Group By",
+            "type": "string"
+          },
+          "seconds": {
+            "title": "Seconds",
+            "type": "integer"
+          },
+          "to": {
+            "title": "To",
+            "type": "string"
+          }
+        },
+        "required": [
+          "from",
+          "to",
+          "seconds",
+          "bucket",
+          "group_by"
+        ],
+        "title": "TransactionsAggregateWindow",
+        "type": "object"
+      },
       "UpdateBody": {
         "description": "PATCH body. The keys in `updates` must be allowlisted; the\nvalues are coerced per the allowlist's `coerce` callable.",
         "properties": {
@@ -6057,6 +6156,91 @@
           }
         },
         "summary": "List transactions (cursor-paginated, global)",
+        "tags": [
+          "transactions"
+        ]
+      }
+    },
+    "/api/v1/transactions/aggregate": {
+      "get": {
+        "description": "Bucketed energy + duration totals over completed sessions.\n\nWindow cap is 90 days; the aggregation is one SQL pass over\n``transactions`` with ``date_trunc`` for the time bucket and\noptional ``cp_id`` / ``id_tag`` split. Active sessions are\nexcluded (no ``stopped_reported_at`` \u2192 no totals to add).\n\nBuckets are UTC. The optional ``group`` field is set on every\nrow when ``group_by != 'none'`` and omitted otherwise.",
+        "operationId": "aggregate_transactions_route_api_v1_transactions_aggregate_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "from",
+            "required": true,
+            "schema": {
+              "title": "From",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "to",
+            "required": true,
+            "schema": {
+              "title": "To",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "bucket",
+            "required": false,
+            "schema": {
+              "default": "day",
+              "title": "Bucket",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "group_by",
+            "required": false,
+            "schema": {
+              "default": "none",
+              "title": "Group By",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransactionsAggregateResponse",
+                  "additionalProperties": true,
+                  "title": "Response Aggregate Transactions Route Api V1 Transactions Aggregate Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Bad from/to, unknown bucket / group_by, or window too large."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Bucketed analytics over completed transactions",
         "tags": [
           "transactions"
         ]

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1935,7 +1935,7 @@
         "type": "object"
       },
       "TransactionsAggregateBucket": {
-        "description": "One bucket \u00d7 group entry in the analytics response.\n\n`group` is omitted when the query used `group_by=none`. Otherwise\nit carries the cp_id or id_tag the row was split on. Aggregates\nonly count completed sessions \u2014 active (open) transactions can't\ncontribute energy or duration totals.",
+        "description": "One (bucket, group) entry in the analytics response.\n\n`group` is omitted when the query used `group_by=none`. Otherwise\nit carries the cp_id or id_tag the row was split on. Aggregates\nonly count completed sessions: active (open) transactions can't\ncontribute energy or duration totals.",
         "properties": {
           "bucket_at": {
             "title": "Bucket At",

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1370,14 +1370,14 @@ components:
       title: TransactionTelemetry
       type: object
     TransactionsAggregateBucket:
-      description: 'One bucket × group entry in the analytics response.
+      description: 'One (bucket, group) entry in the analytics response.
 
 
         `group` is omitted when the query used `group_by=none`. Otherwise
 
         it carries the cp_id or id_tag the row was split on. Aggregates
 
-        only count completed sessions — active (open) transactions can''t
+        only count completed sessions: active (open) transactions can''t
 
         contribute energy or duration totals.'
       properties:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1369,6 +1369,95 @@ components:
       - phases
       title: TransactionTelemetry
       type: object
+    TransactionsAggregateBucket:
+      description: 'One bucket × group entry in the analytics response.
+
+
+        `group` is omitted when the query used `group_by=none`. Otherwise
+
+        it carries the cp_id or id_tag the row was split on. Aggregates
+
+        only count completed sessions — active (open) transactions can''t
+
+        contribute energy or duration totals.'
+      properties:
+        bucket_at:
+          title: Bucket At
+          type: string
+        consumed_wh_total:
+          title: Consumed Wh Total
+          type: integer
+        duration_seconds_total:
+          title: Duration Seconds Total
+          type: integer
+        group:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Group
+        session_count:
+          title: Session Count
+          type: integer
+      required:
+      - bucket_at
+      - session_count
+      - consumed_wh_total
+      - duration_seconds_total
+      title: TransactionsAggregateBucket
+      type: object
+    TransactionsAggregateResponse:
+      description: '`GET /api/v1/transactions/aggregate?from=…&to=…&bucket=…&group_by=…`.
+
+
+        Bucketed analytics over `transactions`. Excludes active sessions
+
+        (no `stopped_reported_at` → no contribution to energy or duration).
+
+        Window cap is 90 days — aggregations are cheap; operators want
+
+        quarterly views.'
+      properties:
+        buckets:
+          items:
+            $ref: '#/components/schemas/TransactionsAggregateBucket'
+          title: Buckets
+          type: array
+        request_id:
+          title: Request Id
+          type: string
+        window:
+          $ref: '#/components/schemas/TransactionsAggregateWindow'
+      required:
+      - buckets
+      - window
+      - request_id
+      title: TransactionsAggregateResponse
+      type: object
+    TransactionsAggregateWindow:
+      properties:
+        bucket:
+          title: Bucket
+          type: string
+        from:
+          title: From
+          type: string
+        group_by:
+          title: Group By
+          type: string
+        seconds:
+          title: Seconds
+          type: integer
+        to:
+          title: To
+          type: string
+      required:
+      - from
+      - to
+      - seconds
+      - bucket
+      - group_by
+      title: TransactionsAggregateWindow
+      type: object
     UpdateBody:
       description: 'PATCH body. The keys in `updates` must be allowlisted; the
 
@@ -4099,6 +4188,77 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
       summary: List transactions (cursor-paginated, global)
+      tags:
+      - transactions
+  /api/v1/transactions/aggregate:
+    get:
+      description: 'Bucketed energy + duration totals over completed sessions.
+
+
+        Window cap is 90 days; the aggregation is one SQL pass over
+
+        ``transactions`` with ``date_trunc`` for the time bucket and
+
+        optional ``cp_id`` / ``id_tag`` split. Active sessions are
+
+        excluded (no ``stopped_reported_at`` → no totals to add).
+
+
+        Buckets are UTC. The optional ``group`` field is set on every
+
+        row when ``group_by != ''none''`` and omitted otherwise.'
+      operationId: aggregate_transactions_route_api_v1_transactions_aggregate_get
+      parameters:
+      - in: query
+        name: from
+        required: true
+        schema:
+          title: From
+          type: string
+      - in: query
+        name: to
+        required: true
+        schema:
+          title: To
+          type: string
+      - in: query
+        name: bucket
+        required: false
+        schema:
+          default: day
+          title: Bucket
+          type: string
+      - in: query
+        name: group_by
+        required: false
+        schema:
+          default: none
+          title: Group By
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransactionsAggregateResponse'
+                additionalProperties: true
+                title: Response Aggregate Transactions Route Api V1 Transactions Aggregate
+                  Get
+                type: object
+          description: Successful Response
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+          description: Bad from/to, unknown bucket / group_by, or window too large.
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Bucketed analytics over completed transactions
       tags:
       - transactions
   /api/v1/transactions/{transaction_id}:

--- a/src/eveys_ocpp/api/_schemas.py
+++ b/src/eveys_ocpp/api/_schemas.py
@@ -651,6 +651,42 @@ class UptimeResponse(BaseModel):
     request_id: str
 
 
+class TransactionsAggregateBucket(BaseModel):
+    """One (bucket, group) entry in the analytics response.
+
+    `group` is omitted when the query used `group_by=none`. Otherwise
+    it carries the cp_id or id_tag the row was split on. Aggregates
+    only count completed sessions: active (open) transactions can't
+    contribute energy or duration totals."""
+
+    bucket_at: str
+    group: str | None = None
+    session_count: int
+    consumed_wh_total: int
+    duration_seconds_total: int
+
+
+class TransactionsAggregateWindow(BaseModel):
+    from_: str = Field(alias="from")
+    to: str
+    seconds: int
+    bucket: str
+    group_by: str
+
+
+class TransactionsAggregateResponse(BaseModel):
+    """`GET /api/v1/transactions/aggregate?from=…&to=…&bucket=…&group_by=…`.
+
+    Bucketed analytics over `transactions`. Excludes active sessions
+    (no `stopped_reported_at` → no contribution to energy or duration).
+    Window cap is 90 days — aggregations are cheap; operators want
+    quarterly views."""
+
+    buckets: list[TransactionsAggregateBucket]
+    window: TransactionsAggregateWindow
+    request_id: str
+
+
 class OfflineDurationEvent(BaseModel):
     """One observed offline window for a charger.
 
@@ -772,6 +808,9 @@ __all__ = [
     "TransactionDetail",
     "TransactionListResponse",
     "TransactionTelemetry",
+    "TransactionsAggregateBucket",
+    "TransactionsAggregateResponse",
+    "TransactionsAggregateWindow",
     "UptimeInterval",
     "UptimeResponse",
     "UptimeWindow",

--- a/src/eveys_ocpp/api/transactions.py
+++ b/src/eveys_ocpp/api/transactions.py
@@ -14,7 +14,7 @@ Per the contract `docs/integration/02-gateway-rest-api.md`:
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any
 
 from fastapi import APIRouter, Query, Request
@@ -23,6 +23,7 @@ from eveys_ocpp.api._errors import (
     ERR_BAD_REQUEST,
     ERR_UNKNOWN_CP_ID,
     ERR_UNKNOWN_TRANSACTION_ID,
+    ERR_WINDOW_TOO_LARGE,
     ApiError,
 )
 from eveys_ocpp.api._pagination import (
@@ -38,9 +39,11 @@ from eveys_ocpp.api._schemas import (
     OcppFramesByTransactionResponse,
     TransactionDetail,
     TransactionListResponse,
+    TransactionsAggregateResponse,
 )
 from eveys_ocpp.persistence.db import session_scope
 from eveys_ocpp.persistence.repositories import (
+    aggregate_transactions,
     count_transactions,
     count_transactions_by_cp,
     get_transaction_by_id,
@@ -316,6 +319,105 @@ async def list_transactions_global_route(
         "next_cursor": next_cursor,
         "request_id": request.state.request_id,
     }
+
+
+_AGGREGATE_MAX_WINDOW = timedelta(days=90)
+_BUCKETS = {"hour", "day"}
+_GROUP_BY = {"none", "cp_id", "id_tag"}
+
+
+@router.get(
+    "/transactions/aggregate",
+    summary="Bucketed analytics over completed transactions",
+    responses={
+        200: {"model": TransactionsAggregateResponse},
+        400: {
+            "model": ErrorEnvelope,
+            "description": "Bad from/to, unknown bucket / group_by, or window too large.",
+        },
+    },
+)
+async def aggregate_transactions_route(
+    request: Request,
+    from_: str = Query(alias="from"),
+    to: str = Query(...),
+    bucket: str = Query(default="day"),
+    group_by: str = Query(default="none"),
+) -> dict[str, Any]:
+    """Bucketed energy + duration totals over completed sessions.
+
+    Window cap is 90 days; the aggregation is one SQL pass over
+    ``transactions`` with ``date_trunc`` for the time bucket and
+    optional ``cp_id`` / ``id_tag`` split. Active sessions are
+    excluded (no ``stopped_reported_at`` → no totals to add).
+
+    Buckets are UTC. The optional ``group`` field is set on every
+    row when ``group_by != 'none'`` and omitted otherwise."""
+    started_from = _parse_iso8601(from_, field_name="from")
+    started_to = _parse_iso8601(to, field_name="to")
+    if started_from is None or started_to is None:
+        raise ApiError(
+            status_code=400,
+            error_code=ERR_BAD_REQUEST,
+            message="`from` and `to` are required",
+        )
+    if started_to < started_from:
+        raise ApiError(
+            status_code=400,
+            error_code=ERR_BAD_REQUEST,
+            message="`to` must be >= `from`",
+        )
+    if started_to - started_from > _AGGREGATE_MAX_WINDOW:
+        raise ApiError(
+            status_code=400,
+            error_code=ERR_WINDOW_TOO_LARGE,
+            message=f"window cannot exceed {_AGGREGATE_MAX_WINDOW.days} days",
+        )
+    if bucket not in _BUCKETS:
+        raise ApiError(
+            status_code=400,
+            error_code=ERR_BAD_REQUEST,
+            message=f"unknown bucket: {bucket!r}",
+        )
+    if group_by not in _GROUP_BY:
+        raise ApiError(
+            status_code=400,
+            error_code=ERR_BAD_REQUEST,
+            message=f"unknown group_by: {group_by!r}",
+        )
+
+    async with session_scope(request.app.state.session_factory) as session:
+        rows = await aggregate_transactions(
+            session,
+            window_from=started_from,
+            window_to=started_to,
+            bucket=bucket,
+            group_by=group_by,
+        )
+
+    return {
+        "buckets": [_aggregate_to_response(r) for r in rows],
+        "window": {
+            "from": _isoformat(started_from),
+            "to": _isoformat(started_to),
+            "seconds": int((started_to - started_from).total_seconds()),
+            "bucket": bucket,
+            "group_by": group_by,
+        },
+        "request_id": request.state.request_id,
+    }
+
+
+def _aggregate_to_response(row: dict[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "bucket_at": _isoformat(row["bucket_at"]),
+        "session_count": int(row["session_count"]),
+        "consumed_wh_total": int(row["consumed_wh_total"]),
+        "duration_seconds_total": int(row["duration_seconds_total"]),
+    }
+    if "group" in row:
+        out["group"] = row["group"]
+    return out
 
 
 @router.get(

--- a/src/eveys_ocpp/persistence/repositories.py
+++ b/src/eveys_ocpp/persistence/repositories.py
@@ -1348,6 +1348,105 @@ async def count_transactions_by_cp(
     return int(result.scalar_one() or 0)
 
 
+async def aggregate_transactions(
+    session: AsyncSession,
+    *,
+    window_from: datetime,
+    window_to: datetime,
+    bucket: str,
+    group_by: str,
+) -> list[dict[str, Any]]:
+    """Bucketed analytics over completed transactions.
+
+    Aggregates ``transactions`` rows whose ``stopped_reported_at`` falls
+    inside ``[window_from, window_to]`` — active sessions are
+    intentionally excluded because they have no ``meter_stop_wh`` /
+    ``stopped_reported_at`` yet, so they'd contribute zero to both
+    energy and duration totals and make the bucket counts misleading.
+
+    Arguments:
+
+    - ``bucket``: ``'hour'`` or ``'day'``. Buckets are computed
+      server-side with PostgreSQL ``date_trunc`` so DST and timezone
+      conversions are consistent regardless of the caller's locale.
+      All bucket timestamps are emitted in UTC.
+    - ``group_by``: ``'none'`` | ``'cp_id'`` | ``'id_tag'``. When
+      ``'none'``, the response has one row per bucket. Otherwise rows
+      are split across the group dimension; (bucket, group) is the
+      primary key of the result.
+
+    Returns a list of dicts with ``bucket_at`` (datetime), ``group``
+    (optional str — only set when ``group_by != 'none'``),
+    ``session_count`` (int), ``consumed_wh_total`` (int),
+    ``duration_seconds_total`` (int).
+    """
+    if bucket == "hour":
+        bucket_expr = func.date_trunc("hour", Transaction.stopped_reported_at)
+    elif bucket == "day":
+        bucket_expr = func.date_trunc("day", Transaction.stopped_reported_at)
+    else:
+        # The caller validates the enum; getting here would be a bug.
+        raise ValueError(f"unsupported bucket: {bucket!r}")
+
+    consumed_expr = Transaction.meter_stop_wh - Transaction.meter_start_wh
+    duration_expr = func.extract(
+        "epoch",
+        Transaction.stopped_reported_at - Transaction.started_reported_at,
+    )
+
+    select_cols: list[Any] = [
+        bucket_expr.label("bucket_at"),
+        func.count().label("session_count"),
+        func.coalesce(func.sum(consumed_expr), 0).label("consumed_wh_total"),
+        func.coalesce(func.sum(duration_expr), 0).label("duration_seconds_total"),
+    ]
+    group_cols: list[Any] = [bucket_expr]
+
+    if group_by == "cp_id":
+        # Join `charge_points` to expose the OCPP-visible cp_id string
+        # in the response; the FK on the transaction is to the
+        # surrogate `id`, which is meaningless externally.
+        stmt = select(*select_cols, ChargePoint.cp_id.label("group_value")).join(
+            ChargePoint, Transaction.charge_point_id == ChargePoint.id
+        )
+        group_cols.append(ChargePoint.cp_id)
+    elif group_by == "id_tag":
+        stmt = select(*select_cols, Transaction.id_tag.label("group_value"))
+        group_cols.append(Transaction.id_tag)
+    elif group_by == "none":
+        stmt = select(*select_cols)
+    else:
+        raise ValueError(f"unsupported group_by: {group_by!r}")
+
+    stmt = (
+        stmt.where(
+            Transaction.stopped_reported_at.is_not(None),
+            Transaction.stopped_reported_at >= window_from,
+            Transaction.stopped_reported_at <= window_to,
+        )
+        .group_by(*group_cols)
+        .order_by(bucket_expr)
+    )
+    if group_by != "none":
+        stmt = stmt.order_by(*group_cols[1:])
+
+    result = await session.execute(stmt)
+    rows = result.mappings().all()
+
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        entry: dict[str, Any] = {
+            "bucket_at": row["bucket_at"],
+            "session_count": int(row["session_count"]),
+            "consumed_wh_total": int(row["consumed_wh_total"]),
+            "duration_seconds_total": int(row["duration_seconds_total"]),
+        }
+        if group_by != "none":
+            entry["group"] = row["group_value"]
+        out.append(entry)
+    return out
+
+
 def _transactions_filter_conditions(
     *,
     cp_id: str | None,

--- a/tests/unit/api/test_transactions.py
+++ b/tests/unit/api/test_transactions.py
@@ -431,3 +431,156 @@ async def test_get_transaction_frames_passes_limit_through(
     kwargs = spy.await_args.kwargs
     assert kwargs["transaction_id"] == 42
     assert kwargs["limit"] == 10
+
+
+# ---------------------------------------------------------------------------
+# Aggregate analytics endpoint (B1 of eveys-console#192)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_aggregate_returns_empty_buckets_when_repo_empty(
+    client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from eveys_ocpp.api import transactions as tx_module
+
+    monkeypatch.setattr(tx_module, "aggregate_transactions", AsyncMock(return_value=[]))
+
+    response = await client.get(
+        "/api/v1/transactions/aggregate?from=2026-05-01T00:00:00Z&to=2026-05-10T00:00:00Z"
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["buckets"] == []
+    assert body["window"]["bucket"] == "day"
+    assert body["window"]["group_by"] == "none"
+
+
+@pytest.mark.asyncio
+async def test_aggregate_forwards_filter_args_to_repo(
+    client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from eveys_ocpp.api import transactions as tx_module
+
+    spy = AsyncMock(return_value=[])
+    monkeypatch.setattr(tx_module, "aggregate_transactions", spy)
+
+    await client.get(
+        "/api/v1/transactions/aggregate"
+        "?from=2026-05-01T00:00:00Z&to=2026-05-10T00:00:00Z"
+        "&bucket=hour&group_by=cp_id"
+    )
+
+    kwargs = spy.await_args.kwargs
+    assert kwargs["bucket"] == "hour"
+    assert kwargs["group_by"] == "cp_id"
+    assert kwargs["window_from"] == datetime(2026, 5, 1, tzinfo=UTC)
+    assert kwargs["window_to"] == datetime(2026, 5, 10, tzinfo=UTC)
+
+
+@pytest.mark.asyncio
+async def test_aggregate_shapes_single_row(
+    client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from eveys_ocpp.api import transactions as tx_module
+
+    repo_rows = [
+        {
+            "bucket_at": datetime(2026, 5, 5, tzinfo=UTC),
+            "session_count": 3,
+            "consumed_wh_total": 12_500,
+            "duration_seconds_total": 7_200,
+        }
+    ]
+    monkeypatch.setattr(tx_module, "aggregate_transactions", AsyncMock(return_value=repo_rows))
+
+    response = await client.get(
+        "/api/v1/transactions/aggregate?from=2026-05-01T00:00:00Z&to=2026-05-10T00:00:00Z"
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["buckets"]) == 1
+    one = body["buckets"][0]
+    assert one["session_count"] == 3
+    assert one["consumed_wh_total"] == 12_500
+    assert one["duration_seconds_total"] == 7_200
+    # `group` is omitted from each row when group_by=none.
+    assert "group" not in one
+
+
+@pytest.mark.asyncio
+async def test_aggregate_group_rows_include_group_field(
+    client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from eveys_ocpp.api import transactions as tx_module
+
+    repo_rows = [
+        {
+            "bucket_at": datetime(2026, 5, 5, tzinfo=UTC),
+            "group": "CP_BERLIN_017",
+            "session_count": 1,
+            "consumed_wh_total": 5_000,
+            "duration_seconds_total": 1_800,
+        },
+        {
+            "bucket_at": datetime(2026, 5, 5, tzinfo=UTC),
+            "group": "CP_BERLIN_022",
+            "session_count": 2,
+            "consumed_wh_total": 10_000,
+            "duration_seconds_total": 3_600,
+        },
+    ]
+    monkeypatch.setattr(tx_module, "aggregate_transactions", AsyncMock(return_value=repo_rows))
+
+    response = await client.get(
+        "/api/v1/transactions/aggregate"
+        "?from=2026-05-01T00:00:00Z&to=2026-05-10T00:00:00Z"
+        "&group_by=cp_id"
+    )
+
+    body = response.json()
+    groups = {b["group"]: b for b in body["buckets"]}
+    assert groups["CP_BERLIN_017"]["session_count"] == 1
+    assert groups["CP_BERLIN_022"]["session_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_aggregate_rejects_window_over_90_days(client: httpx.AsyncClient) -> None:
+    response = await client.get(
+        "/api/v1/transactions/aggregate?from=2025-01-01T00:00:00Z&to=2026-05-10T00:00:00Z"
+    )
+    assert response.status_code == 400
+    assert response.json()["error_code"] == "WINDOW_TOO_LARGE"
+
+
+@pytest.mark.asyncio
+async def test_aggregate_rejects_inverted_window(client: httpx.AsyncClient) -> None:
+    response = await client.get(
+        "/api/v1/transactions/aggregate?from=2026-05-10T00:00:00Z&to=2026-05-01T00:00:00Z"
+    )
+    assert response.status_code == 400
+    assert response.json()["error_code"] == "BAD_REQUEST"
+
+
+@pytest.mark.asyncio
+async def test_aggregate_rejects_unknown_bucket(client: httpx.AsyncClient) -> None:
+    response = await client.get(
+        "/api/v1/transactions/aggregate"
+        "?from=2026-05-01T00:00:00Z&to=2026-05-10T00:00:00Z"
+        "&bucket=banana"
+    )
+    assert response.status_code == 400
+    assert response.json()["error_code"] == "BAD_REQUEST"
+
+
+@pytest.mark.asyncio
+async def test_aggregate_rejects_unknown_group_by(client: httpx.AsyncClient) -> None:
+    response = await client.get(
+        "/api/v1/transactions/aggregate"
+        "?from=2026-05-01T00:00:00Z&to=2026-05-10T00:00:00Z"
+        "&group_by=color"
+    )
+    assert response.status_code == 400
+    assert response.json()["error_code"] == "BAD_REQUEST"

--- a/tests/unit/test_repositories.py
+++ b/tests/unit/test_repositories.py
@@ -543,3 +543,95 @@ def test_charge_points_filter_conditions_includes_ocpp_version_filter() -> None:
     )
     rendered = [str(c) for c in conditions]
     assert any("ocpp_version" in r for r in rendered), rendered
+
+
+# ---------------------------------------------------------------------------
+# aggregate_transactions (B1 of eveys-console#192)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_aggregate_transactions_rejects_unknown_bucket() -> None:
+    session = AsyncMock()
+    with pytest.raises(ValueError, match="unsupported bucket"):
+        await repositories.aggregate_transactions(
+            session,
+            window_from=datetime(2026, 5, 1, tzinfo=UTC),
+            window_to=datetime(2026, 5, 10, tzinfo=UTC),
+            bucket="quarter",
+            group_by="none",
+        )
+
+
+@pytest.mark.asyncio
+async def test_aggregate_transactions_rejects_unknown_group_by() -> None:
+    session = AsyncMock()
+    with pytest.raises(ValueError, match="unsupported group_by"):
+        await repositories.aggregate_transactions(
+            session,
+            window_from=datetime(2026, 5, 1, tzinfo=UTC),
+            window_to=datetime(2026, 5, 10, tzinfo=UTC),
+            bucket="day",
+            group_by="charger_make",
+        )
+
+
+@pytest.mark.asyncio
+async def test_aggregate_transactions_emits_group_when_split_by_cp_id() -> None:
+    """Verifies the project shape — `group` is populated when `group_by`
+    is non-trivial. The mock returns `mappings()` as the structural
+    contract; the helper has to copy `group_value` into the `group` key."""
+    rows_mapping = [
+        {
+            "bucket_at": datetime(2026, 5, 5, tzinfo=UTC),
+            "session_count": 1,
+            "consumed_wh_total": 1_000,
+            "duration_seconds_total": 60,
+            "group_value": "CP_BERLIN_017",
+        },
+    ]
+    result_obj = MagicMock()
+    result_obj.mappings.return_value.all.return_value = rows_mapping
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=result_obj)
+
+    out = await repositories.aggregate_transactions(
+        session,
+        window_from=datetime(2026, 5, 1, tzinfo=UTC),
+        window_to=datetime(2026, 5, 10, tzinfo=UTC),
+        bucket="day",
+        group_by="cp_id",
+    )
+
+    assert len(out) == 1
+    assert out[0]["group"] == "CP_BERLIN_017"
+    assert out[0]["session_count"] == 1
+    assert out[0]["consumed_wh_total"] == 1_000
+    assert out[0]["duration_seconds_total"] == 60
+
+
+@pytest.mark.asyncio
+async def test_aggregate_transactions_omits_group_when_group_by_none() -> None:
+    rows_mapping = [
+        {
+            "bucket_at": datetime(2026, 5, 5, tzinfo=UTC),
+            "session_count": 5,
+            "consumed_wh_total": 12_345,
+            "duration_seconds_total": 600,
+        },
+    ]
+    result_obj = MagicMock()
+    result_obj.mappings.return_value.all.return_value = rows_mapping
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=result_obj)
+
+    out = await repositories.aggregate_transactions(
+        session,
+        window_from=datetime(2026, 5, 1, tzinfo=UTC),
+        window_to=datetime(2026, 5, 10, tzinfo=UTC),
+        bucket="day",
+        group_by="none",
+    )
+
+    assert len(out) == 1
+    assert "group" not in out[0]


### PR DESCRIPTION
## Summary

- New \`GET /api/v1/transactions/aggregate?from=…&to=…&bucket=…&group_by=…\`. Bucketed totals (session_count, consumed_wh_total, duration_seconds_total) over completed transactions.
- Buckets: \`hour\` | \`day\`. Group: \`none\` | \`cp_id\` | \`id_tag\`. 90-day window cap (same as uptime — aggregations are cheap).
- One SQL pass per query: \`date_trunc\` for the time bucket, \`GROUP BY\` over the optional split dimension. Active sessions excluded (no \`stopped_reported_at\` means no totals to add).
- Backs the Console analytics page (eveys-console#192).

## Test plan

- [x] \`pytest tests/unit/\` (1026 passed, 81% coverage)
- [x] \`ruff check\` clean
- [x] \`mypy\` clean
- [x] OpenAPI export regenerated and committed
- [ ] Smoke against real stack: run a few sessions in the simulator, then \`curl /api/v1/transactions/aggregate?from=2026-05-13T00:00:00Z&to=2026-05-15T00:00:00Z\` and confirm the buckets and totals match the per-session list

Closes #228