### PR TITLE
chore(typing): drop now-unused mypy ignores blocking pre-commit

### DIFF
--- a/src/eveys_ocpp/registry.py
+++ b/src/eveys_ocpp/registry.py
@@ -142,12 +142,8 @@ class Registry:
 
     async def mark_offline(self, cp_id: str) -> bool:
         """Release the key iff this pod still owns it. Returns True on delete."""
-        # redis-py's async eval() is incorrectly typed as `Awaitable[str] | str`
-        # (sync/async dual-API typing leak). It's actually awaitable on the
-        # asyncio client. The int() cast at the boundary keeps our caller's
-        # type strict; the ignore is targeted to this one call.
         with _timed_redis("eval"):
-            deleted_raw = await self._redis.eval(  # type: ignore[misc]
+            deleted_raw = await self._redis.eval(
                 _DEL_IF_OWNER,
                 1,
                 _key(cp_id),
@@ -181,10 +177,7 @@ class Registry:
         """
         went_offline_at = datetime.now(UTC).isoformat()
         with _timed_redis("set"):
-            # redis-py's async hset is typed as `Awaitable[int] | int`
-            # (sync/async dual-API typing leak) — same shape as the
-            # `eval` ignore in `mark_offline`.
-            await self._redis.hset(  # type: ignore[misc]
+            await self._redis.hset(
                 _offline_marker_key(cp_id),
                 mapping={
                     "went_offline_at": went_offline_at,
@@ -211,8 +204,7 @@ class Registry:
         """
         key = _offline_marker_key(cp_id)
         with _timed_redis("get"):
-            # Same dual-API typing leak as `record_offline_marker`.
-            data = await self._redis.hgetall(key)  # type: ignore[misc]
+            data = await self._redis.hgetall(key)
         if not data:
             return None
         # decode_responses=True → str keys/values; normalize defensively.

--- a/src/eveys_ocpp/transport/_rate_limiter.py
+++ b/src/eveys_ocpp/transport/_rate_limiter.py
@@ -130,10 +130,7 @@ class RateLimiter:
         """
         try:
             now_ms = int(time.time() * 1000)
-            # redis-py's async eval() is incorrectly typed as
-            # `Awaitable[str] | str` (sync/async dual-API typing leak).
-            # Same pattern as registry.mark_offline.
-            result = await self._redis.eval(  # type: ignore[misc]
+            result = await self._redis.eval(
                 _TOKEN_BUCKET_LUA,
                 1,
                 _key(cp_id),


### PR DESCRIPTION
## Summary
- `redis-py`'s async dual-API typing leak (eval / hset / hgetall returning `Awaitable[T] | T`) was fixed upstream, so the four targeted `# type: ignore[misc]` sites in `registry.py` (3) and `transport/_rate_limiter.py` (1) are now flagged by mypy's `unused-ignore` rule.
- They block the `mypy` pre-commit hook on every new commit — surfaced while preparing PRs for authorizations, cp.heartbeat, and the compose envoy refactor.
- This PR removes the four ignores and their now-stale explanatory comments. No behavioral change.

## Test plan
- [x] `uv run mypy src/eveys_ocpp/registry.py src/eveys_ocpp/transport/_rate_limiter.py` → clean
- [x] full pre-commit run on this commit → all hooks pass
- [ ] CI mypy / pytest green

🤖 Generated with [Claude Code](https://claude.com/claude-code)