### PR TITLE
fix(transactions): wire shape — open/started_at/stopped_at aliases, newest-first list, SoC delta

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1311,7 +1311,7 @@
         "type": "object"
       },
       "PhaseSnapshot": {
-        "description": "Most-recent per-phase electrical snapshot for one transaction.\n\n`argMax(value, occurred_at)` per measurand on the named phase\n(`L1`, `L2`, `L3`). Each field is `null` when the charger never\nreported that measurand on that phase \u2014 single-phase chargers\npopulate only one phase, DC chargers may populate none.",
+        "description": "Most-recent per-phase electrical snapshot for one transaction.\n\n`argMax(value, occurred_at)` per measurand on the named phase\n(`L1`, `L2`, `L3`). Each field is `null` when the charger never\nreported that measurand on that phase \u2014 single-phase chargers\npopulate only one phase, DC chargers may populate none.\n\n`power_factor` is null today (the ingestor doesn't surface it yet)\nbut is part of the contract so UI consumers can render the column\nwithout a schema change later.",
         "properties": {
           "current_a": {
             "anyOf": [
@@ -1324,7 +1324,7 @@
             ],
             "title": "Current A"
           },
-          "last_at": {
+          "occurred_at": {
             "anyOf": [
               {
                 "type": "string"
@@ -1334,7 +1334,18 @@
               }
             ],
             "description": "ISO 8601 timestamp of the most recent sample on this phase.",
-            "title": "Last At"
+            "title": "Occurred At"
+          },
+          "power_factor": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Power Factor"
           },
           "power_w": {
             "anyOf": [
@@ -1502,21 +1513,9 @@
         "type": "object"
       },
       "SocSummary": {
-        "description": "State-of-charge summary for one transaction.\n\n`start_pct` is the earliest SoC sample inside the transaction's\nwindow; `last_pct` is the most recent. For a stopped transaction,\n`last_pct` is effectively the SoC at stop. Any field is `null`\nwhen the charger never reported SoC.",
+        "description": "State-of-charge summary for one transaction.\n\n`start` is the earliest SoC sample inside the transaction's\nwindow; `last` is the most recent. `delta = last - start` when\nboth ends are populated, else `null`. For a stopped transaction,\n`last` is effectively the SoC at stop. Any field is `null` when\nthe charger never reported SoC.",
         "properties": {
-          "last_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "ISO 8601 timestamp of the most recent SoC sample.",
-            "title": "Last At"
-          },
-          "last_pct": {
+          "delta": {
             "anyOf": [
               {
                 "type": "number"
@@ -1525,9 +1524,10 @@
                 "type": "null"
               }
             ],
-            "title": "Last Pct"
+            "description": "`last - start` when both bounds are populated; null otherwise.",
+            "title": "Delta"
           },
-          "start_pct": {
+          "last": {
             "anyOf": [
               {
                 "type": "number"
@@ -1536,7 +1536,18 @@
                 "type": "null"
               }
             ],
-            "title": "Start Pct"
+            "title": "Last"
+          },
+          "start": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start"
           }
         },
         "title": "SocSummary",
@@ -1732,27 +1743,27 @@
             "phases": {
               "L1": {
                 "current_a": 14.8,
-                "last_at": "2026-05-07T12:29:58+00:00",
+                "occurred_at": "2026-05-07T12:29:58+00:00",
                 "power_w": 3417.3,
                 "voltage_v": 231.4
               },
               "L2": {
                 "current_a": 14.6,
-                "last_at": "2026-05-07T12:29:58+00:00",
+                "occurred_at": "2026-05-07T12:29:58+00:00",
                 "power_w": 3370.5,
                 "voltage_v": 230.9
               },
               "L3": {
                 "current_a": 14.7,
-                "last_at": "2026-05-07T12:29:58+00:00",
+                "occurred_at": "2026-05-07T12:29:58+00:00",
                 "power_w": 3393.0,
                 "voltage_v": 231.1
               }
             },
             "soc": {
-              "last_at": "2026-05-07T12:29:58+00:00",
-              "last_pct": 81.0,
-              "start_pct": 38.0
+              "delta": 43.0,
+              "last": 81.0,
+              "start": 38.0
             }
           },
           "transaction_id": 12345

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -947,19 +947,31 @@ components:
 
         reported that measurand on that phase — single-phase chargers
 
-        populate only one phase, DC chargers may populate none.'
+        populate only one phase, DC chargers may populate none.
+
+
+        `power_factor` is null today (the ingestor doesn''t surface it yet)
+
+        but is part of the contract so UI consumers can render the column
+
+        without a schema change later.'
       properties:
         current_a:
           anyOf:
           - type: number
           - type: 'null'
           title: Current A
-        last_at:
+        occurred_at:
           anyOf:
           - type: string
           - type: 'null'
           description: ISO 8601 timestamp of the most recent sample on this phase.
-          title: Last At
+          title: Occurred At
+        power_factor:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Power Factor
         power_w:
           anyOf:
           - type: number
@@ -1069,30 +1081,32 @@ components:
       description: 'State-of-charge summary for one transaction.
 
 
-        `start_pct` is the earliest SoC sample inside the transaction''s
+        `start` is the earliest SoC sample inside the transaction''s
 
-        window; `last_pct` is the most recent. For a stopped transaction,
+        window; `last` is the most recent. `delta = last - start` when
 
-        `last_pct` is effectively the SoC at stop. Any field is `null`
+        both ends are populated, else `null`. For a stopped transaction,
 
-        when the charger never reported SoC.'
+        `last` is effectively the SoC at stop. Any field is `null` when
+
+        the charger never reported SoC.'
       properties:
-        last_at:
-          anyOf:
-          - type: string
-          - type: 'null'
-          description: ISO 8601 timestamp of the most recent SoC sample.
-          title: Last At
-        last_pct:
+        delta:
           anyOf:
           - type: number
           - type: 'null'
-          title: Last Pct
-        start_pct:
+          description: '`last - start` when both bounds are populated; null otherwise.'
+          title: Delta
+        last:
           anyOf:
           - type: number
           - type: 'null'
-          title: Start Pct
+          title: Last
+        start:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Start
       title: SocSummary
       type: object
     StatusEvent:
@@ -1220,23 +1234,23 @@ components:
           phases:
             L1:
               current_a: 14.8
-              last_at: '2026-05-07T12:29:58+00:00'
+              occurred_at: '2026-05-07T12:29:58+00:00'
               power_w: 3417.3
               voltage_v: 231.4
             L2:
               current_a: 14.6
-              last_at: '2026-05-07T12:29:58+00:00'
+              occurred_at: '2026-05-07T12:29:58+00:00'
               power_w: 3370.5
               voltage_v: 230.9
             L3:
               current_a: 14.7
-              last_at: '2026-05-07T12:29:58+00:00'
+              occurred_at: '2026-05-07T12:29:58+00:00'
               power_w: 3393.0
               voltage_v: 231.1
           soc:
-            last_at: '2026-05-07T12:29:58+00:00'
-            last_pct: 81.0
-            start_pct: 38.0
+            delta: 43.0
+            last: 81.0
+            start: 38.0
         transaction_id: 12345
       properties:
         connector_id:

--- a/src/eveys_ocpp/api/_schemas.py
+++ b/src/eveys_ocpp/api/_schemas.py
@@ -340,16 +340,17 @@ class ChargePointListResponse(BaseModel):
 class SocSummary(BaseModel):
     """State-of-charge summary for one transaction.
 
-    `start_pct` is the earliest SoC sample inside the transaction's
-    window; `last_pct` is the most recent. For a stopped transaction,
-    `last_pct` is effectively the SoC at stop. Any field is `null`
-    when the charger never reported SoC."""
+    `start` is the earliest SoC sample inside the transaction's
+    window; `last` is the most recent. `delta = last - start` when
+    both ends are populated, else `null`. For a stopped transaction,
+    `last` is effectively the SoC at stop. Any field is `null` when
+    the charger never reported SoC."""
 
-    start_pct: float | None = None
-    last_pct: float | None = None
-    last_at: str | None = Field(
+    start: float | None = None
+    last: float | None = None
+    delta: float | None = Field(
         default=None,
-        description="ISO 8601 timestamp of the most recent SoC sample.",
+        description="`last - start` when both bounds are populated; null otherwise.",
     )
 
 
@@ -359,12 +360,17 @@ class PhaseSnapshot(BaseModel):
     `argMax(value, occurred_at)` per measurand on the named phase
     (`L1`, `L2`, `L3`). Each field is `null` when the charger never
     reported that measurand on that phase — single-phase chargers
-    populate only one phase, DC chargers may populate none."""
+    populate only one phase, DC chargers may populate none.
+
+    `power_factor` is null today (the ingestor doesn't surface it yet)
+    but is part of the contract so UI consumers can render the column
+    without a schema change later."""
 
     voltage_v: float | None = None
     current_a: float | None = None
     power_w: float | None = None
-    last_at: str | None = Field(
+    power_factor: float | None = None
+    occurred_at: str | None = Field(
         default=None,
         description="ISO 8601 timestamp of the most recent sample on this phase.",
     )
@@ -426,29 +432,28 @@ class TransactionDetail(Transaction):
                 "stop_reason": "Local",
                 "open": False,
                 "telemetry": {
-                    "soc": {
-                        "start_pct": 38.0,
-                        "last_pct": 81.0,
-                        "last_at": "2026-05-07T12:29:58+00:00",
-                    },
+                    "soc": {"start": 38.0, "last": 81.0, "delta": 43.0},
                     "phases": {
                         "L1": {
                             "voltage_v": 231.4,
                             "current_a": 14.8,
                             "power_w": 3417.3,
-                            "last_at": "2026-05-07T12:29:58+00:00",
+                            "power_factor": None,
+                            "occurred_at": "2026-05-07T12:29:58+00:00",
                         },
                         "L2": {
                             "voltage_v": 230.9,
                             "current_a": 14.6,
                             "power_w": 3370.5,
-                            "last_at": "2026-05-07T12:29:58+00:00",
+                            "power_factor": None,
+                            "occurred_at": "2026-05-07T12:29:58+00:00",
                         },
                         "L3": {
                             "voltage_v": 231.1,
                             "current_a": 14.7,
                             "power_w": 3393.0,
-                            "last_at": "2026-05-07T12:29:58+00:00",
+                            "power_factor": None,
+                            "occurred_at": "2026-05-07T12:29:58+00:00",
                         },
                     },
                 },

--- a/src/eveys_ocpp/api/transactions.py
+++ b/src/eveys_ocpp/api/transactions.py
@@ -72,7 +72,16 @@ def _parse_iso8601(value: str | None, *, field_name: str) -> datetime | None:
 
 
 def _transaction_to_response(tx: dict[str, Any]) -> dict[str, Any]:
-    """Wire shape — drop the internal surrogate `id`, format datetimes."""
+    """Wire shape — drop the internal surrogate `id`, format datetimes.
+
+    Emits both the precise `*_reported_at` / `*_received_at` pair and the
+    convenience aliases `started_at` / `stopped_at` (pointing at the
+    `_reported_at` value — the charger's wall clock, which is what UIs
+    render). The `open` flag is `True` while `stopped_reported_at` is
+    null so callers don't have to recompute it.
+    """
+    started_reported = _isoformat(tx["started_reported_at"])
+    stopped_reported = _isoformat(tx["stopped_reported_at"])
     return {
         "transaction_id": tx["transaction_id"],
         "cp_id": tx.get("cp_id"),  # filled by route when needed
@@ -81,11 +90,18 @@ def _transaction_to_response(tx: dict[str, Any]) -> dict[str, Any]:
         "meter_start_wh": tx["meter_start_wh"],
         "meter_stop_wh": tx["meter_stop_wh"],
         "consumed_wh": tx["consumed_wh"],
-        "started_reported_at": _isoformat(tx["started_reported_at"]),
+        "started_reported_at": started_reported,
         "started_received_at": _isoformat(tx["started_received_at"]),
-        "stopped_reported_at": _isoformat(tx["stopped_reported_at"]),
+        "stopped_reported_at": stopped_reported,
         "stopped_received_at": _isoformat(tx["stopped_received_at"]),
         "stop_reason": tx["stop_reason"],
+        # Convenience aliases for UI consumers — `started_at` /
+        # `stopped_at` are the charger-reported timestamps a human-
+        # facing view actually wants, and `open` is the boolean form
+        # of "this session hasn't stopped yet."
+        "started_at": started_reported,
+        "stopped_at": stopped_reported,
+        "open": tx["stopped_reported_at"] is None,
     }
 
 
@@ -523,12 +539,35 @@ async def _telemetry_for(request: Request, tx: dict[str, Any]) -> dict[str, Any]
 
     Compose-smoke and unit-test apps run without ClickHouse; surface
     `telemetry: null` in those environments rather than 500ing on a
-    detail call."""
+    detail call.
+
+    Shapes the CH client's internal field names into the wire form
+    consumed by the UI:
+      `soc.start_pct` → `soc.start`, `soc.last_pct` → `soc.last`,
+      plus a derived `soc.delta = last - start`.
+      Per-phase `last_at` → `occurred_at`, plus a null `power_factor`
+      column so the UI's PhaseSnapshot type has every field present.
+    """
     ch_client = getattr(request.app.state, "ch_client", None)
     if ch_client is None:
         return None
-    result: dict[str, Any] = await ch_client.fetch_transaction_telemetry(
+    raw: dict[str, Any] = await ch_client.fetch_transaction_telemetry(
         cp_id=tx["cp_id"],
         transaction_id=tx["transaction_id"],
     )
-    return result
+    raw_soc = raw.get("soc") or {}
+    start = raw_soc.get("start_pct")
+    last = raw_soc.get("last_pct")
+    delta: float | None = (last - start) if start is not None and last is not None else None
+    soc = {"start": start, "last": last, "delta": delta}
+
+    phases: dict[str, dict[str, Any]] = {}
+    for phase, snap in (raw.get("phases") or {}).items():
+        phases[phase] = {
+            "voltage_v": snap.get("voltage_v"),
+            "current_a": snap.get("current_a"),
+            "power_w": snap.get("power_w"),
+            "power_factor": snap.get("power_factor"),
+            "occurred_at": snap.get("last_at"),
+        }
+    return {"soc": soc, "phases": phases}

--- a/src/eveys_ocpp/persistence/repositories.py
+++ b/src/eveys_ocpp/persistence/repositories.py
@@ -1299,12 +1299,13 @@ async def list_transactions_by_cp(
         min_consumed_wh=min_consumed_wh,
         max_consumed_wh=max_consumed_wh,
     )
-    stmt = select(Transaction).where(and_(*conditions)).order_by(Transaction.id)
+    # Newest-first; see `list_transactions` for the rationale.
+    stmt = select(Transaction).where(and_(*conditions)).order_by(Transaction.id.desc())
     if offset is not None:
         stmt = stmt.offset(offset).limit(limit)
     else:
         if after_id is not None:
-            stmt = stmt.where(Transaction.id > after_id)
+            stmt = stmt.where(Transaction.id < after_id)
         stmt = stmt.limit(limit + 1)
     result = await session.execute(stmt)
     return [_transaction_to_dict(tx) for tx in result.scalars().all()]
@@ -1547,12 +1548,18 @@ async def list_transactions(
     )
     if conditions:
         stmt = stmt.where(and_(*conditions))
-    stmt = stmt.order_by(Transaction.id)
+    # Newest-first by surrogate id. The OCPP `transaction_id` we expose
+    # to operators is server-assigned monotonically per gateway, so
+    # `id DESC` ≈ `transaction_id DESC` ≈ chronologically newest first,
+    # which is the audit-list default operators expect. The cursor
+    # condition flips correspondingly: `id < after_id` walks toward
+    # older rows.
+    stmt = stmt.order_by(Transaction.id.desc())
     if offset is not None:
         stmt = stmt.offset(offset).limit(limit)
     else:
         if after_id is not None:
-            stmt = stmt.where(Transaction.id > after_id)
+            stmt = stmt.where(Transaction.id < after_id)
         stmt = stmt.limit(limit + 1)
 
     result = await session.execute(stmt)

--- a/tests/unit/api/test_transactions.py
+++ b/tests/unit/api/test_transactions.py
@@ -70,6 +70,32 @@ async def test_get_by_id_returns_full_shape(
     assert body["consumed_wh"] == 500_000
     assert isinstance(body["started_reported_at"], str)
     assert body["stop_reason"] == "Local"
+    # UI-facing aliases: `started_at` and `stopped_at` point at the
+    # charger-reported timestamps, and `open` reflects "not stopped yet."
+    assert body["started_at"] == body["started_reported_at"]
+    assert body["stopped_at"] == body["stopped_reported_at"]
+    assert body["open"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_by_id_active_emits_open_true(
+    client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A still-running session has null stop fields and `open=true`."""
+    from eveys_ocpp.api import transactions as tx_module
+
+    monkeypatch.setattr(
+        tx_module,
+        "get_transaction_by_id",
+        AsyncMock(return_value=_tx_row(stopped=False)),
+    )
+
+    response = await client.get("/api/v1/transactions/999")
+
+    body = response.json()
+    assert body["stopped_at"] is None
+    assert body["stopped_reported_at"] is None
+    assert body["open"] is True
 
 
 @pytest.mark.asyncio
@@ -286,11 +312,19 @@ async def test_detail_includes_telemetry_block(
 
     assert response.status_code == 200
     body = response.json()
-    assert body["telemetry"]["soc"]["start_pct"] == 38.0
-    assert body["telemetry"]["soc"]["last_pct"] == 81.0
-    assert body["telemetry"]["phases"]["L1"]["voltage_v"] == 231.4
-    assert body["telemetry"]["phases"]["L1"]["current_a"] == 14.8
-    assert body["telemetry"]["phases"]["L1"]["power_w"] == 3417.3
+    # Wire shape uses `start` / `last` / derived `delta` (not the CH
+    # client's internal `start_pct` / `last_pct`).
+    assert body["telemetry"]["soc"]["start"] == 38.0
+    assert body["telemetry"]["soc"]["last"] == 81.0
+    assert body["telemetry"]["soc"]["delta"] == pytest.approx(43.0)
+    phase_l1 = body["telemetry"]["phases"]["L1"]
+    assert phase_l1["voltage_v"] == 231.4
+    assert phase_l1["current_a"] == 14.8
+    assert phase_l1["power_w"] == 3417.3
+    # Each phase carries power_factor (null when not reported) +
+    # occurred_at (mapped from the CH client's `last_at`).
+    assert phase_l1["power_factor"] is None
+    assert phase_l1["occurred_at"] == "2026-05-05T15:00:00+00:00"
 
     fake_ch_client.fetch_transaction_telemetry.assert_awaited_once_with(
         cp_id="CP_BERLIN_001", transaction_id=999


### PR DESCRIPTION
## Summary

Fixes three correctness issues operators hit on the Console transactions surface:

1. The list + detail handlers never emitted \`started_at\` / \`stopped_at\` / \`open\` even though the schema declared them. UIs got undefined values and rendered active sessions as "Finished".
2. The telemetry block used the CH client's internal field names (\`start_pct\` / \`last_pct\` / \`last_at\`) instead of the schema's \`start\` / \`last\` / \`delta\` (+ \`power_factor\` / \`occurred_at\` per phase). UIs couldn't surface SoC.
3. \`/transactions\` returned oldest-first. Audit operators want newest first. Flipped both list helpers to \`ORDER BY id DESC\` with the matching cursor walk.

OpenAPI regen committed.

## Test plan

- [x] \`pytest tests/unit/\` (1026 unit tests pass, 81% coverage)
- [x] \`ruff check\` + \`mypy\` clean
- [x] OpenAPI export regenerated
- [x] Real-stack smoke: list returns 4, 3, 2, 1 in that order; detail emits \`started_at\` / \`stopped_at\` / \`open\`; SoC block uses \`start\` / \`last\` / \`delta\`

Closes #230