### PR TITLE
fix(compose): retry CH migrator on connection-refused; on-failure for both migrators

### DIFF
--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -162,7 +162,15 @@ services:
       EVEYS_OCPP_DB_URL: postgresql+asyncpg://eveys:eveys@postgres:5432/eveys_ocpp
       EVEYS_OCPP_LOG_JSON: "true"
       EVEYS_OCPP_LOG_LEVEL: "INFO"
-    restart: "no"
+    # `on-failure:5` covers the race between Postgres's healthcheck
+    # flipping healthy and asyncpg's first connect actually succeeding
+    # — Postgres can claim healthy a moment before it accepts new
+    # connections under load. A real migration failure still exits
+    # cleanly after 5 attempts and blocks `ocpp` from starting (since
+    # consumers wait on `service_completed_successfully`, not just
+    # `started`); 5 × ~10s is enough headroom on a laptop without
+    # masking a genuinely-broken migration for too long.
+    restart: on-failure:5
     depends_on:
       postgres: { condition: service_healthy }
 
@@ -182,7 +190,12 @@ services:
     environment:
       EVEYS_OCPP_LOG_JSON: "true"
       EVEYS_OCPP_LOG_LEVEL: "INFO"
-    restart: "no"
+    # `on-failure:3` as a belt-and-braces complement to the script's
+    # own connection-refused retry loop (`--wait-attempts=12` covers
+    # ~30s of HTTP-listener warmup). Three compose-level retries give
+    # us a second escape hatch if some failure mode slips past the
+    # in-script loop without masking a real migration error.
+    restart: on-failure:3
     depends_on:
       clickhouse: { condition: service_healthy }
 

--- a/src/eveys_ocpp/clickhouse/migrate.py
+++ b/src/eveys_ocpp/clickhouse/migrate.py
@@ -31,6 +31,8 @@ import argparse
 import logging
 import re
 import sys
+import time
+import urllib.error
 import urllib.parse
 import urllib.request
 from pathlib import Path
@@ -169,21 +171,70 @@ def apply_pending(*, host: str, port: int, db: str) -> list[int]:
 
 
 def main() -> None:
-    """CLI entry point: ``python -m eveys_ocpp.clickhouse.migrate``."""
+    """CLI entry point: ``python -m eveys_ocpp.clickhouse.migrate``.
+
+    Retries up to ``--wait-attempts`` times on connection-refused errors
+    (default 12 attempts at 2.5 s each, ~30 s total) before giving up.
+    This matters for the compose init-container: ClickHouse can
+    transition healthy -> ready a moment before its HTTP listener
+    accepts new connections, and the init-container's first attempt
+    would otherwise race that window and exit 1, blocking the whole
+    stack (since ``ocpp`` and the ingestor wait on
+    ``service_completed_successfully``).
+    """
     logging.basicConfig(level=logging.INFO, format="%(message)s")
     parser = argparse.ArgumentParser(description="Apply ClickHouse migrations.")
     parser.add_argument("--host", default="localhost")
     parser.add_argument("--port", type=int, default=8123, help="ClickHouse HTTP port")
     parser.add_argument("--db", default="eveys_ocpp")
+    parser.add_argument(
+        "--wait-attempts",
+        type=int,
+        default=12,
+        help="On connection-refused, retry this many times before giving up.",
+    )
+    parser.add_argument(
+        "--wait-seconds",
+        type=float,
+        default=2.5,
+        help="Sleep this long between retries.",
+    )
     args = parser.parse_args()
 
-    try:
-        applied = apply_pending(host=args.host, port=args.port, db=args.db)
-    except urllib.error.URLError as exc:
-        print(
-            f"ERROR: could not reach ClickHouse at {args.host}:{args.port}: {exc}",
-            file=sys.stderr,
-        )
+    last_exc: urllib.error.URLError | None = None
+    for attempt in range(1, args.wait_attempts + 1):
+        try:
+            applied = apply_pending(host=args.host, port=args.port, db=args.db)
+            break
+        except urllib.error.URLError as exc:
+            # Only retry on the "not listening yet" case. A 4xx/5xx
+            # comes back as `HTTPError`, which is also a `URLError` —
+            # filter those out so a real schema failure exits fast.
+            if isinstance(exc, urllib.error.HTTPError):
+                print(
+                    f"ERROR: ClickHouse returned {exc.code} at {args.host}:{args.port}: {exc}",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            last_exc = exc
+            if attempt < args.wait_attempts:
+                print(
+                    f"clickhouse not ready at {args.host}:{args.port} "
+                    f"(attempt {attempt}/{args.wait_attempts}); retrying in {args.wait_seconds}s",
+                    file=sys.stderr,
+                )
+                time.sleep(args.wait_seconds)
+                continue
+            print(
+                f"ERROR: could not reach ClickHouse at {args.host}:{args.port} "
+                f"after {args.wait_attempts} attempts: {exc}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    else:
+        # Loop completed without `break` AND without `sys.exit`.
+        # Unreachable in practice; here for the type checker.
+        assert last_exc is not None
         sys.exit(1)
     print(f"applied {len(applied)} migration(s): {applied}")
 


### PR DESCRIPTION
## Summary

PR #235 set \`restart: \"no\"\` on the migration init-containers. Operator hit this on a fresh \`docker compose up\`: ClickHouse's healthcheck transitioned to healthy a moment before its HTTP listener accepted new connections, the migrator hit \`Connection refused\` and exited 1 **permanently**, leaving \`ocpp\` and the ingestor blocked on \`service_completed_successfully\`.

### Fix (defense in depth)

1. **CH migrator script:** retries on \`URLError\` (connection-refused) up to \`--wait-attempts\` times (default 12 attempts × 2.5s ≈ 30s) before giving up. \`HTTPError\` (a real server-side 4xx/5xx) still exits fast — the loop only soaks up the "not listening yet" case.
2. **Compose:** \`restart: on-failure:5\` on PG (alembic doesn't retry internally) and \`on-failure:3\` on CH (the script handles most slack already). Belt-and-braces.

### Test plan

- [x] In-script retry verified locally against a refused port — exits cleanly after the configured attempts.
- [x] \`pytest -k migrate\` (13 tests pass).
- [x] \`ruff check\` + \`mypy\` clean.
- [x] Cold-boot smoke against a wiped CH volume: migrate-clickhouse applied all 7 pending migrations, both consumers (\`ocpp\`, \`clickhouse-ingestor\`) started cleanly.

Follow-up to #235 / #234.