### PR TITLE
feature(webhooks): compress in-loop retry backoff so retries start sooner

### DIFF
--- a/docs/integration/03-webhooks.md
+++ b/docs/integration/03-webhooks.md
@@ -41,7 +41,7 @@ EVEYS_OCPP_WEBHOOK_ENABLE_TX_STARTED=1
 ## Delivery semantics
 
 - **At-least-once.** A delivery may be retried; the backend MUST be idempotent on `X-Eveys-Event-Id`.
-- **Retries (in-loop)**: 5 attempts with exponential backoff: 1 s, 5 s, 30 s, 2 min, 10 min. After 5 failures the envelope is enqueued into the durable backlog (see below) rather than dropped.
+- **Retries (in-loop)**: 5 attempts with exponential backoff: 1 s, 5 s, 15 s, 30 s, 60 s. After 5 failures the envelope is enqueued into the durable backlog (see below) rather than dropped.
 - **Durable backlog (tail)**: any envelope the dispatcher couldn't deliver in-loop is persisted into the `webhook_delivery_backlog` Postgres table. A background drainer keeps retrying on a coarser cadence (5 min, 15 min, 30 min, 1 h, 2 h, 4 h, 6 h, then held at 6 h) until either the row delivers or ages past the retention window (`EVEYS_OCPP_WEBHOOK_BACKLOG_RETENTION_HOURS`, default 7 days). Retention aging is the only path to `dead=true`; the `eveys_ocpp_webhook_backlog_deadletter_total` counter fires — alert on any non-zero increment.
 - **Per-charger ordering not guaranteed.** Two events from the same charger may arrive out of order. The backend should use `occurred_at` for ordering, not arrival time. Same caveat as Kafka — `cp_id` is the partition key on Kafka, but webhooks are unordered.
 - **HTTP status interpretation**:

--- a/src/eveys_ocpp/webhooks/dispatcher.py
+++ b/src/eveys_ocpp/webhooks/dispatcher.py
@@ -46,7 +46,7 @@ log = get_logger(__name__)
 # Backoff schedule per docs/integration/03-webhooks.md § Delivery
 # semantics. Indexed by attempt number (0 = first attempt; we sleep
 # this many seconds BEFORE the (n+1)th attempt).
-_BACKOFF_SECONDS: tuple[float, ...] = (1.0, 5.0, 30.0, 120.0, 600.0)
+_BACKOFF_SECONDS: tuple[float, ...] = (1.0, 5.0, 15.0, 30.0, 60.0)
 
 
 class WebhookDispatcher:


### PR DESCRIPTION
## Problem

A webhook delivery that fails could take **156 s** to reach its 5th (final) in-loop attempt. With the default `webhook_max_attempts=5`, the old `_BACKOFF_SECONDS = (1, 5, 30, 120, 600)` schedule meant a single **120 s** sleep sat before the last attempt — so any transient backend outage held the envelope for over two minutes before the last try, and only then handed off to the durable backlog.

## Change

Compress the in-loop schedule to `(1, 5, 15, 30, 60)`.

| Attempt | Old fires at | New fires at |
|--------:|-------------:|-------------:|
| 1 | 0 s | 0 s |
| 2 | 1 s | 1 s |
| 3 | 6 s | 6 s |
| 4 | 36 s | 21 s |
| 5 | **156 s** | **51 s** |

Full in-loop exhaustion drops from 156 s → 51 s (fast-fail), and no single sleep exceeds 30 s at the default attempt count. The `60` tail only comes into play if an operator raises `webhook_max_attempts`.

The durable backlog drainer's separate (coarser) schedule is unchanged — rows still only reach it after the in-loop budget is exhausted.

## Docs

`docs/integration/03-webhooks.md` § Delivery semantics updated to match the new schedule.