### PR TITLE
feature(api): GET /transactions sort + dir params

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -6129,6 +6129,38 @@
               ],
               "title": "Max Consumed Wh"
             }
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Sort"
+            }
+          },
+          {
+            "in": "query",
+            "name": "dir",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Dir"
+            }
           }
         ],
         "responses": {
@@ -6153,7 +6185,7 @@
                 }
               }
             },
-            "description": "Bad cursor or unparseable from/to timestamp."
+            "description": "Bad cursor, sort/dir, or unparseable from/to timestamp."
           },
           "422": {
             "content": {

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -4178,6 +4178,22 @@ paths:
             type: integer
           - type: 'null'
           title: Max Consumed Wh
+      - in: query
+        name: sort
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Sort
+      - in: query
+        name: dir
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Dir
       responses:
         '200':
           content:
@@ -4194,7 +4210,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorEnvelope'
-          description: Bad cursor or unparseable from/to timestamp.
+          description: Bad cursor, sort/dir, or unparseable from/to timestamp.
         '422':
           content:
             application/json:

--- a/src/eveys_ocpp/api/transactions.py
+++ b/src/eveys_ocpp/api/transactions.py
@@ -53,6 +53,11 @@ from eveys_ocpp.persistence.repositories import (
 
 router = APIRouter(tags=["transactions"])
 
+# Sort + direction enums for `GET /transactions`. The Console UI is the
+# only intended consumer today; expand here when a new use case lands.
+_TX_SORT_VALUES = {"id", "started_at", "stopped_at", "consumed_wh"}
+_TX_DIR_VALUES = {"asc", "desc"}
+
 
 def _isoformat(value: datetime | None) -> str | None:
     return value.isoformat() if value is not None else None
@@ -237,7 +242,7 @@ async def list_transactions_route(
         200: {"model": TransactionListResponse},
         400: {
             "model": ErrorEnvelope,
-            "description": "Bad cursor or unparseable from/to timestamp.",
+            "description": "Bad cursor, sort/dir, or unparseable from/to timestamp.",
         },
     },
 )
@@ -258,9 +263,37 @@ async def list_transactions_global_route(
     stopped_before: str | None = Query(default=None),
     min_consumed_wh: int | None = Query(default=None, ge=0),
     max_consumed_wh: int | None = Query(default=None, ge=0),
+    sort: str | None = Query(default=None),
+    dir: str | None = Query(default=None),
 ) -> dict[str, Any]:
     settings = request.app.state.settings
     reject_mixed_pagination(cursor=cursor, page=page)
+
+    if sort is not None and sort not in _TX_SORT_VALUES:
+        raise ApiError(
+            status_code=400,
+            error_code=ERR_BAD_REQUEST,
+            message=f"unknown sort: {sort!r}; expected one of {sorted(_TX_SORT_VALUES)}",
+        )
+    if dir is not None and dir not in _TX_DIR_VALUES:
+        raise ApiError(
+            status_code=400,
+            error_code=ERR_BAD_REQUEST,
+            message=f"unknown dir: {dir!r}; expected 'asc' or 'desc'",
+        )
+    # Cursor pagination is only keyset-stable when sorting on the
+    # surrogate id. For any other sort the route requires offset
+    # (page) mode — otherwise `next_cursor` would skip rows whose
+    # sort_value tied with the last row on the previous page.
+    if sort is not None and sort != "id" and cursor is not None:
+        raise ApiError(
+            status_code=400,
+            error_code=ERR_BAD_REQUEST,
+            message=(
+                "cursor pagination is not supported with a non-default sort; "
+                "use `page` + `page_size` instead"
+            ),
+        )
 
     filter_kwargs: dict[str, Any] = {
         "cp_id": cp_id,
@@ -274,6 +307,8 @@ async def list_transactions_global_route(
         "stopped_to": _parse_iso8601(stopped_before, field_name="stopped_before"),
         "min_consumed_wh": min_consumed_wh,
         "max_consumed_wh": max_consumed_wh,
+        "sort": sort,
+        "direction": dir or "desc",
     }
 
     if page is not None:
@@ -283,6 +318,10 @@ async def list_transactions_global_route(
             maximum=settings.rest_max_page_size,
         )
         offset = offset_for_page(page, effective_size)
+        # `count_transactions` doesn't care about ordering — strip the
+        # sort kwargs before the count call to avoid forwarding kwargs
+        # that aren't in its signature.
+        count_kwargs = {k: v for k, v in filter_kwargs.items() if k not in {"sort", "direction"}}
         async with session_scope(request.app.state.session_factory) as session:
             rows = await list_transactions(
                 session,
@@ -291,7 +330,7 @@ async def list_transactions_global_route(
                 offset=offset,
                 **filter_kwargs,
             )
-            total = await count_transactions(session, **filter_kwargs)
+            total = await count_transactions(session, **count_kwargs)
         return {
             "transactions": [_transaction_to_response(tx) for tx in rows],
             "pagination": pagination_block(page=page, page_size=effective_size, total=total),

--- a/src/eveys_ocpp/persistence/repositories.py
+++ b/src/eveys_ocpp/persistence/repositories.py
@@ -1494,6 +1494,22 @@ def _transactions_filter_conditions(
     return conditions
 
 
+def _tx_sort_expr(sort: str | None) -> Any:
+    """Resolve the sort enum to a SQLAlchemy expression.
+
+    `consumed_wh` is computed (`meter_stop_wh - meter_start_wh`), not a
+    column, so we can't `getattr(Transaction, name)` for it. The other
+    sorts map to real columns.
+    """
+    if sort == "started_at":
+        return Transaction.started_reported_at
+    if sort == "stopped_at":
+        return Transaction.stopped_reported_at
+    if sort == "consumed_wh":
+        return Transaction.meter_stop_wh - Transaction.meter_start_wh
+    return Transaction.id
+
+
 async def list_transactions(
     session: AsyncSession,
     *,
@@ -1511,6 +1527,8 @@ async def list_transactions(
     min_consumed_wh: int | None = None,
     max_consumed_wh: int | None = None,
     offset: int | None = None,
+    sort: str | None = None,
+    direction: str = "desc",
 ) -> list[dict[str, Any]]:
     """Global transactions list.
 
@@ -1548,13 +1566,29 @@ async def list_transactions(
     )
     if conditions:
         stmt = stmt.where(and_(*conditions))
-    # Newest-first by surrogate id. The OCPP `transaction_id` we expose
-    # to operators is server-assigned monotonically per gateway, so
-    # `id DESC` ≈ `transaction_id DESC` ≈ chronologically newest first,
-    # which is the audit-list default operators expect. The cursor
-    # condition flips correspondingly: `id < after_id` walks toward
-    # older rows.
-    stmt = stmt.order_by(Transaction.id.desc())
+    # Default: newest-first by surrogate id. The OCPP `transaction_id`
+    # we expose to operators is server-assigned monotonically per
+    # gateway, so `id DESC` ≈ chronologically newest first — the
+    # audit-list default operators expect.
+    #
+    # When `sort` is supplied the route layer guarantees it's already
+    # the closed-enum-validated string ('started_at', 'consumed_wh',
+    # …); we translate to the underlying column and tie-break on
+    # `id` so the order is stable across calls. The cursor-mode
+    # condition (`id < after_id`) is only meaningful when sorting on
+    # `id` itself; the route rejects cursor+non-id-sort with 400.
+    sort_expr = _tx_sort_expr(sort)
+    is_id_sort = sort in (None, "id")
+    dir_lower = direction.lower()
+    primary = sort_expr.desc() if dir_lower == "desc" else sort_expr.asc()
+    if is_id_sort:
+        stmt = stmt.order_by(primary)
+    else:
+        # `id` tiebreaker keeps rows with identical sort values in a
+        # stable order (matters most for `consumed_wh`, where many
+        # sessions share the value `0` or `null`).
+        tiebreak = Transaction.id.desc() if dir_lower == "desc" else Transaction.id.asc()
+        stmt = stmt.order_by(primary, tiebreak)
     if offset is not None:
         stmt = stmt.offset(offset).limit(limit)
     else:

--- a/tests/unit/api/test_transactions.py
+++ b/tests/unit/api/test_transactions.py
@@ -618,3 +618,105 @@ async def test_aggregate_rejects_unknown_group_by(client: httpx.AsyncClient) -> 
     )
     assert response.status_code == 400
     assert response.json()["error_code"] == "BAD_REQUEST"
+
+
+# ---------------------------------------------------------------------------
+# Sortable list (#43)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_global_forwards_sort_and_dir(
+    client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from eveys_ocpp.api import transactions as tx_module
+
+    spy = AsyncMock(return_value=[])
+    monkeypatch.setattr(tx_module, "list_transactions", spy)
+    monkeypatch.setattr(tx_module, "count_transactions", AsyncMock(return_value=0))
+
+    await client.get("/api/v1/transactions?page=1&page_size=20&sort=consumed_wh&dir=desc")
+
+    kwargs = spy.await_args.kwargs
+    assert kwargs["sort"] == "consumed_wh"
+    assert kwargs["direction"] == "desc"
+
+
+@pytest.mark.asyncio
+async def test_list_global_defaults_dir_to_desc(
+    client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from eveys_ocpp.api import transactions as tx_module
+
+    spy = AsyncMock(return_value=[])
+    monkeypatch.setattr(tx_module, "list_transactions", spy)
+    monkeypatch.setattr(tx_module, "count_transactions", AsyncMock(return_value=0))
+
+    await client.get("/api/v1/transactions?page=1&page_size=20&sort=started_at")
+
+    assert spy.await_args.kwargs["direction"] == "desc"
+
+
+@pytest.mark.asyncio
+async def test_list_global_rejects_unknown_sort(
+    client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from eveys_ocpp.api import transactions as tx_module
+
+    monkeypatch.setattr(tx_module, "list_transactions", AsyncMock(return_value=[]))
+
+    response = await client.get("/api/v1/transactions?sort=banana")
+
+    assert response.status_code == 400
+    assert response.json()["error_code"] == "BAD_REQUEST"
+
+
+@pytest.mark.asyncio
+async def test_list_global_rejects_unknown_dir(
+    client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from eveys_ocpp.api import transactions as tx_module
+
+    monkeypatch.setattr(tx_module, "list_transactions", AsyncMock(return_value=[]))
+
+    response = await client.get("/api/v1/transactions?sort=consumed_wh&dir=upside-down")
+
+    assert response.status_code == 400
+    assert response.json()["error_code"] == "BAD_REQUEST"
+
+
+@pytest.mark.asyncio
+async def test_list_global_rejects_cursor_with_non_default_sort(
+    client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Keyset cursors only walk stably when ordering by the surrogate id;
+    a non-id sort + cursor would skip rows with tied sort-values across
+    pages. Route forces page mode in that combo."""
+    from eveys_ocpp.api import transactions as tx_module
+
+    monkeypatch.setattr(tx_module, "list_transactions", AsyncMock(return_value=[]))
+
+    response = await client.get("/api/v1/transactions?sort=consumed_wh&cursor=cur-1")
+
+    assert response.status_code == 400
+    body = response.json()
+    assert body["error_code"] == "BAD_REQUEST"
+    assert "cursor pagination is not supported" in body["error"]
+
+
+@pytest.mark.asyncio
+async def test_list_global_default_sort_remains_cursor_paginated(
+    client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`sort=id` (the implicit default) still allows cursor mode."""
+    from eveys_ocpp.api import transactions as tx_module
+
+    monkeypatch.setattr(tx_module, "list_transactions", AsyncMock(return_value=[]))
+
+    response = await client.get("/api/v1/transactions?sort=id&cursor=cur-1")
+
+    # Cursor decode happens after the sort check; a malformed cursor
+    # would 400, but the sort check itself must NOT fire.
+    assert response.status_code != 400 or "cursor pagination" not in (
+        response.json().get("message") or ""
+    )


### PR DESCRIPTION
## Summary

Adds \`?sort=&dir=\` to the global transactions list. Sort is a closed enum (\`id\` | \`started_at\` | \`stopped_at\` | \`consumed_wh\`); \`dir\` defaults to \`desc\`. Default (no sort param) keeps the existing newest-first-by-id behaviour and stays cursor-paginated.

### Notes

- Cursor pagination is rejected with 400 for non-id sorts (keyset walks aren't stable across tied sort values). Operators wanting a sorted view switch to \`page\` + \`page_size\`.
- Tie-break on \`id\` keeps the order stable across pages (matters most for \`consumed_wh\`, where many sessions share \`0\` or null).
- \`consumed_wh\` sorts on the computed expression \`meter_stop_wh - meter_start_wh\` — there's no column with that name. The mocked unit test passed against \`getattr(Transaction, 'consumed_wh')\` but the real query 500ed on AttributeError; smoke against real Postgres caught it before merge.

## Test plan

- [x] \`pytest tests/unit/\` (1033 unit tests pass, 81% coverage)
- [x] \`ruff check\` + \`mypy\` clean
- [x] OpenAPI export regenerated
- [x] Real-stack smoke: \`sort=consumed_wh dir=desc\` returns 36016 → 0; \`asc\` reverses; \`sort=banana\` → 400; \`cursor\` + non-id sort → 400

Closes #232