### PR TITLE
feature(boot): push MeterValueSampleInterval after Accepted boot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,6 +95,7 @@ EVEYS_OCPP_LOG_JSON=true
 # ---- OCPP defaults -----------------------------------------------
 
 EVEYS_OCPP_HEARTBEAT_INTERVAL_SECONDS=60
+EVEYS_OCPP_METER_VALUE_SAMPLE_INTERVAL_SECONDS=15
 
 # ---- Cross-pod command bus (ADR-0016) ----------------------------
 

--- a/docs/11-configuration-reference.md
+++ b/docs/11-configuration-reference.md
@@ -138,6 +138,7 @@ sensitivity.
 | Variable | Default | Range | Stability | Secret | What it does | Impact of changing |
 |---|---|---|---|---|---|---|
 | `EVEYS_OCPP_HEARTBEAT_INTERVAL_SECONDS` | `60` | 30–86400 | tunable | no | Sent back in `BootNotification.interval`; the charger pings us this often. | Lower → quicker offline detection at the cost of fleet-wide heartbeat traffic. Coordinate with `REDIS_ONLINE_TTL_SECONDS` (rule of thumb: TTL ~= 2x heartbeat). 60 s pairs with the default 120 s online TTL — 2 missed heartbeats triggers offline detection. The OCPP-1.6 spec doesn't mandate a value; 300 s was the previous gateway default. |
+| `EVEYS_OCPP_METER_VALUE_SAMPLE_INTERVAL_SECONDS` | `15` | 5–3600 | tunable | no | Value pushed to every charger after `BootNotification.Accepted` via `ChangeConfiguration(MeterValueSampleInterval=…)`. Sets how often the charger sends `MeterValues` during a transaction. | Lower → finer-grained power/energy charts on the operator console, more `MeterValues` frames per session (and more Kafka/ClickHouse traffic). 15 s is fine for AC sessions on the order of hours; consider 5-10 s for short fast-charge sessions if you want sub-minute resolution. Pushed best-effort: a charger that rejects the configuration key is logged but does not fail boot. See https://github.com/eveys-mobility/OCPP/issues/238. |
 
 ## Cross-pod command bus (ADR-0016)
 

--- a/src/eveys_ocpp/handlers/v16/boot_notification.py
+++ b/src/eveys_ocpp/handlers/v16/boot_notification.py
@@ -42,11 +42,12 @@ Deviations from the OCA spec to verify before W2 / OCTT (see
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-from ocpp.v16 import call_result
+from ocpp.v16 import call, call_result
 from ocpp.v16.enums import RegistrationStatus
 
 from eveys_ocpp._generated.events.v1 import events_pb2
@@ -61,6 +62,13 @@ if TYPE_CHECKING:
     from eveys_ocpp.connection import EveysChargePoint
 
 log = get_logger(__name__)
+
+# Charger needs a moment to settle after BootNotification before we
+# start pushing ChangeConfiguration calls — some firmwares ignore or
+# error on commands during the boot handshake. 2s is the empirical
+# settle window from the mobilityhouse/ocpp sim and a few production
+# Schneider/ABB units. See eveys-mobility/OCPP#238.
+_METER_VALUE_PUSH_DELAY_SECONDS = 2.0
 
 
 # OCPP wire string → mobilityhouse/ocpp enum. Forward-compat: an
@@ -257,4 +265,66 @@ async def _handle_inner(
         except Exception as exc:
             log.warning("boot_notification.publish_failed", error=str(exc))
 
+    # Push the configured MeterValueSampleInterval on every Accepted
+    # boot (eveys-mobility/OCPP#238). Fire-and-forget — we don't want
+    # the boot reply to wait on a charger that's slow to ack the
+    # ChangeConfiguration. The task itself sleeps a couple of seconds
+    # first to let the charger settle post-boot before issuing the
+    # command (some firmwares reject ChangeConfiguration during the
+    # boot handshake window).
+    if status == RegistrationStatus.accepted:
+        _schedule_meter_value_sample_interval_push(cp)
+
     return _response(received_at, status, interval)
+
+
+def _schedule_meter_value_sample_interval_push(cp: EveysChargePoint) -> None:
+    """Spawn the deferred ChangeConfiguration task.
+
+    Pinned on `cp` so the asyncio loop doesn't garbage-collect it
+    before it runs (the "lost task" footgun from PEP 3156-style
+    fire-and-forget code).
+    """
+    task = asyncio.create_task(
+        _push_meter_value_sample_interval(cp),
+        name=f"boot_notification.push_meter_value_sample_interval.{cp.id}",
+    )
+    # Hold a reference via the cp object. The library doesn't expose
+    # a hook for this so we tack a private attribute on; reassigning
+    # on subsequent boots is fine — the prior task either ran to
+    # completion (no leak) or is still pending (it'll keep running
+    # because asyncio holds its own ref via the loop).
+    cp._meter_value_push_task = task
+
+
+async def _push_meter_value_sample_interval(cp: EveysChargePoint) -> None:
+    """Wait briefly, then send ChangeConfiguration(MeterValueSampleInterval=…).
+
+    Failure modes (all logged at WARN, none re-raised):
+    - Charger has disconnected by the time we wake up → CALL fails.
+    - Charger rejects the key (read-only, unknown on older firmwares)
+      → response.status is `Rejected` / `NotSupported`; we log and
+      move on. Operators can override per-charger via the existing
+      `POST /api/v1/charge-points/{cp_id}/commands/change-configuration`.
+    """
+    try:
+        await asyncio.sleep(_METER_VALUE_PUSH_DELAY_SECONDS)
+        value = str(cp.settings.meter_value_sample_interval_seconds)
+        request = call.ChangeConfiguration(key="MeterValueSampleInterval", value=value)
+        response = await cp.call(request)
+        accepted_status = getattr(response, "status", None)
+        log.info(
+            "boot_notification.meter_value_sample_interval.pushed",
+            cp_id=cp.id,
+            value=value,
+            response_status=str(accepted_status) if accepted_status is not None else None,
+        )
+    except Exception as exc:
+        # Best-effort — a charger that disconnected or refuses the
+        # key must not crash a background asyncio task or, worse,
+        # propagate to the WS read loop. Log + drop.
+        log.warning(
+            "boot_notification.meter_value_sample_interval.failed",
+            cp_id=cp.id,
+            error=str(exc),
+        )

--- a/src/eveys_ocpp/settings.py
+++ b/src/eveys_ocpp/settings.py
@@ -843,6 +843,31 @@ class Settings(BaseSettings):
             "stability": "tunable",
         },
     )
+    meter_value_sample_interval_seconds: int = Field(
+        default=15,
+        ge=5,
+        le=3600,
+        description=(
+            "Value pushed to every charger after `BootNotification.Accepted` via "
+            "`ChangeConfiguration(MeterValueSampleInterval=…)`. Sets how often the "
+            "charger sends `MeterValues` during a transaction."
+        ),
+        json_schema_extra={
+            "category": "ocpp_defaults",
+            "impact": (
+                "Lower → finer-grained power/energy charts on the operator "
+                "console, more `MeterValues` frames per session (and more "
+                "Kafka/ClickHouse traffic). 15 s is fine for AC sessions on "
+                "the order of hours; consider 5-10 s for short fast-charge "
+                "sessions if you want sub-minute resolution. Pushed best-"
+                "effort: a charger that rejects the configuration key is "
+                "logged but does not fail boot. See "
+                "https://github.com/eveys-mobility/OCPP/issues/238."
+            ),
+            "secret": False,
+            "stability": "tunable",
+        },
+    )
 
     # ---- Cross-pod command bus (ADR-0016) -------------------------------
     bus_request_timeout_seconds: int = Field(

--- a/tests/unit/handlers/v16/test_boot_notification.py
+++ b/tests/unit/handlers/v16/test_boot_notification.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from ocpp.v16 import call_result
@@ -461,3 +461,91 @@ async def test_replay_does_not_call_backend(fake_cp: Any, monkeypatch: pytest.Mo
     assert result.status == "Accepted"
     fake_cp.backend_client.register_charge_point.assert_not_awaited()
     upsert.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# MeterValueSampleInterval push (eveys-mobility/OCPP#238)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_meter_value_sample_interval_pushed_after_accepted_boot(
+    fake_cp: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """After BootNotification.Accepted, the handler schedules a
+    deferred ChangeConfiguration push. Sleep is patched to 0 so the
+    task runs synchronously inside the test."""
+    from eveys_ocpp.handlers.v16 import boot_notification
+
+    upsert = AsyncMock(return_value=None)
+    monkeypatch.setattr(boot_notification, "upsert_charge_point_boot", upsert)
+    # Patch the inter-step sleep so the deferred task fires immediately.
+    monkeypatch.setattr(boot_notification, "_METER_VALUE_PUSH_DELAY_SECONDS", 0)
+    fake_cp.call = AsyncMock(return_value=MagicMock(status="Accepted"))
+    # Default is 15 — fake_cp.settings ships with it. If a test needs
+    # a different value, swap the whole `cp.settings` for a new
+    # `Settings(meter_value_sample_interval_seconds=…)` instance
+    # (Settings is frozen).
+
+    await boot_notification.handle(fake_cp, charge_point_vendor="ACME")
+    # Let the deferred task run. Read from __dict__ so a MagicMock
+    # auto-attr can't paper over a missing assignment.
+    task = fake_cp.__dict__.get("_meter_value_push_task")
+    assert task is not None, "the deferred task should be attached to cp"
+    await task
+
+    fake_cp.call.assert_awaited_once()
+    request = fake_cp.call.await_args.args[0]
+    assert type(request).__name__ == "ChangeConfiguration"
+    assert request.key == "MeterValueSampleInterval"
+    assert request.value == "15"
+
+
+@pytest.mark.asyncio
+async def test_meter_value_sample_interval_not_pushed_on_rejected_boot(
+    fake_cp: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No push if the boot was Rejected — a charger we just turned
+    away shouldn't receive any commands."""
+    from eveys_ocpp.handlers.v16 import boot_notification
+
+    monkeypatch.setattr(boot_notification, "upsert_charge_point_boot", AsyncMock(return_value=None))
+    monkeypatch.setattr(boot_notification, "_METER_VALUE_PUSH_DELAY_SECONDS", 0)
+    # Backend rejects → handler maps to RegistrationStatus.rejected.
+    fake_cp.backend_client = MagicMock()
+    fake_cp.backend_client.register_charge_point = AsyncMock(
+        side_effect=boot_notification.BackendBusinessError(
+            error_code="cp_disabled", message="charger is disabled"
+        )
+    )
+    fake_cp.call = AsyncMock()
+
+    result = await boot_notification.handle(fake_cp, charge_point_vendor="ACME")
+
+    assert result.status == "Rejected"
+    # MagicMock auto-creates attributes on access — check the real
+    # __dict__ instead. The handler attaches the task to `cp` only
+    # on Accepted; a Rejected boot must NOT have touched it.
+    assert "_meter_value_push_task" not in fake_cp.__dict__
+    fake_cp.call.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_meter_value_sample_interval_push_failure_does_not_propagate(
+    fake_cp: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A charger that disconnects (or refuses the key) must not crash
+    the background task or leak the exception."""
+    from eveys_ocpp.handlers.v16 import boot_notification
+
+    monkeypatch.setattr(boot_notification, "upsert_charge_point_boot", AsyncMock(return_value=None))
+    monkeypatch.setattr(boot_notification, "_METER_VALUE_PUSH_DELAY_SECONDS", 0)
+    fake_cp.call = AsyncMock(side_effect=RuntimeError("WS closed"))
+
+    await boot_notification.handle(fake_cp, charge_point_vendor="ACME")
+    task = fake_cp.__dict__.get("_meter_value_push_task")
+    assert task is not None
+    # The task should finish without raising — log + drop is the contract.
+    await task
+    assert task.done()
+    assert task.exception() is None


### PR DESCRIPTION
## Summary

Per the design recommendations in #238: gateway pushes \`MeterValueSampleInterval=15s\` (configurable) to every charger after \`BootNotification.Accepted\`. Async dispatch, best-effort, no per-charger override.

### What

- New \`Settings.meter_value_sample_interval_seconds\` field, default \`15\`, range \`5..3600\`.
- New deferred task in \`boot_notification.py\`: after \`Accepted\`, schedules a fire-and-forget \`asyncio.create_task\` that waits 2s, then dispatches \`ChangeConfiguration(key=\"MeterValueSampleInterval\", value=str(...))\` via the existing \`cp.call\` primitive.
- Task is pinned on \`cp._meter_value_push_task\` so the asyncio loop doesn't garbage-collect it before it runs.
- All failures (charger disconnected, key rejected, library raised) are caught + logged at WARN; never propagate.

### Behaviour table

| Boot outcome | Push behaviour |
|---|---|
| Accepted | Deferred task scheduled; runs ~2s after the boot reply. |
| Pending  | No push (charger isn't fully online yet). |
| Rejected | No push. |
| Replay (idempotency hit) | No push (handler returns canonical Accepted but doesn't run the rest of the side-effects, including this one). |

### Design decisions called out in #238

- ✅ **Async dispatch** — chosen over sync to keep the boot handshake fast.
- ✅ **Re-push on every Accepted boot** — handles firmware updates that reset config.
- ✅ **No DB tracking** — push outcomes are audited via the existing \`/sys/cp/:cpId/frames\` log.
- ✅ **No per-charger override** — operators use \`POST /api/v1/charge-points/{cp_id}/commands/change-configuration\` for one-off deviations.

## Test plan

- [x] \`pytest tests/unit/\` (1034 tests pass — 3 new for the push behaviour: success path, no-push-on-rejected, no-exception-on-failure)
- [x] \`ruff check\` + \`mypy\` clean
- [x] \`make config-export\` (regenerated docs + .env.example)
- [ ] Smoke against a real or simulated charger BootNotification — would require sim or real CP connect; deferred to live ops. The unit tests verify the call payload + the task lifecycle.

Closes #238