### PR TITLE
chore(settings): heartbeat interval default 300s -> 60s

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,7 +94,7 @@ EVEYS_OCPP_LOG_JSON=true
 
 # ---- OCPP defaults -----------------------------------------------
 
-EVEYS_OCPP_HEARTBEAT_INTERVAL_SECONDS=300
+EVEYS_OCPP_HEARTBEAT_INTERVAL_SECONDS=60
 
 # ---- Cross-pod command bus (ADR-0016) ----------------------------
 

--- a/docs/11-configuration-reference.md
+++ b/docs/11-configuration-reference.md
@@ -137,7 +137,7 @@ sensitivity.
 
 | Variable | Default | Range | Stability | Secret | What it does | Impact of changing |
 |---|---|---|---|---|---|---|
-| `EVEYS_OCPP_HEARTBEAT_INTERVAL_SECONDS` | `300` | 30–86400 | tunable | no | Sent back in `BootNotification.interval`; the charger pings us this often. | Lower → quicker offline detection at the cost of fleet-wide heartbeat traffic. Coordinate with `REDIS_ONLINE_TTL_SECONDS` (rule of thumb: TTL ~= 2x heartbeat). 300 s is the OCPP-recommended default. |
+| `EVEYS_OCPP_HEARTBEAT_INTERVAL_SECONDS` | `60` | 30–86400 | tunable | no | Sent back in `BootNotification.interval`; the charger pings us this often. | Lower → quicker offline detection at the cost of fleet-wide heartbeat traffic. Coordinate with `REDIS_ONLINE_TTL_SECONDS` (rule of thumb: TTL ~= 2x heartbeat). 60 s pairs with the default 120 s online TTL — 2 missed heartbeats triggers offline detection. The OCPP-1.6 spec doesn't mandate a value; 300 s was the previous gateway default. |
 
 ## Cross-pod command bus (ADR-0016)
 

--- a/src/eveys_ocpp/settings.py
+++ b/src/eveys_ocpp/settings.py
@@ -824,7 +824,7 @@ class Settings(BaseSettings):
 
     # ---- OCPP defaults --------------------------------------------------
     heartbeat_interval_seconds: int = Field(
-        default=300,
+        default=60,
         ge=30,
         le=86400,
         description=("Sent back in `BootNotification.interval`; the charger pings us this often."),
@@ -834,7 +834,10 @@ class Settings(BaseSettings):
                 "Lower → quicker offline detection at the cost of fleet-"
                 "wide heartbeat traffic. Coordinate with "
                 "`REDIS_ONLINE_TTL_SECONDS` (rule of thumb: TTL ~= 2x "
-                "heartbeat). 300 s is the OCPP-recommended default."
+                "heartbeat). 60 s pairs with the default 120 s online "
+                "TTL — 2 missed heartbeats triggers offline detection. "
+                "The OCPP-1.6 spec doesn't mandate a value; 300 s was "
+                "the previous gateway default."
             ),
             "secret": False,
             "stability": "tunable",

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -11,7 +11,7 @@ def test_defaults_are_dev_safe() -> None:
     s = Settings()
     assert s.ws_host == "0.0.0.0"
     assert s.ws_port == 9000
-    assert s.heartbeat_interval_seconds == 300
+    assert s.heartbeat_interval_seconds == 60
     assert s.log_level == "INFO"
     assert s.log_json is True
 


### PR DESCRIPTION
## Summary

Operator requested a 60s heartbeat default. Pairs with the existing 120s Redis online-TTL — 2 missed heartbeats triggers offline detection, matching the rule of thumb the impact-text already calls out.

## On the rest of the operator's ask

- **\`redis_online_ttl_seconds\`** is already 120s in main. No change needed.
- **MeterValueSampleInterval** is a charger-side OCPP-1.6 ConfigurationKey, not a gateway-emitted default. Making the gateway push a value would require a new \`Settings\` field + an auto-dispatch of \`ChangeConfiguration\` after \`BootNotification.Accepted\` — real new functionality, separate PR if/when requested.

## Test plan

- [x] \`pytest tests/unit/\` (1033 tests pass)
- [x] \`ruff check\` + \`mypy\` clean
- [x] \`make config-export\` ran; \`docs/11-configuration-reference.md\` + \`.env.example\` regenerated