### PR TITLE
chore(compose): apply DB migrations on boot via init-containers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -35,7 +35,10 @@ docs/
 deploy/compose/
 scripts/
 tests/
-alembic/
-alembic.ini
+# Note: alembic/ + alembic.ini are intentionally INCLUDED in the
+# build context — the runtime image ships them so the compose
+# `migrate-postgres` init-container (and the Helm pre-install hook
+# in the future) can run `python -m alembic upgrade head` without
+# a host bind-mount. See eveys-mobility/OCPP#234.
 AGENTS.md
 CLAUDE.md

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -46,6 +46,12 @@ WORKDIR /build
 
 COPY pyproject.toml README.md ./
 COPY src/ ./src/
+# Alembic config + migration scripts. Shipped in the runtime image so
+# the compose init-container (and the Helm pre-install hook) can run
+# `python -m alembic upgrade head` without a host bind-mount. See
+# eveys-mobility/OCPP#234.
+COPY alembic.ini ./alembic.ini
+COPY alembic/ ./alembic/
 # Replace the empty _generated dir from src/ with the generated stubs.
 COPY --from=codegen /codegen/out/eveys_ocpp/_generated/ ./src/eveys_ocpp/_generated/
 
@@ -63,6 +69,14 @@ COPY --from=builder /usr/local/lib/python3.13 /usr/local/lib/python3.13
 COPY --from=builder /usr/local/lib/libpython3.13.so.1.0 /usr/local/lib/libpython3.13.so.1.0
 COPY --from=builder /usr/local/bin/python3.13 /usr/local/bin/python3.13
 COPY --from=builder /opt/venv /opt/venv
+# Carry alembic.ini + alembic/ from the builder into the runtime
+# layer (under /build, same path the builder used) so `python -m
+# alembic` finds them when the init-container runs. Two thin copies;
+# the contents are <50KB.
+COPY --from=builder /build/alembic.ini /build/alembic.ini
+COPY --from=builder /build/alembic/ /build/alembic/
+
+WORKDIR /build
 
 ENV PATH="/opt/venv/bin:/usr/local/bin:${PATH}" \
     LD_LIBRARY_PATH="/usr/local/lib" \

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -132,6 +132,60 @@ services:
       retries: 6
       start_period: 10s
 
+  # ---- migration init-containers (eveys-mobility/OCPP#234) ------------------
+  #
+  # Each is a one-shot service that applies pending schema migrations
+  # then exits 0. The `ocpp` and `clickhouse-ingestor` services
+  # `depends_on: { condition: service_completed_successfully }` so a
+  # fresh stack — or a stack pulling an image with a new migration —
+  # is guaranteed to be at-HEAD before any consumer starts.
+  #
+  # `restart: "no"` is intentional. If a migration fails the stack
+  # halts loudly with a non-zero exit; the alternative (silent
+  # crashloop) is the failure mode #234 was filed to prevent. Inspect
+  # `docker compose logs migrate-postgres migrate-clickhouse` to
+  # diagnose.
+  #
+  # The Helm chart equivalent (pre-install/pre-upgrade hook or init
+  # container on the gateway Deployment) is separate work — see
+  # #234's "Helm chart equivalent" decision point.
+  migrate-postgres:
+    image: eveys-ocpp:dev
+    container_name: eveys-ocpp-migrate-postgres
+    # Alembic is async-friendly (see alembic/env.py); run via
+    # `python -m alembic` against the image's bundled WORKDIR /build,
+    # which now ships alembic.ini + alembic/ alongside the venv.
+    command: ["-m", "alembic", "upgrade", "head"]
+    environment:
+      # Same DSN the runtime uses; alembic reads it via
+      # eveys_ocpp.settings.get_settings().db_url.
+      EVEYS_OCPP_DB_URL: postgresql+asyncpg://eveys:eveys@postgres:5432/eveys_ocpp
+      EVEYS_OCPP_LOG_JSON: "true"
+      EVEYS_OCPP_LOG_LEVEL: "INFO"
+    restart: "no"
+    depends_on:
+      postgres: { condition: service_healthy }
+
+  migrate-clickhouse:
+    image: eveys-ocpp:dev
+    container_name: eveys-ocpp-migrate-clickhouse
+    # The ClickHouse migrator is HTTP/8123 (not the 9000 native
+    # protocol) — kept stdlib-urllib on purpose, see migrate.py
+    # header. Forward host/port/db verbatim from env so the same
+    # image works under Helm with different addresses.
+    command:
+      - "-m"
+      - "eveys_ocpp.clickhouse.migrate"
+      - "--host=clickhouse"
+      - "--port=8123"
+      - "--db=eveys_ocpp"
+    environment:
+      EVEYS_OCPP_LOG_JSON: "true"
+      EVEYS_OCPP_LOG_LEVEL: "INFO"
+    restart: "no"
+    depends_on:
+      clickhouse: { condition: service_healthy }
+
   ocpp:
     # Built locally from deploy/Dockerfile (distroless multi-stage; ~168 MB).
     # Use `make build-image` (or `docker compose build ocpp`) before
@@ -203,6 +257,11 @@ services:
       redis: { condition: service_healthy }
       kafka: { condition: service_healthy }
       clickhouse: { condition: service_healthy }
+      # Block boot until both migrators report exit 0. Prevents the
+      # "code ships but schema lags" failure mode that bit the
+      # ingestor in #234 — see the comment on the migrate-* services.
+      migrate-postgres: { condition: service_completed_successfully }
+      migrate-clickhouse: { condition: service_completed_successfully }
     # Envoy's first health-check fires the moment it starts and a
     # network-level failure on attempt #1 puts the upstream in a
     # state Envoy doesn't always reschedule from. Adding a
@@ -251,6 +310,10 @@ services:
     depends_on:
       kafka: { condition: service_healthy }
       clickhouse: { condition: service_healthy }
+      # Same migration gate as `ocpp`: don't start the ingestor until
+      # the CH schema is at HEAD. The dead-ingestor case in #234 was
+      # exactly "tables don't exist yet, 10 flush failures, exit 1."
+      migrate-clickhouse: { condition: service_completed_successfully }
 
   # Envoy edge proxy (E5-1, ADR-0007).
   #


### PR DESCRIPTION
## Summary

Closes the "code ships but schema lags" failure mode that hit twice this month: the uptime DateTime64 case (#225) and the ClickHouse ingestor dying when DDL 0007 was missing (cp_meter pipeline silently dropped 17h of MeterValues before catch).

### What

- Two one-shot init-services in compose: \`migrate-postgres\` (runs \`python -m alembic upgrade head\`) and \`migrate-clickhouse\` (runs \`python -m eveys_ocpp.clickhouse.migrate ...\`).
- \`ocpp\` and \`clickhouse-ingestor\` now \`depends_on: { condition: service_completed_successfully }\` for the matching migrator. Both consumers refuse to start until the migrator exits 0.
- \`restart: "no"\` on the init services — a migration failure must halt the stack loudly, not crashloop silently.
- Runtime image (\`deploy/Dockerfile\`) now ships \`alembic.ini\` + \`alembic/\` so \`python -m alembic\` works without a host bind-mount. \`.dockerignore\` updated.

### What's NOT in this PR

- The Helm chart equivalent (pre-install hook or k8s init container). Tracked in #234's "Helm chart equivalent" decision point; separate PR when that work comes up.

## Test plan

- [x] \`pytest tests/unit/\` (1033 tests pass, 81% coverage)
- [x] \`ruff check\` clean
- [x] Real-stack smoke: \`docker compose up -d ocpp clickhouse-ingestor\` on a fresh build — both migrators exited 0, consumers started only after, gateway REST returns expected rows.
- [x] Idempotent: both migrators re-run cleanly on a stack that's already at HEAD (\`applied 0 migration(s)\` for CH, alembic no-op for PG).

Closes #234