### PR TITLE
docs: explain migrate-postgres + migrate-clickhouse init-containers

### DIFF
--- a/docs/07-local-dev-setup.md
+++ b/docs/07-local-dev-setup.md
@@ -102,6 +102,26 @@ make compose-status  # or: docker compose ps
 
 All five services should be `healthy`. If any is `unhealthy`, see [Troubleshooting](#troubleshooting) below.
 
+#### About the two `Exited (0)` containers
+
+After `compose-up` you'll see two extra entries in `docker ps -a`:
+
+```
+eveys-ocpp-migrate-postgres      Exited (0)
+eveys-ocpp-migrate-clickhouse    Exited (0)
+```
+
+These are **migration init-containers**, not crashes. Each runs once at stack boot:
+
+- `migrate-postgres` runs `alembic upgrade head` against Postgres.
+- `migrate-clickhouse` runs `python -m eveys_ocpp.clickhouse.migrate ...` against ClickHouse.
+
+`ocpp` and `clickhouse-ingestor` `depends_on: { condition: service_completed_successfully }` for the matching migrator, so the gateway and ingestor only start once schemas are at HEAD. `Exited (0)` is the desired terminal state — same as `make ch-migrate` finishing and the shell returning to a prompt.
+
+If a migration fails, the exit code is non-zero, compose retries up to `restart: on-failure:N`, and the dependents stay blocked. `docker compose logs migrate-postgres migrate-clickhouse` shows the failure.
+
+`make ch-migrate` and `alembic upgrade head` still work for explicit local override or CI; they're idempotent against the init-container path.
+
 ### Verify it works
 
 Two scripted smoke tests exercise the stack at different trust levels (see [`10-testing-strategy.md`](./10-testing-strategy.md) and ADR-0024):

--- a/docs/10-testing-strategy.md
+++ b/docs/10-testing-strategy.md
@@ -95,12 +95,17 @@ Steps run by the target:
 
 1. `docker compose -f deploy/compose/docker-compose.yml down --volumes`
    (clean slate)
-2. `docker compose ... up -d --build` (builds the image, starts the stack)
+2. `docker compose ... up -d --build` (builds the image, starts the stack —
+   includes the `migrate-postgres` and `migrate-clickhouse` init-containers
+   which apply schemas before `ocpp` and `clickhouse-ingestor` are allowed
+   to start; see [#234](https://github.com/eveys-mobility/OCPP/issues/234))
 3. `make compose-wait` (block on healthchecks)
-4. `alembic upgrade head` (Postgres schema)
-5. `make ch-migrate` (ClickHouse schema)
-6. `pytest tests/compose_smoke -v --no-cov`
-7. `docker compose ... down --volumes` (tear down on success or fail)
+4. `pytest tests/compose_smoke -v --no-cov`
+5. `docker compose ... down --volumes` (tear down on success or fail)
+
+`alembic upgrade head` / `make ch-migrate` are no longer required steps —
+compose runs both at boot. They still work for explicit re-runs (debugging
+schema drift, applying a new migration to an already-running stack).
 
 **CI:** `compose-smoke` workflow. Uses the runner's preinstalled Docker
 daemon directly — no DinD wrapping needed on GitHub Actions. Triggered

--- a/docs/12-connecting-real-charger.md
+++ b/docs/12-connecting-real-charger.md
@@ -78,19 +78,18 @@ make compose-wait    # block until every container reports healthy
 
 `make compose-wait` exits zero when all five services are healthy (default 120 s). If it times out, run `make compose-status` to see which one is unhealthy and `docker logs <container>` for diagnostics.
 
-### 4.2 Apply schemas
+### 4.2 Verify schemas
 
-The gateway image ships with the SQLAlchemy models, but Postgres needs the schema applied once and ClickHouse needs the DDL migrations:
+`compose-up` runs two init-containers (`migrate-postgres`, `migrate-clickhouse`) before `ocpp` and `clickhouse-ingestor` are allowed to start — both apply pending migrations and exit `0`. If you see `eveys-ocpp` up and healthy, schemas are at HEAD.
+
+If you ever need to re-run explicitly (e.g. debugging schema drift):
 
 ```bash
-# Postgres — Alembic migration (idempotent)
-.venv/bin/alembic upgrade head
-
-# ClickHouse — apply DDL migrations 0001..0005
-make ch-migrate
+.venv/bin/alembic upgrade head   # Postgres
+make ch-migrate                  # ClickHouse
 ```
 
-You can verify the schemas are in place:
+Both are idempotent. Verify the result:
 
 ```bash
 psql postgres://eveys:eveys@localhost:5432/eveys_ocpp -c "\dt"

--- a/docs/adr/0020-clickhouse-ingestion-sidecar.md
+++ b/docs/adr/0020-clickhouse-ingestion-sidecar.md
@@ -98,6 +98,7 @@ Reversible at moderate cost. Switching to Kafka Engine, Kafka Connect, or a diff
 - Repeated proto fields become `Nested` columns. Same.
 - DDL files are append-only; never edit a merged file. To change a table, write a new migration.
 - `eveys/ocpp` does not query ClickHouse (per ADR-0004 line 35). The ingestor writes; downstream consumers read.
+- Pending migrations are applied automatically on `docker compose up` by the `migrate-clickhouse` init-container (one-shot, exits `0`); the gateway and the ingestor wait on `service_completed_successfully` before starting. `make ch-migrate` still works for explicit local re-runs. See [#234](https://github.com/eveys-mobility/OCPP/issues/234) for the rationale.
 
 ## References
 


### PR DESCRIPTION
## Summary

Closes a doc gap from PR #235. The two new \`Exited (0)\` init-containers (\`migrate-postgres\`, \`migrate-clickhouse\`) look like crashes to operators who haven't read the PR, and the doc set still told them to run \`alembic upgrade head\` and \`make ch-migrate\` as required steps that compose now handles automatically.

### Four touches

- \`docs/07-local-dev-setup.md\` — new subsection \"About the two \`Exited (0)\` containers\" right after the \`compose-up\` block, explaining what they do, why \`Exited (0)\` is the desired terminal state, and what to inspect if either fails.
- \`docs/10-testing-strategy.md\` — drops \`alembic upgrade head\` + \`make ch-migrate\` from the compose-smoke sequence; keeps the commands as explicit escape hatches.
- \`docs/12-connecting-real-charger.md\` — section 4.2 reframed from \"apply schemas\" to \"verify schemas\" + idempotent escape-hatch commands.
- \`docs/adr/0020\` — rules block calls out the auto-apply path with a link to #234.

## Test plan

- [x] \`make docs\` produces 5 warnings, all pre-existing in files I didn't touch (CHANGELOG xref, Grafana README xref, two RemoteStop xrefs in 18-rollback-runbook, one JSON-lexer warning in integration/02). Zero new warnings from this PR.

Refs #234, #235